### PR TITLE
Add typed ISensorMapManager service for JS interop

### DIFF
--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/SensorMap.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/SensorMap.razor
@@ -2,10 +2,11 @@
 @using EcoData.AquaTrack.Contracts.Dtos
 @using EcoData.AquaTrack.Contracts.Parameters
 @using EcoData.AquaTrack.Application.Client
+@using EcoData.AquaTrack.WebApp.Client.Services
 @using BlazingSingularity
 @using BlazingSingularity.Commands
 @inject ISensorHttpClient SensorClient
-@inject IJSRuntime JS
+@inject ISensorMapManager MapManager
 @implements IAsyncDisposable
 
 <PageTitle>Map</PageTitle>
@@ -48,8 +49,8 @@
         if (!LoadSensorsCommand.IsLoading && !_mapInitialized && _sensors is not null)
         {
             _mapInitialized = true;
-            await JS.InvokeVoidAsync("sensorMap.init", "sensor-map");
-            await JS.InvokeVoidAsync("sensorMap.addSensors", _sensors);
+            await MapManager.InitializeAsync("sensor-map");
+            await MapManager.AddSensorsAsync(_sensors);
         }
     }
 
@@ -60,7 +61,7 @@
 
         if (_mapInitialized)
         {
-            await JS.InvokeVoidAsync("sensorMap.dispose");
+            await MapManager.DisposeAsync();
         }
     }
 }

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Program.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Program.cs
@@ -1,4 +1,5 @@
 using EcoData.AquaTrack.Application.Client;
+using EcoData.AquaTrack.WebApp.Client.Services;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 
@@ -7,6 +8,7 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 var baseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 builder.Services.AddAquaTrackClient(baseAddress);
 
+builder.Services.AddScoped<ISensorMapManager, SensorMapManager>();
 builder.Services.AddMudServices();
 
 await builder.Build().RunAsync();

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Services/ISensorMapManager.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Services/ISensorMapManager.cs
@@ -1,0 +1,10 @@
+using EcoData.AquaTrack.Contracts.Dtos;
+
+namespace EcoData.AquaTrack.WebApp.Client.Services;
+
+public interface ISensorMapManager
+{
+    ValueTask InitializeAsync(string elementId);
+    ValueTask AddSensorsAsync(IEnumerable<SensorDtoForList> sensors);
+    ValueTask DisposeAsync();
+}

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Services/SensorMapManager.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Services/SensorMapManager.cs
@@ -1,0 +1,22 @@
+using EcoData.AquaTrack.Contracts.Dtos;
+using Microsoft.JSInterop;
+
+namespace EcoData.AquaTrack.WebApp.Client.Services;
+
+public sealed class SensorMapManager(IJSRuntime js) : ISensorMapManager
+{
+    public ValueTask InitializeAsync(string elementId)
+    {
+        return js.InvokeVoidAsync("sensorMap.init", elementId);
+    }
+
+    public ValueTask AddSensorsAsync(IEnumerable<SensorDtoForList> sensors)
+    {
+        return js.InvokeVoidAsync("sensorMap.addSensors", sensors);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return js.InvokeVoidAsync("sensorMap.dispose");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ISensorMapManager` interface to abstract Leaflet map JS interop
- Add `SensorMapManager` implementation wrapping IJSRuntime calls
- Update `SensorMap.razor` to use the typed service instead of direct JS calls

## Benefits
- Type-safe API for map operations
- Easier to mock for testing
- Centralizes JS interop logic

## Test plan
- [ ] Verify map initializes correctly
- [ ] Verify sensors are displayed on the map
- [ ] Verify map disposes properly on navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)