### PR TITLE
Add data source filter for map sensors

### DIFF
--- a/src/AquaTrack/EcoData.AquaTrack.Api/DataSourceEndpoints.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Api/DataSourceEndpoints.cs
@@ -1,0 +1,24 @@
+using EcoData.AquaTrack.Contracts.Dtos;
+using EcoData.AquaTrack.DataAccess.Interfaces;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace EcoData.AquaTrack.Api;
+
+public static class DataSourceEndpoints
+{
+    public static IEndpointRouteBuilder MapDataSourceEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/datasources").WithTags("DataSources");
+
+        group.MapGet("/", GetDataSources).WithName("GetDataSources");
+
+        return app;
+    }
+
+    private static async Task<IReadOnlyList<DataSourceDtoForList>> GetDataSources(
+        IDataSourceRepository repository,
+        CancellationToken ct
+    ) => await repository.GetAllAsync(ct);
+}

--- a/src/AquaTrack/EcoData.AquaTrack.Application.Client/DataSourceHttpClient.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Application.Client/DataSourceHttpClient.cs
@@ -1,0 +1,18 @@
+using System.Net.Http.Json;
+using EcoData.AquaTrack.Contracts.Dtos;
+
+namespace EcoData.AquaTrack.Application.Client;
+
+public sealed class DataSourceHttpClient(HttpClient httpClient) : IDataSourceHttpClient
+{
+    public async Task<IReadOnlyList<DataSourceDtoForList>> GetDataSourcesAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = await httpClient.GetFromJsonAsync<IReadOnlyList<DataSourceDtoForList>>(
+            "api/datasources",
+            cancellationToken
+        );
+        return result ?? [];
+    }
+}

--- a/src/AquaTrack/EcoData.AquaTrack.Application.Client/DependencyInjection.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Application.Client/DependencyInjection.cs
@@ -14,6 +14,11 @@ public static class DependencyInjection
             configureClient?.Invoke(client);
         });
 
+        services.AddHttpClient<IDataSourceHttpClient, DataSourceHttpClient>(client =>
+        {
+            configureClient?.Invoke(client);
+        });
+
         return services;
     }
 

--- a/src/AquaTrack/EcoData.AquaTrack.Application.Client/IDataSourceHttpClient.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Application.Client/IDataSourceHttpClient.cs
@@ -1,0 +1,8 @@
+using EcoData.AquaTrack.Contracts.Dtos;
+
+namespace EcoData.AquaTrack.Application.Client;
+
+public interface IDataSourceHttpClient
+{
+    Task<IReadOnlyList<DataSourceDtoForList>> GetDataSourcesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/AquaTrack/EcoData.AquaTrack.Contracts/Dtos/SensorDto.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Contracts/Dtos/SensorDto.cs
@@ -2,12 +2,14 @@ namespace EcoData.AquaTrack.Contracts.Dtos;
 
 public sealed record SensorDtoForList(
     Guid Id,
+    Guid SourceId,
     string ExternalId,
     string Name,
     decimal Latitude,
     decimal Longitude,
     string? Municipality,
-    bool IsActive
+    bool IsActive,
+    string DataSourceName
 );
 
 public sealed record SensorDtoForDetail(

--- a/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/SensorRepository.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/SensorRepository.cs
@@ -45,12 +45,14 @@ public sealed class SensorRepository(IDbContextFactory<AquaTrackDbContext> conte
             .Where(s => s.SourceId == dataSourceId)
             .Select(s => new SensorDtoForList(
                 s.Id,
+                s.SourceId,
                 s.ExternalId,
                 s.Name,
                 s.Latitude,
                 s.Longitude,
                 s.Municipality,
-                s.IsActive
+                s.IsActive,
+                s.DataSource!.Name
             ))
             .ToListAsync(cancellationToken);
     }
@@ -101,12 +103,14 @@ public sealed class SensorRepository(IDbContextFactory<AquaTrackDbContext> conte
             .Take(parameters.PageSize + 1)
             .Select(static s => new SensorDtoForList(
                 s.Id,
+                s.SourceId,
                 s.ExternalId,
                 s.Name,
                 s.Latitude,
                 s.Longitude,
                 s.Municipality,
-                s.IsActive
+                s.IsActive,
+                s.DataSource!.Name
             ))
             .AsAsyncEnumerable()
             .WithCancellation(cancellationToken))

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/SensorMap.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/SensorMap.razor
@@ -6,12 +6,53 @@
 @using BlazingSingularity
 @using BlazingSingularity.Commands
 @inject ISensorHttpClient SensorClient
+@inject IDataSourceHttpClient DataSourceClient
 @inject ISensorMapManager MapManager
 @implements IAsyncDisposable
 
 <PageTitle>Map</PageTitle>
 
 <div class="map-page">
+    <div class="map-filter-panel">
+        <MudPaper Elevation="2" Class="pa-3">
+            <MudText Typo="Typo.subtitle1" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.FilterList" Size="Size.Small" Class="mr-1" />
+                Data Sources
+            </MudText>
+            @if (LoadDataSourcesCommand.IsLoading)
+            {
+                <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="mb-2" />
+            }
+            else if (_dataSources is not null && _dataSources.Count > 0)
+            {
+                <MudStack Spacing="1">
+                    @foreach (var dataSource in _dataSources)
+                    {
+                        <MudCheckBox T="bool"
+                                     Value="@IsDataSourceSelected(dataSource.Id)"
+                                     ValueChanged="@((bool value) => OnDataSourceSelectionChanged(dataSource.Id, value))"
+                                     Label="@dataSource.Name"
+                                     Color="Color.Primary"
+                                     Dense="true"
+                                     Class="ma-0" />
+                    }
+                </MudStack>
+                <MudDivider Class="my-2" />
+                <MudStack Row="true" Spacing="1">
+                    <MudButton Variant="Variant.Text" Size="Size.Small" Color="Color.Primary" OnClick="SelectAllDataSources">
+                        Select All
+                    </MudButton>
+                    <MudButton Variant="Variant.Text" Size="Size.Small" Color="Color.Secondary" OnClick="ClearAllDataSources">
+                        Clear
+                    </MudButton>
+                </MudStack>
+            }
+            else
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">No data sources available</MudText>
+            }
+        </MudPaper>
+    </div>
     <div class="map-container">
         @if (LoadSensorsCommand.IsLoading)
         {
@@ -26,11 +67,24 @@
 @code {
     private readonly CancellationTokenSource _cts = new();
     private List<SensorDtoForList>? _sensors;
+    private IReadOnlyList<DataSourceDtoForList>? _dataSources;
+    private HashSet<Guid> _selectedDataSourceIds = new();
     private bool _mapInitialized;
 
     protected override async Task OnInitializedAsync()
     {
-        await LoadSensorsCommand.ExecuteAsync();
+        await Task.WhenAll(
+            LoadDataSourcesCommand.ExecuteAsync(),
+            LoadSensorsCommand.ExecuteAsync()
+        );
+    }
+
+    [RelayCommand]
+    private async Task LoadDataSources()
+    {
+        _dataSources = await DataSourceClient.GetDataSourcesAsync(_cts.Token);
+        // Select all data sources by default
+        _selectedDataSourceIds = _dataSources.Select(ds => ds.Id).ToHashSet();
     }
 
     [RelayCommand]
@@ -50,8 +104,51 @@
         {
             _mapInitialized = true;
             await MapManager.InitializeAsync("sensor-map");
-            await MapManager.AddSensorsAsync(_sensors);
+            await UpdateMapSensorsAsync();
         }
+    }
+
+    private bool IsDataSourceSelected(Guid dataSourceId)
+    {
+        return _selectedDataSourceIds.Contains(dataSourceId);
+    }
+
+    private async Task OnDataSourceSelectionChanged(Guid dataSourceId, bool isSelected)
+    {
+        if (isSelected)
+        {
+            _selectedDataSourceIds.Add(dataSourceId);
+        }
+        else
+        {
+            _selectedDataSourceIds.Remove(dataSourceId);
+        }
+
+        await UpdateMapSensorsAsync();
+    }
+
+    private async Task SelectAllDataSources()
+    {
+        if (_dataSources is null) return;
+        _selectedDataSourceIds = _dataSources.Select(ds => ds.Id).ToHashSet();
+        await UpdateMapSensorsAsync();
+    }
+
+    private async Task ClearAllDataSources()
+    {
+        _selectedDataSourceIds.Clear();
+        await UpdateMapSensorsAsync();
+    }
+
+    private async Task UpdateMapSensorsAsync()
+    {
+        if (!_mapInitialized || _sensors is null) return;
+
+        var filteredSensors = _sensors
+            .Where(s => _selectedDataSourceIds.Contains(s.SourceId))
+            .ToList();
+
+        await MapManager.AddSensorsAsync(filteredSensors);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp/Program.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp/Program.cs
@@ -37,5 +37,6 @@ app.MapRazorComponents<App>()
     .AddAdditionalAssemblies(typeof(EcoData.AquaTrack.WebApp.Client._Imports).Assembly);
 
 app.MapSensorEndpoints();
+app.MapDataSourceEndpoints();
 
 app.Run();

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp/wwwroot/app.css
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp/wwwroot/app.css
@@ -95,3 +95,39 @@ h1:focus {
 .leaflet-control-attribution a {
     color: var(--mud-palette-primary) !important;
 }
+
+/* ==========================================================================
+   Map Filter Panel
+   ========================================================================== */
+.map-filter-panel {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 1000;
+    min-width: 200px;
+    max-width: 280px;
+    max-height: calc(100vh - 100px);
+    overflow-y: auto;
+}
+
+.map-filter-panel .mud-paper {
+    background-color: var(--mud-palette-surface);
+}
+
+.map-filter-panel .mud-checkbox {
+    margin-left: -8px;
+}
+
+/* Custom scrollbar for filter panel */
+.map-filter-panel::-webkit-scrollbar {
+    width: 6px;
+}
+
+.map-filter-panel::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.map-filter-panel::-webkit-scrollbar-thumb {
+    background-color: var(--mud-palette-lines-default);
+    border-radius: 3px;
+}

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp/wwwroot/js/map.js
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp/wwwroot/js/map.js
@@ -36,6 +36,7 @@ window.sensorMap = {
                 <div style="min-width: 150px;">
                     <strong>${sensor.name}</strong><br/>
                     <small>ID: ${sensor.externalId}</small><br/>
+                    ${sensor.dataSourceName ? `<small>Source: ${sensor.dataSourceName}</small><br/>` : ''}
                     ${sensor.municipality ? `<small>Municipality: ${sensor.municipality}</small><br/>` : ''}
                     <small>Status: ${sensor.isActive ? 'Active' : 'Inactive'}</small>
                 </div>


### PR DESCRIPTION
## Summary
- Adds a filter panel to the map that allows users to filter sensors by data source
- Users can select/deselect individual data sources with checkboxes
- Includes "Select All" and "Clear" buttons for convenience
- Filter state persists during the session
- Data source name is displayed in sensor popups

## Changes
- **SensorDtoForList**: Added `SourceId` and `DataSourceName` fields
- **DataSourceEndpoints**: New API endpoint `GET /api/datasources`
- **DataSourceHttpClient**: HTTP client for fetching data sources
- **SensorMap.razor**: Filter panel UI with real-time filtering
- **app.css**: Styling for the filter panel
- **map.js**: Updated popups to show data source name

## Test plan
- [ ] Open the map page
- [ ] Verify the filter panel appears in the top-right corner
- [ ] Verify all data sources are listed with checkboxes
- [ ] Toggle individual data sources and verify sensors are filtered
- [ ] Test "Select All" and "Clear" buttons
- [ ] Verify filter state persists when interacting with the map
- [ ] Verify data source name appears in sensor popups

Closes #15