### PR TITLE
Add EcoDataVirtualizedList component

### DIFF
--- a/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/SensorRepository.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/SensorRepository.cs
@@ -72,7 +72,7 @@ public sealed class SensorRepository(IDbContextFactory<AquaTrackDbContext> conte
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 
-        var query = context.Sensors.AsNoTracking().AsQueryable();
+        var query = context.Sensors.AsQueryable();
 
         if (parameters.IsActive.HasValue)
         {
@@ -88,9 +88,8 @@ public sealed class SensorRepository(IDbContextFactory<AquaTrackDbContext> conte
         {
             var search = parameters.Search.Trim().ToLower();
             query = query.Where(s =>
-                s.Name.ToLower().Contains(search)
-                || (s.Municipality != null && s.Municipality.ToLower().Contains(search))
-            );
+                s.Name.ToLower().Contains(search) ||
+                (s.Municipality != null && s.Municipality.ToLower().Contains(search)));
         }
 
         if (parameters.Cursor.HasValue)

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationsPage.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationsPage.razor
@@ -1,5 +1,4 @@
 @page "/organizations"
-@using Microsoft.AspNetCore.Components.Web.Virtualization
 @using EcoData.AquaTrack.Contracts.Dtos
 @using EcoData.AquaTrack.Contracts.Parameters
 @using EcoData.AquaTrack.Application.Client
@@ -11,7 +10,6 @@
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject AuthStateService AuthState
-@implements IDisposable
 
 <PageTitle>Organizations - AquaTrack</PageTitle>
 
@@ -37,81 +35,69 @@
         }
     </div>
 
-    <MudPaper Elevation="1" Class="organization-list-container" Style="height: calc(100vh - 200px); overflow-y: auto; border-radius: 12px;">
-        @if (_isLoading)
-        {
-            @for (var i = 0; i < 8; i++)
-            {
+    <MudPaper Elevation="1" Class="organization-list-container" Style="height: calc(100vh - 200px); border-radius: 12px;">
+        <EcoDataVirtualizedList @ref="_list"
+                                TItem="OrganizationDtoForList"
+                                TParams="OrganizationParameters"
+                                ItemsProvider="OrganizationClient.GetOrganizationsAsync"
+                                ParametersFactory="CreateParameters"
+                                KeySelector="o => o.Id"
+                                HasActiveFilters="_ => HasActiveFilters"
+                                OnClearFilters="ClearFilters">
+            <ItemTemplate Context="organization">
+                <OrganizationListItem Organization="organization"
+                                      ShowActions="IsAdmin"
+                                      OnEdit="OpenEditDialog"
+                                      OnDelete="ConfirmDelete" />
+            </ItemTemplate>
+            <SkeletonTemplate>
                 <div class="organization-skeleton">
                     <MudSkeleton Width="180px" Height="16px" />
                     <MudSkeleton Width="100px" Height="14px" Class="hide-mobile" />
                     <MudSkeleton SkeletonType="SkeletonType.Circle" Width="32px" Height="32px" />
                 </div>
-            }
-        }
-        else
-        {
-            <Virtualize @ref="_virtualize"
-                        TItem="OrganizationDtoForList"
-                        ItemsProvider="LoadItemsAsync"
-                        ItemSize="65"
-                        OverscanCount="5"
-                        Context="organization">
-                <ItemContent>
-                    <OrganizationListItem Organization="organization"
-                                          ShowActions="IsAdmin"
-                                          OnEdit="OpenEditDialog"
-                                          OnDelete="ConfirmDelete" />
-                </ItemContent>
-                <Placeholder>
-                    <div style="height: 65px;"></div>
-                </Placeholder>
-                <EmptyContent>
-                    <MudStack AlignItems="AlignItems.Center" Class="pa-8">
-                        <MudIcon Icon="@Icons.Material.Filled.Business" Size="Size.Large" Color="Color.Secondary" />
-                        <MudText Typo="Typo.h6" Color="Color.Secondary" Class="mt-2">No organizations found</MudText>
-                        <MudText Typo="Typo.body2" Color="Color.Secondary">
-                            @if (HasActiveFilters)
-                            {
-                                <span>No organizations match your search criteria.</span>
-                            }
-                            else
-                            {
-                                <span>Get started by adding your first organization.</span>
-                            }
-                        </MudText>
-                        @if (HasActiveFilters)
-                        {
-                            <MudButton Variant="Variant.Outlined"
-                                       Color="Color.Primary"
-                                       StartIcon="@Icons.Material.Filled.FilterAltOff"
-                                       OnClick="ClearFilters"
-                                       Class="mt-3">
-                                Clear Filters
-                            </MudButton>
-                        }
-                        else if (IsAdmin)
-                        {
-                            <MudButton Variant="Variant.Filled"
-                                       Color="Color.Primary"
-                                       StartIcon="@Icons.Material.Filled.Add"
-                                       OnClick="OpenCreateDialog"
-                                       Class="mt-3">
-                                Add Organization
-                            </MudButton>
-                        }
-                    </MudStack>
-                </EmptyContent>
-            </Virtualize>
-        }
+            </SkeletonTemplate>
+            <EmptyTemplate>
+                <MudStack AlignItems="AlignItems.Center" Class="pa-8">
+                    <MudIcon Icon="@Icons.Material.Filled.Business" Size="Size.Large" Color="Color.Secondary" />
+                    <MudText Typo="Typo.h6" Color="Color.Secondary" Class="mt-2">No organizations yet</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        Get started by adding your first organization.
+                    </MudText>
+                    @if (IsAdmin)
+                    {
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Add"
+                                   OnClick="OpenCreateDialog"
+                                   Class="mt-3">
+                            Add Organization
+                        </MudButton>
+                    }
+                </MudStack>
+            </EmptyTemplate>
+            <FilteredEmptyTemplate Context="clearFilters">
+                <MudStack AlignItems="AlignItems.Center" Class="pa-8">
+                    <MudIcon Icon="@Icons.Material.Filled.SearchOff" Size="Size.Large" Color="Color.Secondary" />
+                    <MudText Typo="Typo.h6" Color="Color.Secondary" Class="mt-2">No organizations found</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        No organizations match your search criteria.
+                    </MudText>
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.FilterAltOff"
+                               OnClick="clearFilters"
+                               Class="mt-3">
+                        Clear Filters
+                    </MudButton>
+                </MudStack>
+            </FilteredEmptyTemplate>
+        </EcoDataVirtualizedList>
     </MudPaper>
 </MudContainer>
 
 @code {
-    private Virtualize<OrganizationDtoForList>? _virtualize;
-    private readonly CursorPaginationState<OrganizationDtoForList, OrganizationParameters> _paginationState = new(o => o.Id);
-    private CancellationTokenSource? _refreshCts;
-    private bool _isLoading = true;
+    private EcoDataVirtualizedList<OrganizationDtoForList, OrganizationParameters>? _list;
 
     [Signal]
     private string? _searchText;
@@ -121,56 +107,21 @@
 
     protected override void OnInitialized()
     {
-        SearchTextSignal.OnChange(async _ => await RefreshDataAsync());
+        SearchTextSignal.OnChange(async _ => await RefreshAsync());
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    private OrganizationParameters CreateParameters() => new()
     {
-        if (firstRender)
-        {
-            await RefreshDataAsync();
-        }
-    }
+        PageSize = 50,
+        Search = string.IsNullOrWhiteSpace(SearchText) ? null : SearchText
+    };
 
-    private async Task RefreshDataAsync()
+    private async Task RefreshAsync()
     {
-        _refreshCts?.Cancel();
-        _refreshCts = new CancellationTokenSource();
-        var token = _refreshCts.Token;
-
-        try
+        if (_list is not null)
         {
-            _isLoading = true;
-            StateHasChanged();
-
-            _paginationState.Reset();
-
-            var request = new ItemsProviderRequest(0, 50, token);
-            await LoadItemsAsync(request);
-
-            _isLoading = false;
-            StateHasChanged();
-
-            if (_virtualize is not null)
-            {
-                await _virtualize.RefreshDataAsync();
-            }
+            await _list.RefreshAsync();
         }
-        catch (TaskCanceledException)
-        {
-        }
-    }
-
-    private ValueTask<ItemsProviderResult<OrganizationDtoForList>> LoadItemsAsync(ItemsProviderRequest request)
-    {
-        return _paginationState.ProvideItemsAsync(
-            request,
-            () => new OrganizationParameters
-            {
-                PageSize = 50,
-                Search = string.IsNullOrWhiteSpace(SearchText) ? null : SearchText
-            },
-            (parameters, ct) => OrganizationClient.GetOrganizationsAsync(parameters, ct));
     }
 
     private void ClearFilters()
@@ -190,7 +141,7 @@
             {
                 await OrganizationClient.CreateAsync(new OrganizationDtoForCreate(name));
                 Snackbar.Add("Organization created successfully", Severity.Success);
-                await RefreshDataAsync();
+                await RefreshAsync();
             }
             catch
             {
@@ -216,7 +167,7 @@
             {
                 await OrganizationClient.UpdateAsync(organization.Id, new OrganizationDtoForUpdate(name));
                 Snackbar.Add("Organization updated successfully", Severity.Success);
-                await RefreshDataAsync();
+                await RefreshAsync();
             }
             catch
             {
@@ -245,7 +196,7 @@
                 if (deleted)
                 {
                     Snackbar.Add("Organization deleted successfully", Severity.Success);
-                    await RefreshDataAsync();
+                    await RefreshAsync();
                 }
                 else
                 {
@@ -257,12 +208,5 @@
                 Snackbar.Add("Failed to delete organization", Severity.Error);
             }
         }
-    }
-
-    public void Dispose()
-    {
-        _refreshCts?.Cancel();
-        _refreshCts?.Dispose();
-        _paginationState.Dispose();
     }
 }

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/SensorsPage.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/SensorsPage.razor
@@ -1,5 +1,4 @@
 @page "/sensors"
-@using Microsoft.AspNetCore.Components.Web.Virtualization
 @using EcoData.AquaTrack.Contracts.Dtos
 @using EcoData.AquaTrack.Contracts.Parameters
 @using EcoData.AquaTrack.Application.Client
@@ -8,7 +7,6 @@
 @using EcoData.AquaTrack.WebApp.Client.Components
 @inject ISensorHttpClient SensorClient
 @inject NavigationManager Navigation
-@implements IDisposable
 
 <PageTitle>Sensors - AquaTrack</PageTitle>
 
@@ -40,11 +38,19 @@
         }
     </div>
 
-    <MudPaper Elevation="1" Class="sensor-list-container" Style="height: calc(100vh - 200px); overflow-y: auto; border-radius: 12px;">
-        @if (_isLoading)
-        {
-            @for (var i = 0; i < 8; i++)
-            {
+    <MudPaper Elevation="1" Class="sensor-list-container" Style="height: calc(100vh - 200px); border-radius: 12px;">
+        <EcoDataVirtualizedList @ref="_list"
+                                TItem="SensorDtoForList"
+                                TParams="SensorParameters"
+                                ItemsProvider="SensorClient.GetSensorsAsync"
+                                ParametersFactory="CreateParameters"
+                                KeySelector="s => s.Id"
+                                HasActiveFilters="_ => HasActiveFilters"
+                                OnClearFilters="ClearFilters">
+            <ItemTemplate Context="sensor">
+                <SensorListItem Sensor="sensor" OnMapClick="NavigateToMap" />
+            </ItemTemplate>
+            <SkeletonTemplate>
                 <div class="sensor-skeleton">
                     <div class="skeleton-primary">
                         <MudSkeleton Width="180px" Height="16px" />
@@ -55,48 +61,38 @@
                     <MudSkeleton Width="60px" Height="24px" Class="rounded-pill" />
                     <MudSkeleton SkeletonType="SkeletonType.Circle" Width="32px" Height="32px" />
                 </div>
-            }
-        }
-        else
-        {
-            <Virtualize @ref="_virtualize"
-                        TItem="SensorDtoForList"
-                        ItemsProvider="LoadItemsAsync"
-                        ItemSize="65"
-                        OverscanCount="5"
-                        Context="sensor">
-                <ItemContent>
-                    <SensorListItem Sensor="sensor" OnMapClick="NavigateToMap" />
-                </ItemContent>
-                <Placeholder>
-                    <div style="height: 65px;"></div>
-                </Placeholder>
-                <EmptyContent>
-                    <MudStack AlignItems="AlignItems.Center" Class="pa-8">
-                        <MudIcon Icon="@Icons.Material.Filled.SearchOff" Size="Size.Large" Color="Color.Secondary" />
-                        <MudText Typo="Typo.h6" Color="Color.Secondary" Class="mt-2">No sensors found</MudText>
-                        <MudText Typo="Typo.body2" Color="Color.Secondary">
-                            No sensors match your current filter criteria.
-                        </MudText>
-                        <MudButton Variant="Variant.Outlined"
-                                   Color="Color.Primary"
-                                   StartIcon="@Icons.Material.Filled.FilterAltOff"
-                                   OnClick="ClearFilters"
-                                   Class="mt-3">
-                            Clear Filters
-                        </MudButton>
-                    </MudStack>
-                </EmptyContent>
-            </Virtualize>
-        }
+            </SkeletonTemplate>
+            <EmptyTemplate>
+                <MudStack AlignItems="AlignItems.Center" Class="pa-8">
+                    <MudIcon Icon="@Icons.Material.Filled.Sensors" Size="Size.Large" Color="Color.Secondary" />
+                    <MudText Typo="Typo.h6" Color="Color.Secondary" Class="mt-2">No sensors yet</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        Sensors will appear here once data is ingested.
+                    </MudText>
+                </MudStack>
+            </EmptyTemplate>
+            <FilteredEmptyTemplate Context="clearFilters">
+                <MudStack AlignItems="AlignItems.Center" Class="pa-8">
+                    <MudIcon Icon="@Icons.Material.Filled.SearchOff" Size="Size.Large" Color="Color.Secondary" />
+                    <MudText Typo="Typo.h6" Color="Color.Secondary" Class="mt-2">No sensors found</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        No sensors match your current filter criteria.
+                    </MudText>
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.FilterAltOff"
+                               OnClick="clearFilters"
+                               Class="mt-3">
+                        Clear Filters
+                    </MudButton>
+                </MudStack>
+            </FilteredEmptyTemplate>
+        </EcoDataVirtualizedList>
     </MudPaper>
 </MudContainer>
 
 @code {
-    private Virtualize<SensorDtoForList>? _virtualize;
-    private readonly CursorPaginationState<SensorDtoForList, SensorParameters> _paginationState = new(s => s.Id);
-    private CancellationTokenSource? _refreshCts;
-    private bool _isLoading = true;
+    private EcoDataVirtualizedList<SensorDtoForList, SensorParameters>? _list;
 
     [Signal]
     private string? _searchText;
@@ -108,63 +104,28 @@
 
     protected override void OnInitialized()
     {
-        SearchTextSignal.OnChange(async _ => await RefreshDataAsync());
-        StatusFilterSignal.OnChange(async _ => await RefreshDataAsync());
+        SearchTextSignal.OnChange(async _ => await RefreshAsync());
+        StatusFilterSignal.OnChange(async _ => await RefreshAsync());
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    private SensorParameters CreateParameters() => new()
     {
-        if (firstRender)
+        PageSize = 50,
+        Search = string.IsNullOrWhiteSpace(SearchText) ? null : SearchText,
+        IsActive = StatusFilter switch
         {
-            await RefreshDataAsync();
+            SensorStatusFilter.Active => true,
+            SensorStatusFilter.Inactive => false,
+            _ => null
         }
-    }
+    };
 
-    private async Task RefreshDataAsync()
+    private async Task RefreshAsync()
     {
-        _refreshCts?.Cancel();
-        _refreshCts = new CancellationTokenSource();
-        var token = _refreshCts.Token;
-
-        try
+        if (_list is not null)
         {
-            _isLoading = true;
-            StateHasChanged();
-
-            _paginationState.Reset();
-
-            var request = new ItemsProviderRequest(0, 50, token);
-            await LoadItemsAsync(request);
-
-            _isLoading = false;
-            StateHasChanged();
-
-            if (_virtualize is not null)
-            {
-                await _virtualize.RefreshDataAsync();
-            }
+            await _list.RefreshAsync();
         }
-        catch (TaskCanceledException)
-        {
-        }
-    }
-
-    private ValueTask<ItemsProviderResult<SensorDtoForList>> LoadItemsAsync(ItemsProviderRequest request)
-    {
-        return _paginationState.ProvideItemsAsync(
-            request,
-            () => new SensorParameters
-            {
-                PageSize = 50,
-                Search = string.IsNullOrWhiteSpace(SearchText) ? null : SearchText,
-                IsActive = StatusFilter switch
-                {
-                    SensorStatusFilter.Active => true,
-                    SensorStatusFilter.Inactive => false,
-                    _ => null
-                }
-            },
-            (parameters, ct) => SensorClient.GetSensorsAsync(parameters, ct));
     }
 
     private void ClearFilters()
@@ -176,13 +137,6 @@
     private void NavigateToMap(SensorDtoForList sensor)
     {
         Navigation.NavigateTo($"/map?lat={sensor.Latitude}&lon={sensor.Longitude}");
-    }
-
-    public void Dispose()
-    {
-        _refreshCts?.Cancel();
-        _refreshCts?.Dispose();
-        _paginationState.Dispose();
     }
 
     public enum SensorStatusFilter

--- a/src/Common/EcoData.Common.Pagination.Blazor/EcoData.Common.Pagination.Blazor.csproj
+++ b/src/Common/EcoData.Common.Pagination.Blazor/EcoData.Common.Pagination.Blazor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EcoData.Common.Pagination\EcoData.Common.Pagination.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.1" />
+    <PackageReference Include="MudBlazor" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Common/EcoData.Common.Pagination.Blazor/EcoDataVirtualizedList.razor
+++ b/src/Common/EcoData.Common.Pagination.Blazor/EcoDataVirtualizedList.razor
@@ -1,0 +1,60 @@
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@typeparam TItem
+@typeparam TParams where TParams : CursorParameters
+
+<div class="eco-virtualized-list-container">
+    @if (_isLoading)
+    {
+        @if (SkeletonTemplate is not null)
+        {
+            @for (var i = 0; i < SkeletonCount; i++)
+            {
+                @SkeletonTemplate
+            }
+        }
+        else
+        {
+            @for (var i = 0; i < SkeletonCount; i++)
+            {
+                <div class="eco-skeleton-item" style="height: @(ItemSize)px;">
+                    <MudSkeleton Width="60%" Height="16px" />
+                    <MudSkeleton Width="40%" Height="14px" Class="mt-1" />
+                </div>
+            }
+        }
+    }
+    else if (_paginationState.CachedItems.Count == 0)
+    {
+        @if (HasActiveFilters?.Invoke(ParametersFactory()) == true && FilteredEmptyTemplate is not null)
+        {
+            @FilteredEmptyTemplate(ClearFiltersAsync)
+        }
+        else if (EmptyTemplate is not null)
+        {
+            @EmptyTemplate
+        }
+        else
+        {
+            <MudStack AlignItems="AlignItems.Center" Class="pa-8">
+                <MudIcon Icon="@Icons.Material.Filled.SearchOff" Size="Size.Large" Color="Color.Secondary" />
+                <MudText Typo="Typo.h6" Color="Color.Secondary" Class="mt-2">No items found</MudText>
+            </MudStack>
+        }
+    }
+    else
+    {
+        <Virtualize @ref="_virtualize"
+                    TItem="TItem"
+                    ItemsProvider="LoadItemsAsync"
+                    ItemSize="ItemSize"
+                    OverscanCount="OverscanCount"
+                    Context="item">
+            <ItemContent>
+                @ItemTemplate(item)
+            </ItemContent>
+            <Placeholder>
+                <div style="height: @(ItemSize)px;"></div>
+            </Placeholder>
+        </Virtualize>
+    }
+</div>

--- a/src/Common/EcoData.Common.Pagination.Blazor/EcoDataVirtualizedList.razor.cs
+++ b/src/Common/EcoData.Common.Pagination.Blazor/EcoDataVirtualizedList.razor.cs
@@ -1,0 +1,210 @@
+using EcoData.Common.Pagination;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
+
+namespace EcoData.Common.Pagination.Blazor;
+
+/// <summary>
+/// A virtualized list component that encapsulates cursor-based pagination state and provides
+/// a consistent UI for loading, empty, and filtered-empty states.
+/// </summary>
+/// <typeparam name="TItem">The type of items in the list.</typeparam>
+/// <typeparam name="TParams">The type of pagination parameters.</typeparam>
+public partial class EcoDataVirtualizedList<TItem, TParams> : ComponentBase, IDisposable
+    where TParams : CursorParameters
+{
+    private Virtualize<TItem>? _virtualize;
+    private CursorPaginationState<TItem, TParams> _paginationState = null!;
+    private CancellationTokenSource? _refreshCts;
+    private bool _isLoading = true;
+    private bool _disposed;
+
+    /// <summary>
+    /// Template for rendering each item in the list.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public RenderFragment<TItem> ItemTemplate { get; set; } = null!;
+
+    /// <summary>
+    /// Optional template for rendering skeleton loading items.
+    /// If not provided, a default skeleton is used.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? SkeletonTemplate { get; set; }
+
+    /// <summary>
+    /// Template to display when the list is empty and no filters are active.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? EmptyTemplate { get; set; }
+
+    /// <summary>
+    /// Template to display when the list is empty due to active filters.
+    /// The context provides a callback to clear filters.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<Func<Task>>? FilteredEmptyTemplate { get; set; }
+
+    /// <summary>
+    /// Function that provides items asynchronously based on parameters.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public Func<TParams, CancellationToken, IAsyncEnumerable<TItem>> ItemsProvider { get; set; } = null!;
+
+    /// <summary>
+    /// Factory function that creates pagination parameters.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public Func<TParams> ParametersFactory { get; set; } = null!;
+
+    /// <summary>
+    /// Function that extracts the unique key (Guid) from an item.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public Func<TItem, Guid> KeySelector { get; set; } = null!;
+
+    /// <summary>
+    /// Optional function that determines if any filters are currently active.
+    /// Used to decide whether to show EmptyTemplate or FilteredEmptyTemplate.
+    /// </summary>
+    [Parameter]
+    public Func<TParams, bool>? HasActiveFilters { get; set; }
+
+    /// <summary>
+    /// Callback invoked when the user requests to clear filters.
+    /// </summary>
+    [Parameter]
+    public EventCallback OnClearFilters { get; set; }
+
+    /// <summary>
+    /// The height in pixels of each item. Used by the virtualizer.
+    /// </summary>
+    [Parameter]
+    public float ItemSize { get; set; } = 65;
+
+    /// <summary>
+    /// The number of items to render outside the visible viewport.
+    /// </summary>
+    [Parameter]
+    public int OverscanCount { get; set; } = 5;
+
+    /// <summary>
+    /// The number of skeleton items to show during initial loading.
+    /// </summary>
+    [Parameter]
+    public int SkeletonCount { get; set; } = 8;
+
+    /// <summary>
+    /// Gets the cached items from the pagination state.
+    /// </summary>
+    public IReadOnlyList<TItem> CachedItems => _paginationState.CachedItems;
+
+    protected override void OnInitialized()
+    {
+        _paginationState = new CursorPaginationState<TItem, TParams>(KeySelector);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await RefreshAsync();
+        }
+    }
+
+    /// <summary>
+    /// Refreshes the list by resetting pagination state and reloading data.
+    /// </summary>
+    public async Task RefreshAsync()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        _refreshCts?.Cancel();
+        _refreshCts = new CancellationTokenSource();
+        var token = _refreshCts.Token;
+
+        try
+        {
+            _isLoading = true;
+            StateHasChanged();
+
+            _paginationState.Reset();
+
+            // Pre-fetch initial items
+            var request = new ItemsProviderRequest(0, 50, token);
+            await LoadItemsAsync(request);
+
+            _isLoading = false;
+            StateHasChanged();
+
+            if (_virtualize is not null)
+            {
+                await _virtualize.RefreshDataAsync();
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            // Refresh was cancelled, ignore
+        }
+    }
+
+    /// <summary>
+    /// Updates an item in the cache by its key.
+    /// </summary>
+    /// <param name="updatedItem">The updated item.</param>
+    public void UpdateItem(TItem updatedItem)
+    {
+        _paginationState.UpdateItem(updatedItem);
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Updates an item in the cache using an updater function.
+    /// </summary>
+    /// <param name="id">The key of the item to update.</param>
+    /// <param name="updater">A function that returns the updated item.</param>
+    public void UpdateItem(Guid id, Func<TItem, TItem> updater)
+    {
+        _paginationState.UpdateItem(id, updater);
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Removes an item from the cache by its key.
+    /// </summary>
+    /// <param name="id">The key of the item to remove.</param>
+    /// <returns>True if the item was removed; otherwise, false.</returns>
+    public bool RemoveItem(Guid id)
+    {
+        var result = _paginationState.RemoveItem(id);
+        if (result)
+        {
+            StateHasChanged();
+        }
+        return result;
+    }
+
+    private ValueTask<ItemsProviderResult<TItem>> LoadItemsAsync(ItemsProviderRequest request)
+    {
+        return _paginationState.ProvideItemsAsync(
+            request,
+            ParametersFactory,
+            ItemsProvider);
+    }
+
+    private async Task ClearFiltersAsync()
+    {
+        await OnClearFilters.InvokeAsync();
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _refreshCts?.Cancel();
+            _refreshCts?.Dispose();
+            _paginationState.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/src/Common/EcoData.Common.Pagination.Blazor/EcoDataVirtualizedList.razor.css
+++ b/src/Common/EcoData.Common.Pagination.Blazor/EcoDataVirtualizedList.razor.css
@@ -1,0 +1,16 @@
+.eco-virtualized-list-container {
+    height: 100%;
+    overflow-y: auto;
+}
+
+.eco-skeleton-item {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 12px 16px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+::deep .eco-skeleton-item:last-child {
+    border-bottom: none;
+}

--- a/src/Common/EcoData.Common.Pagination.Blazor/_Imports.razor
+++ b/src/Common/EcoData.Common.Pagination.Blazor/_Imports.razor
@@ -1,0 +1,6 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using MudBlazor
+@using EcoData.Common.Pagination
+@using EcoData.Common.Pagination.Blazor


### PR DESCRIPTION
## Summary

- Add `EcoDataVirtualizedList<TItem, TParams>` component that encapsulates cursor pagination state, loading skeletons, and empty states
- Migrate `SensorsPage` and `OrganizationsPage` to use the new component
- Add MudBlazor dependency to `EcoData.Common.Pagination.Blazor`

## Component Features

- `ItemTemplate` - render each item
- `SkeletonTemplate` - loading state
- `EmptyTemplate` - no data exists
- `FilteredEmptyTemplate` - filters return no results (with clear callback)
- `RefreshAsync()`, `UpdateItem()`, `RemoveItem()` methods

## Usage Example

```razor
<EcoDataVirtualizedList TItem="SensorDtoForList"
                        TParams="SensorParameters"
                        ItemsProvider="SensorClient.GetSensorsAsync"
                        ParametersFactory="CreateParameters"
                        KeySelector="s => s.Id"
                        HasActiveFilters="_ => HasActiveFilters"
                        OnClearFilters="ClearFilters">
    <ItemTemplate Context="sensor">
        <SensorListItem Sensor="sensor" />
    </ItemTemplate>
</EcoDataVirtualizedList>
```

## Test plan

- [ ] Verify SensorsPage loads and paginates correctly
- [ ] Verify OrganizationsPage loads and paginates correctly
- [ ] Verify loading skeletons appear during initial load
- [ ] Verify empty states display correctly
- [ ] Verify filter clear functionality works

Closes #26