### PR TITLE
Add centralized BackButtonService for consistent back navigation

### DIFF
--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Layout/MainLayout.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Layout/MainLayout.razor
@@ -7,6 +7,7 @@
 @using EcoData.AquaTrack.WebApp.Client.Themes
 @inject AuthStateService AuthState
 @inject ClientAuthStateProvider AuthStateProvider
+@inject BackButtonService BackButton
 @inject NavigationManager Navigation
 @implements IDisposable
 
@@ -18,9 +19,11 @@
 <MudLayout>
     <MudAppBar Elevation="0"
                Style="background-color: var(--mud-palette-drawer-background); color: var(--mud-palette-text-primary);" Fixed="true">
-        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start"
+        <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Color="Color.Inherit" Edge="Edge.Start" Size="Size.Small"
+                       Disabled="@(!BackButton.IsVisible)" OnClick="NavigateBack" />
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
                        OnClick="ToggleDrawer" />
-        <MudText Typo="Typo.h6" Class="ml-2">AquaTrack</MudText>
+        <MudText Typo="Typo.h6">AquaTrack</MudText>
         <MudSpacer />
         <MudHidden Breakpoint="Breakpoint.SmAndDown">
             <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
@@ -100,14 +103,30 @@
     private void ToggleDrawer() => _drawerOpen = !_drawerOpen;
     private void ToggleTheme() => _isDarkMode = !_isDarkMode;
 
+    private void NavigateBack()
+    {
+        if (BackButton.Path is not null)
+        {
+            var path = BackButton.Path;
+            BackButton.ResetPath();
+            Navigation.NavigateTo(path);
+        }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         AuthState.SetAuthStateProvider(AuthStateProvider);
         AuthState.OnAuthStateChanged += HandleAuthStateChanged;
+        BackButton.OnStateChanged += HandleBackButtonStateChanged;
         await AuthState.InitializeAsync();
     }
 
     private void HandleAuthStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleBackButtonStateChanged()
     {
         InvokeAsync(StateHasChanged);
     }
@@ -132,5 +151,6 @@
     public void Dispose()
     {
         AuthState.OnAuthStateChanged -= HandleAuthStateChanged;
+        BackButton.OnStateChanged -= HandleBackButtonStateChanged;
     }
 }

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationDetailsPage.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationDetailsPage.razor
@@ -10,6 +10,7 @@
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject AuthStateService AuthState
+@inject BackButtonService BackButton
 
 <PageTitle>@(_organization?.Name ?? "Organization") - AquaTrack</PageTitle>
 
@@ -28,9 +29,6 @@ else if (_organization is null)
     <MudStack AlignItems="AlignItems.Center" Class="pa-8">
         <MudIcon Icon="@Icons.Material.Filled.Error" Size="Size.Large" Color="Color.Error" />
         <MudText Typo="Typo.h6" Color="Color.Error">Organization not found</MudText>
-        <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack" OnClick="NavigateBack">
-            Back
-        </MudButton>
     </MudStack>
 }
 else
@@ -42,7 +40,6 @@ else
             {
                 <img src="@_organization.CardPictureUrl" alt="" />
             }
-            <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Class="back-btn" OnClick="NavigateBack" />
         </div>
 
         @* Header: Avatar + Name + Actions *@
@@ -119,6 +116,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        BackButton.SetPath("/organizations");
         await LoadCommand.ExecuteAsync();
     }
 
@@ -132,7 +130,6 @@ else
         );
     }
 
-    private void NavigateBack() => Navigation.NavigateTo("/organizations");
     private void NavigateToEdit() => Navigation.NavigateTo($"/organizations/{Id}/edit");
     private void NavigateToSensors() => Navigation.NavigateTo($"/organizations/{Id}/sensors");
 

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationEditPage.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationEditPage.razor
@@ -8,6 +8,7 @@
 @inject NavigationManager Navigation
 @inject ISnackbar Snackbar
 @inject AuthStateService AuthState
+@inject BackButtonService BackButton
 
 <PageTitle>Edit Organization - AquaTrack</PageTitle>
 
@@ -28,13 +29,6 @@
             <MudStack AlignItems="AlignItems.Center">
                 <MudIcon Icon="@Icons.Material.Filled.Error" Size="Size.Large" Color="Color.Error" />
                 <MudText Typo="Typo.h6" Color="Color.Error" Class="mt-2">Organization not found</MudText>
-                <MudButton Variant="Variant.Outlined"
-                           Color="Color.Primary"
-                           StartIcon="@Icons.Material.Filled.ArrowBack"
-                           OnClick="NavigateBack"
-                           Class="mt-3">
-                    Back to Organizations
-                </MudButton>
             </MudStack>
         </MudPaper>
     }
@@ -47,24 +41,13 @@
                 <MudText Typo="Typo.body2" Color="Color.Secondary">
                     You don't have permission to edit organizations.
                 </MudText>
-                <MudButton Variant="Variant.Outlined"
-                           Color="Color.Primary"
-                           StartIcon="@Icons.Material.Filled.ArrowBack"
-                           OnClick="NavigateBack"
-                           Class="mt-3">
-                    Back to Organizations
-                </MudButton>
             </MudStack>
         </MudPaper>
     }
     else
     {
         <MudPaper Elevation="1" Class="pa-6">
-            <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4">
-                <MudIconButton Icon="@Icons.Material.Filled.ArrowBack"
-                               OnClick="NavigateToDetails" />
-                <MudText Typo="Typo.h5">Edit Organization</MudText>
-            </MudStack>
+            <MudText Typo="Typo.h5" Class="mb-4">Edit Organization</MudText>
 
             @if (!string.IsNullOrEmpty(_errorMessage))
             {
@@ -170,6 +153,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        BackButton.SetPath($"/organizations/{Id}");
         await LoadCommand.ExecuteAsync();
     }
 
@@ -224,13 +208,5 @@
         );
     }
 
-    private void NavigateBack()
-    {
-        Navigation.NavigateTo("/organizations");
-    }
-
-    private void NavigateToDetails()
-    {
-        Navigation.NavigateTo($"/organizations/{Id}");
-    }
+    private void NavigateToDetails() => Navigation.NavigateTo($"/organizations/{Id}");
 }

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationSensorCreatePage.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationSensorCreatePage.razor
@@ -11,6 +11,7 @@
 @inject NavigationManager Navigation
 @inject ISnackbar Snackbar
 @inject AuthStateService AuthState
+@inject BackButtonService BackButton
 
 <PageTitle>Add Sensor - AquaTrack</PageTitle>
 
@@ -30,10 +31,6 @@
             <MudStack AlignItems="AlignItems.Center">
                 <MudIcon Icon="@Icons.Material.Filled.Error" Size="Size.Large" Color="Color.Error" />
                 <MudText Typo="Typo.h6" Color="Color.Error" Class="mt-2">Organization not found</MudText>
-                <MudButton Variant="Variant.Outlined" Color="Color.Primary"             StartIcon="@Icons.Material.Filled.ArrowBack"
-                           OnClick="NavigateBack"        Class="mt-3">
-                    Back to Organizations
-                </MudButton>
             </MudStack>
         </MudPaper>
     }
@@ -46,20 +43,13 @@
                 <MudText Typo="Typo.body2" Color="Color.Secondary">
                     You don't have permission to add sensors.
                 </MudText>
-                <MudButton Variant="Variant.Outlined"                  Color="Color.Primary"                        StartIcon="@Icons.Material.Filled.ArrowBack"
-                           OnClick="NavigateToOrganization"                   Class="mt-3">
-                    Back to Organization
-                </MudButton>
             </MudStack>
         </MudPaper>
     }
     else
     {
         <MudPaper Elevation="1" Class="pa-6">
-            <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4">
-                <MudIconButton Icon="@Icons.Material.Filled.ArrowBack"             OnClick="NavigateToOrganization" />
-                <MudText Typo="Typo.h5">Add Sensor</MudText>
-            </MudStack>
+            <MudText Typo="Typo.h5" Class="mb-4">Add Sensor</MudText>
 
             <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
                 Adding sensor to <strong>@_organization.Name</strong>
@@ -116,7 +106,7 @@
                            Disabled="CreateCommand.IsLoading" />
 
                 <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2" Class="mt-4">
-                    <MudButton Variant="Variant.Text"                               Color="Color.Default"                               OnClick="NavigateToOrganization"
+                    <MudButton Variant="Variant.Text" Color="Color.Default" OnClick="NavigateToSensors"
                                Disabled="CreateCommand.IsLoading">
                         Cancel
                     </MudButton>
@@ -154,6 +144,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        BackButton.SetPath($"/organizations/{OrganizationId}/sensors");
         await LoadCommand.ExecuteAsync();
     }
 
@@ -244,7 +235,7 @@
         if (result is not null)
         {
             Snackbar.Add("Sensor created successfully", Severity.Success);
-            Navigation.NavigateTo($"/organizations/{OrganizationId}");
+            Navigation.NavigateTo($"/organizations/{OrganizationId}/sensors");
         }
         else
         {
@@ -252,6 +243,5 @@
         }
     }
 
-    private void NavigateBack() => Navigation.NavigateTo("/organizations");
-    private void NavigateToOrganization() => Navigation.NavigateTo($"/organizations/{OrganizationId}");
+    private void NavigateToSensors() => Navigation.NavigateTo($"/organizations/{OrganizationId}/sensors");
 }

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationSensorsPage.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Pages/OrganizationSensorsPage.razor
@@ -7,12 +7,12 @@
 @inject IOrganizationHttpClient OrganizationClient
 @inject NavigationManager Navigation
 @inject AuthStateService AuthState
+@inject BackButtonService BackButton
 
 <PageTitle>Sensors - @(_organization?.Name ?? "Organization") - AquaTrack</PageTitle>
 
 <div class="sensors-page">
     <div class="page-header">
-        <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" OnClick="NavigateBack" />
         @if (_organization is not null)
         {
             <MudText Typo="Typo.h6">@_organization.Name - Sensors</MudText>
@@ -46,6 +46,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        BackButton.SetPath($"/organizations/{OrganizationId}");
         await LoadCommand.ExecuteAsync();
     }
 
@@ -59,7 +60,6 @@
         );
     }
 
-    private void NavigateBack() => Navigation.NavigateTo($"/organizations/{OrganizationId}");
     private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{OrganizationId}/sensors/create");
 
     private void NavigateToMap(SensorDtoForList sensor)

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Program.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddAquaTrackClient(baseAddress);
 builder.Services.AddIdentityClient(baseAddress);
 
 builder.Services.AddScoped<ISensorMapManager, SensorMapManager>();
+builder.Services.AddScoped<BackButtonService>();
 builder.Services.AddScoped<AuthStateService>();
 builder.Services.AddScoped<ClientAuthStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(sp =>

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Services/BackButtonService.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Services/BackButtonService.cs
@@ -1,0 +1,21 @@
+namespace EcoData.AquaTrack.WebApp.Client.Services;
+
+public sealed class BackButtonService
+{
+    public string? Path { get; private set; }
+    public bool IsVisible => Path is not null;
+
+    public event Action? OnStateChanged;
+
+    public void SetPath(string path)
+    {
+        Path = path;
+        OnStateChanged?.Invoke();
+    }
+
+    public void ResetPath()
+    {
+        Path = null;
+        OnStateChanged?.Invoke();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `BackButtonService` with `SetPath()` and `ResetPath()` methods
- Add back button to the left of hamburger menu in MainLayout
- Back button resets path when consumed
- Pages call `BackButton.SetPath()` on init to configure navigation
- Remove individual back buttons from organization pages

Closes #37

## Test plan

- [ ] Navigate to organization details, verify back button appears and goes to /organizations
- [ ] Navigate to organization sensors, verify back button goes to organization details
- [ ] Navigate to create sensor, verify back button goes to sensors list
- [ ] Navigate to edit organization, verify back button goes to organization details
- [ ] Verify back button is disabled on pages that don't set a path

🤖 Generated with [Claude Code](https://claude.com/claude-code)