### PR TITLE
Add static typed permission constants

### DIFF
--- a/src/AquaTrack/EcoData.AquaTrack.Api/MemberEndpoints.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Api/MemberEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using static EcoData.AquaTrack.Contracts.Permissions;
 using EcoData.AquaTrack.Contracts.Dtos;
 using EcoData.AquaTrack.DataAccess.Interfaces;
 using EcoData.Identity.Contracts.Claims;
@@ -74,7 +75,7 @@ public static class MemberEndpoints
                         || !await permissionService.HasPermissionAsync(
                             token.UserId.Value,
                             organizationId,
-                            "org:members:manage",
+                            Organization.ManageMembers,
                             ct
                         )
                     )
@@ -141,7 +142,7 @@ public static class MemberEndpoints
                         || !await permissionService.HasPermissionAsync(
                             token.UserId.Value,
                             organizationId,
-                            "org:members:manage",
+                            Organization.ManageMembers,
                             ct
                         )
                     )
@@ -198,7 +199,7 @@ public static class MemberEndpoints
                         || !await permissionService.HasPermissionAsync(
                             token.UserId.Value,
                             organizationId,
-                            "org:members:manage",
+                            Organization.ManageMembers,
                             ct
                         )
                     )

--- a/src/AquaTrack/EcoData.AquaTrack.Api/OrganizationEndpoints.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Api/OrganizationEndpoints.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Routing;
+using static EcoData.AquaTrack.Contracts.Permissions;
 
 namespace EcoData.AquaTrack.Api;
 
@@ -38,7 +39,9 @@ public static class OrganizationEndpoints
                 ) =>
                 {
                     var organization = await repository.GetByIdAsync(id, ct);
-                    return organization is null ? TypedResults.NotFound() : TypedResults.Ok(organization);
+                    return organization is null
+                        ? TypedResults.NotFound()
+                        : TypedResults.Ok(organization);
                 }
             )
             .WithName("GetOrganizationById");
@@ -59,13 +62,19 @@ public static class OrganizationEndpoints
                         return Results.Ok(new OrganizationPermissionsDto(null, []));
                     }
 
-                    var membership = await membershipRepository.GetAsync(token.UserId.Value, id, ct);
+                    var membership = await membershipRepository.GetAsync(
+                        token.UserId.Value,
+                        id,
+                        ct
+                    );
                     if (membership is null)
                     {
                         return Results.Ok(new OrganizationPermissionsDto(null, []));
                     }
 
-                    return Results.Ok(new OrganizationPermissionsDto(membership.RoleName, membership.Permissions));
+                    return Results.Ok(
+                        new OrganizationPermissionsDto(membership.RoleName, membership.Permissions)
+                    );
                 }
             )
             .WithName("GetMyOrganizationPermissions")
@@ -83,7 +92,9 @@ public static class OrganizationEndpoints
                     var exists = await repository.ExistsAsync(dto.Name, ct);
                     if (exists)
                     {
-                        return TypedResults.Conflict("An organization with this name already exists.");
+                        return TypedResults.Conflict(
+                            "An organization with this name already exists."
+                        );
                     }
 
                     var created = await repository.CreateAsync(dto, ct);
@@ -106,7 +117,15 @@ public static class OrganizationEndpoints
                 ) =>
                 {
                     var token = new RequestClaimToken(user);
-                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, id, "org:update", ct))
+                    if (
+                        !token.IsAuthenticated
+                        || !await permissionService.HasPermissionAsync(
+                            token.UserId.Value,
+                            id,
+                            Organization.Update,
+                            ct
+                        )
+                    )
                     {
                         return TypedResults.Forbid();
                     }
@@ -130,7 +149,15 @@ public static class OrganizationEndpoints
                 ) =>
                 {
                     var token = new RequestClaimToken(user);
-                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, id, "org:delete", ct))
+                    if (
+                        !token.IsAuthenticated
+                        || !await permissionService.HasPermissionAsync(
+                            token.UserId.Value,
+                            id,
+                            Organization.Delete,
+                            ct
+                        )
+                    )
                     {
                         return TypedResults.Forbid();
                     }

--- a/src/AquaTrack/EcoData.AquaTrack.Api/SensorEndpoints.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Api/SensorEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using static EcoData.AquaTrack.Contracts.Permissions;
 using EcoData.AquaTrack.Contracts.Dtos;
 using EcoData.AquaTrack.Contracts.Parameters;
 using EcoData.AquaTrack.DataAccess.Interfaces;
@@ -50,7 +51,7 @@ public static class SensorEndpoints
                     }
 
                     var token = new RequestClaimToken(user);
-                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, "sensor:read", ct))
+                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, Sensor.Read, ct))
                     {
                         return TypedResults.Forbid();
                     }
@@ -74,7 +75,7 @@ public static class SensorEndpoints
                 ) =>
                 {
                     var token = new RequestClaimToken(user);
-                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, "sensor:read", ct))
+                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, Sensor.Read, ct))
                     {
                         return TypedResults.Forbid();
                     }
@@ -110,7 +111,7 @@ public static class SensorEndpoints
                     }
 
                     var token = new RequestClaimToken(user);
-                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, "sensor:create", ct))
+                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, Sensor.Create, ct))
                     {
                         return TypedResults.Forbid();
                     }
@@ -135,7 +136,7 @@ public static class SensorEndpoints
                 ) =>
                 {
                     var token = new RequestClaimToken(user);
-                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, "sensor:update", ct))
+                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, Sensor.Update, ct))
                     {
                         return TypedResults.Forbid();
                     }
@@ -170,7 +171,7 @@ public static class SensorEndpoints
                 ) =>
                 {
                     var token = new RequestClaimToken(user);
-                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, "sensor:delete", ct))
+                    if (!token.IsAuthenticated || !await permissionService.HasPermissionAsync(token.UserId.Value, organizationId, Sensor.Delete, ct))
                     {
                         return TypedResults.Forbid();
                     }

--- a/src/AquaTrack/EcoData.AquaTrack.Contracts/Permissions.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Contracts/Permissions.cs
@@ -1,0 +1,19 @@
+namespace EcoData.AquaTrack.Contracts;
+
+public static class Permissions
+{
+    public static class Sensor
+    {
+        public const string Read = "sensor:read";
+        public const string Create = "sensor:create";
+        public const string Update = "sensor:update";
+        public const string Delete = "sensor:delete";
+    }
+
+    public static class Organization
+    {
+        public const string Update = "org:update";
+        public const string Delete = "org:delete";
+        public const string ManageMembers = "org:members:manage";
+    }
+}

--- a/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
+++ b/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using P = EcoData.AquaTrack.Contracts.Permissions;
 using EcoData.AquaTrack.Database;
 using EcoData.AquaTrack.Database.Models;
 using EcoData.Identity.Database;
@@ -130,21 +131,21 @@ public sealed class DatabaseSeederWorker(
         var permissions = new List<OrganizationRolePermission>
         {
             // Viewer permissions
-            new() { RoleId = viewerRole.Id, Permission = "sensor:read" },
+            new() { RoleId = viewerRole.Id, Permission = P.Sensor.Read },
 
             // Contributor permissions
-            new() { RoleId = contributorRole.Id, Permission = "sensor:read" },
-            new() { RoleId = contributorRole.Id, Permission = "sensor:create" },
-            new() { RoleId = contributorRole.Id, Permission = "sensor:update" },
+            new() { RoleId = contributorRole.Id, Permission = P.Sensor.Read },
+            new() { RoleId = contributorRole.Id, Permission = P.Sensor.Create },
+            new() { RoleId = contributorRole.Id, Permission = P.Sensor.Update },
 
             // Admin permissions
-            new() { RoleId = adminRole.Id, Permission = "sensor:read" },
-            new() { RoleId = adminRole.Id, Permission = "sensor:create" },
-            new() { RoleId = adminRole.Id, Permission = "sensor:update" },
-            new() { RoleId = adminRole.Id, Permission = "sensor:delete" },
-            new() { RoleId = adminRole.Id, Permission = "org:update" },
-            new() { RoleId = adminRole.Id, Permission = "org:delete" },
-            new() { RoleId = adminRole.Id, Permission = "org:members:manage" },
+            new() { RoleId = adminRole.Id, Permission = P.Sensor.Read },
+            new() { RoleId = adminRole.Id, Permission = P.Sensor.Create },
+            new() { RoleId = adminRole.Id, Permission = P.Sensor.Update },
+            new() { RoleId = adminRole.Id, Permission = P.Sensor.Delete },
+            new() { RoleId = adminRole.Id, Permission = P.Organization.Update },
+            new() { RoleId = adminRole.Id, Permission = P.Organization.Delete },
+            new() { RoleId = adminRole.Id, Permission = P.Organization.ManageMembers },
         };
 
         context.OrganizationRolePermissions.AddRange(permissions);

--- a/src/Host/EcoData.Seeder/EcoData.Seeder.csproj
+++ b/src/Host/EcoData.Seeder/EcoData.Seeder.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EcoData.ServiceDefaults\EcoData.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\AquaTrack\EcoData.AquaTrack.Contracts\EcoData.AquaTrack.Contracts.csproj" />
     <ProjectReference Include="..\..\AquaTrack\EcoData.AquaTrack.Database\EcoData.AquaTrack.Database.csproj" />
     <ProjectReference Include="..\..\Identity\EcoData.Identity.Database\EcoData.Identity.Database.csproj" />
     <ProjectReference Include="..\..\Locations\EcoData.Locations.Database\EcoData.Locations.Database.csproj" />


### PR DESCRIPTION
## Summary
- Create `Permissions` class in `EcoData.AquaTrack.Contracts` with nested `Sensor` and `Organization` classes
- Replace all string literal permission checks with typed constants
- Ensures compile-time safety and consistency for permission checks

## Changes
- `Permissions.Sensor.Read`, `Create`, `Update`, `Delete`
- `Permissions.Organization.Update`, `Delete`, `ManageMembers`

## Files Updated
- `MemberEndpoints.cs`
- `OrganizationEndpoints.cs`
- `SensorEndpoints.cs`
- `DatabaseSeederWorker.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)