### PR TITLE
Make organization roles require an organization

### DIFF
--- a/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/OrganizationMemberRepository.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/OrganizationMemberRepository.cs
@@ -111,11 +111,8 @@ public sealed class OrganizationMemberRepository(
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 
         var role = await context
-            .OrganizationRoles.Where(r =>
-                r.Name == roleName
-                && (r.OrganizationId == organizationId || r.OrganizationId == null)
-            )
-            .OrderByDescending(r => r.OrganizationId)
+            .OrganizationRoles
+            .Where(r => r.Name == roleName && r.OrganizationId == organizationId)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (role is null)
@@ -170,11 +167,8 @@ public sealed class OrganizationMemberRepository(
         }
 
         var role = await context
-            .OrganizationRoles.Where(r =>
-                r.Name == roleName
-                && (r.OrganizationId == organizationId || r.OrganizationId == null)
-            )
-            .OrderByDescending(r => r.OrganizationId)
+            .OrganizationRoles
+            .Where(r => r.Name == roleName && r.OrganizationId == organizationId)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (role is null)

--- a/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/OrganizationRepository.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/OrganizationRepository.cs
@@ -115,6 +115,34 @@ public sealed class OrganizationRepository(IDbContextFactory<AquaTrackDbContext>
         };
 
         context.Organizations.Add(entity);
+
+        // Seed default roles for the organization
+        var defaultRoles = new[]
+        {
+            new OrganizationRole
+            {
+                Id = Guid.CreateVersion7(),
+                OrganizationId = entity.Id,
+                Name = "Owner",
+                CreatedAt = now,
+            },
+            new OrganizationRole
+            {
+                Id = Guid.CreateVersion7(),
+                OrganizationId = entity.Id,
+                Name = "Admin",
+                CreatedAt = now,
+            },
+            new OrganizationRole
+            {
+                Id = Guid.CreateVersion7(),
+                OrganizationId = entity.Id,
+                Name = "Viewer",
+                CreatedAt = now,
+            },
+        };
+        context.OrganizationRoles.AddRange(defaultRoles);
+
         await context.SaveChangesAsync(cancellationToken);
 
         return new OrganizationDtoForCreated(entity.Id, entity.Name);

--- a/src/AquaTrack/EcoData.AquaTrack.Database/Migrations/20260312055204_Initial.Designer.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Database/Migrations/20260312055204_Initial.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EcoData.AquaTrack.Database.Migrations
 {
     [DbContext(typeof(AquaTrackDbContext))]
-    [Migration("20260312050200_Initial")]
+    [Migration("20260312055204_Initial")]
     partial class Initial
     {
         /// <inheritdoc />
@@ -439,7 +439,7 @@ namespace EcoData.AquaTrack.Database.Migrations
                         .HasColumnType("character varying(100)")
                         .HasColumnName("name");
 
-                    b.Property<Guid?>("OrganizationId")
+                    b.Property<Guid>("OrganizationId")
                         .HasColumnType("uuid")
                         .HasColumnName("organization_id");
 
@@ -927,6 +927,7 @@ namespace EcoData.AquaTrack.Database.Migrations
                         .WithMany()
                         .HasForeignKey("OrganizationId")
                         .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
                         .HasConstraintName("fk_organization_roles_organizations_organization_id");
 
                     b.Navigation("Organization");

--- a/src/AquaTrack/EcoData.AquaTrack.Database/Migrations/20260312055204_Initial.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Database/Migrations/20260312055204_Initial.cs
@@ -148,7 +148,7 @@ namespace EcoData.AquaTrack.Database.Migrations
                 columns: table => new
                 {
                     id = table.Column<Guid>(type: "uuid", nullable: false),
-                    organization_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    organization_id = table.Column<Guid>(type: "uuid", nullable: false),
                     name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                     created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
                 },

--- a/src/AquaTrack/EcoData.AquaTrack.Database/Migrations/AquaTrackDbContextModelSnapshot.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Database/Migrations/AquaTrackDbContextModelSnapshot.cs
@@ -436,7 +436,7 @@ namespace EcoData.AquaTrack.Database.Migrations
                         .HasColumnType("character varying(100)")
                         .HasColumnName("name");
 
-                    b.Property<Guid?>("OrganizationId")
+                    b.Property<Guid>("OrganizationId")
                         .HasColumnType("uuid")
                         .HasColumnName("organization_id");
 
@@ -924,6 +924,7 @@ namespace EcoData.AquaTrack.Database.Migrations
                         .WithMany()
                         .HasForeignKey("OrganizationId")
                         .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
                         .HasConstraintName("fk_organization_roles_organizations_organization_id");
 
                     b.Navigation("Organization");

--- a/src/AquaTrack/EcoData.AquaTrack.Database/Models/OrganizationRole.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Database/Models/OrganizationRole.cs
@@ -6,7 +6,7 @@ namespace EcoData.AquaTrack.Database.Models;
 public sealed class OrganizationRole
 {
     public required Guid Id { get; set; }
-    public required Guid? OrganizationId { get; set; }
+    public required Guid OrganizationId { get; set; }
     public required string Name { get; set; }
     public required DateTimeOffset CreatedAt { get; set; }
 
@@ -24,7 +24,7 @@ public sealed class OrganizationRole
             builder.Property(static e => e.Name).HasMaxLength(100).IsRequired();
             builder.Property(static e => e.CreatedAt).IsRequired();
 
-            // Unique constraint: role name per org (or globally if org is null)
+            // Unique constraint: role name per org
             builder.HasIndex(static e => new { e.OrganizationId, e.Name }).IsUnique();
 
             builder

--- a/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
+++ b/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
@@ -1,7 +1,5 @@
 using System.Text.Json;
-using P = EcoData.AquaTrack.Contracts.Permissions;
 using EcoData.AquaTrack.Database;
-using EcoData.AquaTrack.Database.Models;
 using EcoData.Identity.Database;
 using EcoData.Identity.Database.Models;
 using EcoData.Locations.Database;
@@ -30,7 +28,6 @@ public sealed class DatabaseSeederWorker(
             await MigrateIdentityAsync(services, stoppingToken);
             await MigrateLocationsAsync(services, stoppingToken);
 
-            await SeedOrganizationRolesAsync(services, stoppingToken);
             await SeedAdminUserAsync(services, stoppingToken);
             await SeedLocationsAsync(services, stoppingToken);
 
@@ -78,80 +75,6 @@ public sealed class DatabaseSeederWorker(
         logger.LogInformation("Applying Locations database migrations...");
         await context.Database.MigrateAsync(stoppingToken);
         logger.LogInformation("Locations database migrations applied.");
-    }
-
-    private async Task SeedOrganizationRolesAsync(
-        IServiceProvider services,
-        CancellationToken stoppingToken
-    )
-    {
-        var context = services.GetRequiredService<AquaTrackDbContext>();
-
-        var existingRoles = await context.OrganizationRoles
-            .Where(r => r.OrganizationId == null)
-            .AnyAsync(stoppingToken);
-
-        if (existingRoles)
-        {
-            logger.LogInformation("Default organization roles already exist. Skipping...");
-            return;
-        }
-
-        logger.LogInformation("Seeding default organization roles...");
-
-        var now = DateTimeOffset.UtcNow;
-
-        var viewerRole = new OrganizationRole
-        {
-            Id = Guid.CreateVersion7(),
-            OrganizationId = null,
-            Name = "Viewer",
-            CreatedAt = now,
-        };
-
-        var contributorRole = new OrganizationRole
-        {
-            Id = Guid.CreateVersion7(),
-            OrganizationId = null,
-            Name = "Contributor",
-            CreatedAt = now,
-        };
-
-        var adminRole = new OrganizationRole
-        {
-            Id = Guid.CreateVersion7(),
-            OrganizationId = null,
-            Name = "Admin",
-            CreatedAt = now,
-        };
-
-        context.OrganizationRoles.AddRange(viewerRole, contributorRole, adminRole);
-        await context.SaveChangesAsync(stoppingToken);
-
-        var permissions = new List<OrganizationRolePermission>
-        {
-            // Viewer permissions
-            new() { RoleId = viewerRole.Id, Permission = P.Sensor.Read },
-
-            // Contributor permissions
-            new() { RoleId = contributorRole.Id, Permission = P.Sensor.Read },
-            new() { RoleId = contributorRole.Id, Permission = P.Sensor.Create },
-            new() { RoleId = contributorRole.Id, Permission = P.Sensor.Update },
-
-            // Admin permissions
-            new() { RoleId = adminRole.Id, Permission = P.Sensor.Read },
-            new() { RoleId = adminRole.Id, Permission = P.Sensor.Create },
-            new() { RoleId = adminRole.Id, Permission = P.Sensor.Update },
-            new() { RoleId = adminRole.Id, Permission = P.Sensor.Delete },
-            new() { RoleId = adminRole.Id, Permission = P.Organization.Update },
-            new() { RoleId = adminRole.Id, Permission = P.Organization.Delete },
-            new() { RoleId = adminRole.Id, Permission = P.Organization.ManageMembers },
-        };
-
-        context.OrganizationRolePermissions.AddRange(permissions);
-        await context.SaveChangesAsync(stoppingToken);
-
-        logger.LogInformation("Default organization roles seeded: Viewer, Contributor, Admin");
     }
 
     private async Task SeedAdminUserAsync(


### PR DESCRIPTION
## Summary

- Make `OrganizationRole.OrganizationId` required (no longer nullable)
- Seed default roles (Owner, Admin, Viewer) when creating an organization
- Remove global role seeding from `DatabaseSeederWorker`
- Each organization can now add custom roles with custom permissions at runtime

## Changes

### Database
- `OrganizationRole.OrganizationId` is now `Guid` (not `Guid?`)
- Reset migrations to Initial

### Repository
- `OrganizationRepository.CreateAsync` now seeds default roles for new organizations
- `OrganizationMemberRepository` looks up roles only within the organization

### Seeder
- Removed `SeedOrganizationRolesAsync` method (roles are seeded per-org now)

## Rationale

This separates global/system roles (stored in Identity) from organization roles (stored per-org). Organizations can now have fully customizable roles without affecting other orgs.

## Test plan
- [ ] Create a new organization and verify it has Owner, Admin, Viewer roles
- [ ] Verify adding members with roles works correctly
- [ ] Verify role-based permissions work correctly