### PR TITLE
Modernize navigation back button to use NavigationManager

### DIFF
--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Features/OrganizationSensors/Pages/OrganizationSensorsPage.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Features/OrganizationSensors/Pages/OrganizationSensorsPage.razor
@@ -51,7 +51,7 @@
         );
     }
 
-    private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{OrganizationId}/sensors/create", trackReturn: true);
+    private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{OrganizationId}/sensors/create");
 
     private void NavigateToMap(SensorDtoForList sensor)
     {

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
@@ -222,11 +222,11 @@ else
         }
     }
 
-    private void NavigateToEdit() => Navigation.NavigateTo($"/organizations/{Id}/edit", trackReturn: true);
+    private void NavigateToEdit() => Navigation.NavigateTo($"/organizations/{Id}/edit");
     private void NavigateToSensors() => Navigation.NavigateTo($"/organizations/{Id}/sensors");
     private void NavigateToTeam() => Navigation.NavigateTo($"/organizations/{Id}/team");
     private void NavigateToSensor(SensorDtoForList sensor) => Navigation.NavigateTo($"/sensors/{sensor.Id}");
-    private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{Id}/sensors/create", trackReturn: true);
+    private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{Id}/sensors/create");
 
     private async Task ConfirmDelete()
     {

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Layout/MainLayout.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Layout/MainLayout.razor
@@ -1,7 +1,6 @@
 @inherits LayoutComponentBase
 @using BlazingSingularity
 @using BlazingSingularity.Commands
-@using BlazorStaticNavigation
 @using EcoData.AquaTrack.WebApp.Client.Pages
 @using EcoData.AquaTrack.WebApp.Client.Services
 @using EcoData.AquaTrack.WebApp.Client.Themes
@@ -19,7 +18,7 @@
     <MudAppBar Elevation="0"
                Style="background-color: var(--mud-palette-drawer-background); color: var(--mud-palette-text-primary);" Fixed="true">
         <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Color="Color.Inherit" Edge="Edge.Start" Size="Size.Small"
-                       Disabled="@(!Navigation.CanGoBack)" OnClick="NavigateBack" />
+                       Disabled="@(!Navigation.CanGoBack)" OnClick="NavigateBackAsync" />
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
                        OnClick="ToggleDrawer" />
         <MudText Typo="Typo.h6">AquaTrack</MudText>
@@ -102,9 +101,9 @@
     private void ToggleDrawer() => _drawerOpen = !_drawerOpen;
     private void ToggleTheme() => _isDarkMode = !_isDarkMode;
 
-    private void NavigateBack()
+    private async Task NavigateBackAsync()
     {
-        Navigation.GoBack();
+        await Navigation.GoBackAsync();
     }
 
     protected override async Task OnInitializedAsync()

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Services/NavigationService.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Services/NavigationService.cs
@@ -1,6 +1,6 @@
-using System.Web;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.JSInterop;
 
 namespace EcoData.AquaTrack.WebApp.Client.Services;
 
@@ -9,9 +9,9 @@ public interface INavigationService
     string CurrentUri { get; }
     string CurrentPath { get; }
 
-    void NavigateTo(string uri, bool trackReturn = false);
+    void NavigateTo(string uri);
+    Task GoBackAsync(string? fallback = null);
     void GoBack(string? fallback = null);
-    string? GetReturnUrl();
 
     void SetFallback(string path);
     bool CanGoBack { get; }
@@ -22,57 +22,56 @@ public interface INavigationService
 public sealed class NavigationService : INavigationService, IDisposable
 {
     private readonly NavigationManager _navigationManager;
+    private readonly IJSRuntime _jsRuntime;
+    private readonly List<string> _history = [];
     private string? _fallbackPath;
+    private bool _isNavigatingBack;
 
-    public NavigationService(NavigationManager navigationManager)
+    public NavigationService(NavigationManager navigationManager, IJSRuntime jsRuntime)
     {
         _navigationManager = navigationManager;
+        _jsRuntime = jsRuntime;
         _navigationManager.LocationChanged += OnLocationChanged;
+
+        // Initialize with current path
+        _history.Add(GetPathFromUri(_navigationManager.Uri));
     }
 
     public string CurrentUri => _navigationManager.Uri;
 
-    public string CurrentPath
-    {
-        get
-        {
-            var uri = new Uri(_navigationManager.Uri);
-            return uri.AbsolutePath;
-        }
-    }
+    public string CurrentPath => GetPathFromUri(_navigationManager.Uri);
 
-    public bool CanGoBack => GetReturnUrl() is not null || _fallbackPath is not null;
+    public bool CanGoBack => _history.Count > 1 || _fallbackPath is not null;
 
     public event Action? OnStateChanged;
 
-    public void NavigateTo(string uri, bool trackReturn = false)
+    public void NavigateTo(string uri)
     {
-        if (trackReturn)
-        {
-            var returnUrl = Uri.EscapeDataString(CurrentPath);
-            var separator = uri.Contains('?') ? "&" : "?";
-            uri = $"{uri}{separator}returnUrl={returnUrl}";
-        }
-
         _navigationManager.NavigateTo(uri);
+    }
+
+    public async Task GoBackAsync(string? fallback = null)
+    {
+        if (_history.Count > 1)
+        {
+            // Use browser history for proper back/forward navigation
+            _isNavigatingBack = true;
+            await _jsRuntime.InvokeVoidAsync("history.back");
+        }
+        else
+        {
+            // Fall back to explicit navigation when no history exists
+            var fallbackPath = fallback ?? _fallbackPath;
+            if (fallbackPath is not null)
+            {
+                _navigationManager.NavigateTo(fallbackPath);
+            }
+        }
     }
 
     public void GoBack(string? fallback = null)
     {
-        var returnUrl = GetReturnUrl() ?? fallback ?? _fallbackPath;
-        if (returnUrl is not null)
-        {
-            _navigationManager.NavigateTo(returnUrl);
-        }
-    }
-
-    public string? GetReturnUrl()
-    {
-        var uri = new Uri(_navigationManager.Uri);
-        var query = HttpUtility.ParseQueryString(uri.Query);
-        var returnUrl = query["returnUrl"];
-
-        return string.IsNullOrEmpty(returnUrl) ? null : returnUrl;
+        _ = GoBackAsync(fallback);
     }
 
     public void SetFallback(string path)
@@ -83,7 +82,33 @@ public sealed class NavigationService : INavigationService, IDisposable
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
+        var newPath = GetPathFromUri(e.Location);
+
+        if (_isNavigatingBack)
+        {
+            // Remove the current page from history when navigating back
+            if (_history.Count > 0)
+            {
+                _history.RemoveAt(_history.Count - 1);
+            }
+            _isNavigatingBack = false;
+        }
+        else
+        {
+            // Add new path to history for forward navigation
+            _history.Add(newPath);
+        }
+
+        // Reset fallback on navigation
+        _fallbackPath = null;
+
         OnStateChanged?.Invoke();
+    }
+
+    private static string GetPathFromUri(string uri)
+    {
+        var uriObj = new Uri(uri);
+        return uriObj.AbsolutePath;
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- Updates `NavigationService` to use `IJSRuntime` for calling `window.history.back()` 
- Properly integrates with browser back/forward history
- Removes the `trackReturn` parameter in favor of native browser history tracking
- Maintains internal navigation history for accurate `CanGoBack` state

## Test plan
- [ ] Navigate between pages and verify browser back button works correctly
- [ ] Verify in-app back button properly navigates to previous page
- [ ] Test direct navigation to a page (no history) falls back correctly
- [ ] Confirm browser forward button works after using back button

Fixes #69