### PR TITLE
Add access request cancellation and search support

### DIFF
--- a/src/AquaTrack/EcoData.AquaTrack.Api/OrganizationAccessRequestEndpoints.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Api/OrganizationAccessRequestEndpoints.cs
@@ -238,9 +238,9 @@ public static class OrganizationAccessRequestEndpoints
             .WithName("GetMyAccessRequests");
 
         meGroup
-            .MapDelete(
-                "/{id:guid}",
-                async Task<Results<NoContent, NotFound, BadRequest<string>, UnauthorizedHttpResult>> (
+            .MapPost(
+                "/{id:guid}/cancel",
+                async Task<Results<Ok<OrganizationAccessRequestDto>, NotFound, BadRequest<string>, UnauthorizedHttpResult>> (
                     Guid id,
                     ClaimsPrincipal user,
                     IOrganizationAccessRequestRepository repository,
@@ -264,8 +264,8 @@ public static class OrganizationAccessRequestEndpoints
                         return TypedResults.BadRequest("Only pending requests can be cancelled.");
                     }
 
-                    var deleted = await repository.DeleteAsync(id, ct);
-                    return deleted ? TypedResults.NoContent() : TypedResults.NotFound();
+                    var cancelled = await repository.CancelAsync(id, ct);
+                    return cancelled is not null ? TypedResults.Ok(cancelled) : TypedResults.NotFound();
                 }
             )
             .WithName("CancelMyAccessRequest");

--- a/src/AquaTrack/EcoData.AquaTrack.Application.Client/IOrganizationAccessRequestHttpClient.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Application.Client/IOrganizationAccessRequestHttpClient.cs
@@ -18,5 +18,5 @@ public interface IOrganizationAccessRequestHttpClient
 
     IAsyncEnumerable<OrganizationAccessRequestDto> GetMyRequestsAsync(OrganizationAccessRequestParameters parameters, CancellationToken cancellationToken = default);
 
-    Task<OneOf<Success, NotFoundError, ValidationError, ApiError>> CancelMyRequestAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<OneOf<OrganizationAccessRequestDto, NotFoundError, ValidationError, ApiError>> CancelMyRequestAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/src/AquaTrack/EcoData.AquaTrack.Application.Client/OrganizationAccessRequestHttpClient.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Application.Client/OrganizationAccessRequestHttpClient.cs
@@ -117,6 +117,7 @@ public sealed class OrganizationAccessRequestHttpClient(HttpClient httpClient) :
         var query = new QueryStringBuilder()
             .AddCursorParameters(parameters)
             .Add("status", parameters.Status)
+            .Add("search", parameters.Search)
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<OrganizationAccessRequestDto>(
@@ -125,12 +126,12 @@ public sealed class OrganizationAccessRequestHttpClient(HttpClient httpClient) :
         )!;
     }
 
-    public async Task<OneOf<Success, NotFoundError, ValidationError, ApiError>> CancelMyRequestAsync(
+    public async Task<OneOf<OrganizationAccessRequestDto, NotFoundError, ValidationError, ApiError>> CancelMyRequestAsync(
         Guid id,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.DeleteAsync($"api/me/access-requests/{id}", cancellationToken);
+        var response = await httpClient.PostAsync($"api/me/access-requests/{id}/cancel", null, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -148,6 +149,7 @@ public sealed class OrganizationAccessRequestHttpClient(HttpClient httpClient) :
             return new ApiError((int)response.StatusCode, await response.Content.ReadAsStringAsync(cancellationToken));
         }
 
-        return new Success();
+        var result = await response.Content.ReadFromJsonAsync<OrganizationAccessRequestDto>(cancellationToken);
+        return result!;
     }
 }

--- a/src/AquaTrack/EcoData.AquaTrack.Contracts/Parameters/OrganizationAccessRequestParameters.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Contracts/Parameters/OrganizationAccessRequestParameters.cs
@@ -5,5 +5,6 @@ namespace EcoData.AquaTrack.Contracts.Parameters;
 public sealed record OrganizationAccessRequestParameters(
     int PageSize = 20,
     Guid? Cursor = null,
-    string? Status = null
+    string? Status = null,
+    string? Search = null
 ) : CursorParameters(PageSize, Cursor);

--- a/src/AquaTrack/EcoData.AquaTrack.DataAccess/Interfaces/IOrganizationAccessRequestRepository.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.DataAccess/Interfaces/IOrganizationAccessRequestRepository.cs
@@ -43,6 +43,11 @@ public interface IOrganizationAccessRequestRepository
         CancellationToken cancellationToken = default
     );
 
+    Task<OrganizationAccessRequestDto?> CancelAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    );
+
     Task<bool> ExistsPendingAsync(
         Guid userId,
         Guid organizationId,

--- a/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/OrganizationAccessRequestRepository.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.DataAccess/Repositories/OrganizationAccessRequestRepository.cs
@@ -110,6 +110,12 @@ public sealed class OrganizationAccessRequestRepository(
             query = query.Where(r => r.Status == status);
         }
 
+        if (!string.IsNullOrEmpty(parameters.Search))
+        {
+            var searchLower = parameters.Search.ToLower();
+            query = query.Where(r => r.Organization!.Name.ToLower().Contains(searchLower));
+        }
+
         if (parameters.Cursor.HasValue)
         {
             query = query.Where(r => r.Id.CompareTo(parameters.Cursor.Value) > 0);
@@ -339,6 +345,46 @@ public sealed class OrganizationAccessRequestRepository(
         await context.SaveChangesAsync(cancellationToken);
 
         return true;
+    }
+
+    public async Task<OrganizationAccessRequestDto?> CancelAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.OrganizationAccessRequests
+            .AsTracking()
+            .Include(r => r.Organization)
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+
+        if (entity is null)
+        {
+            return null;
+        }
+
+        entity.Status = OrganizationAccessRequestStatus.Cancelled;
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var user = await userLookupRepository.GetByIdAsync(entity.UserId, cancellationToken);
+
+        return new OrganizationAccessRequestDto(
+            entity.Id,
+            entity.UserId,
+            user?.Email ?? "",
+            user?.DisplayName ?? "",
+            entity.OrganizationId,
+            entity.Organization!.Name,
+            entity.Status.ToString(),
+            entity.RequestMessage,
+            entity.ReviewNotes,
+            entity.ReviewedByUserId,
+            null,
+            entity.ReviewedAt,
+            entity.CreatedAt
+        );
     }
 
     public async Task<bool> ExistsPendingAsync(

--- a/src/AquaTrack/EcoData.AquaTrack.Database/Models/OrganizationAccessRequest.cs
+++ b/src/AquaTrack/EcoData.AquaTrack.Database/Models/OrganizationAccessRequest.cs
@@ -57,5 +57,6 @@ public enum OrganizationAccessRequestStatus
 {
     Pending = 0,
     Approved = 1,
-    Rejected = 2
+    Rejected = 2,
+    Cancelled = 3
 }

--- a/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Features/OrganizationAccessRequests/Pages/MyAccessRequestsPage.razor
+++ b/src/AquaTrack/EcoData.AquaTrack.WebApp.Client/Features/OrganizationAccessRequests/Pages/MyAccessRequestsPage.razor
@@ -77,7 +77,7 @@
                                 </MudText>
                             </MudAlert>
                         }
-                        @if (request.Status != "Pending" && request.ReviewedAt.HasValue)
+                        @if (request.Status is "Approved" or "Rejected" && request.ReviewedAt.HasValue)
                         {
                             <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
                                 @(request.Status == "Approved" ? "Approved" : "Rejected") by @(request.ReviewedByDisplayName ?? "Unknown") on @FormatDate(request.ReviewedAt.Value)
@@ -109,6 +109,11 @@
                         case "Rejected":
                             <MudChip T="string" Color="Color.Error" Variant="Variant.Filled" Size="Size.Small">
                                 Rejected
+                            </MudChip>
+                            break;
+                        case "Cancelled":
+                            <MudChip T="string" Color="Color.Default" Variant="Variant.Filled" Size="Size.Small">
+                                Cancelled
                             </MudChip>
                             break;
                     }


### PR DESCRIPTION
## Summary
- Add `Cancelled` status to allow users to cancel pending requests without deleting them
- Add `Search` parameter for filtering access requests by organization name
- Change cancel API from DELETE to POST `/{id}/cancel` to preserve request history
- Update UI to display the Cancelled status chip

## Test plan
- [ ] Verify cancelling a pending request sets its status to Cancelled
- [ ] Verify cancelled requests appear in the list with Cancelled chip
- [ ] Verify search filter works for organization names
- [ ] Verify only pending requests can be cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)