### PR TITLE
fix: Remove unused MultipleSensorReadingBatch DTO

### DIFF
--- a/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/ReadingBatchDto.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/ReadingBatchDto.cs
@@ -19,5 +19,3 @@ public sealed record ReadingBatchResult(
     int Rejected,
     IReadOnlyList<string> Errors
 );
-
-public sealed record MultipleSensorReadingBatch(IReadOnlyList<ReadingBatchDtoForCreate> Batches);


### PR DESCRIPTION
Removes the unused `MultipleSensorReadingBatch` DTO since the batch readings endpoint was removed.

Closes #97