### PR TITLE
feat: Validate reading timestamps to prevent future-dated readings

### DIFF
--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorReadingEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorReadingEndpoints.cs
@@ -46,6 +46,7 @@ public static class SensorReadingEndpoints
                     ISensorRepository sensorRepository,
                     IReadingRepository readingRepository,
                     ISensorHealthRepository healthRepository,
+                    TimeProvider timeProvider,
                     CancellationToken ct
                 ) =>
                 {
@@ -55,27 +56,39 @@ public static class SensorReadingEndpoints
                         return TypedResults.NotFound($"Sensor {sensorId} not found");
                     }
 
-                    var readingsToCreate = batch
-                        .Readings.Select(reading => new ReadingDtoForCreate(
+                    var validator = new ReadingItemValidator(timeProvider.GetUtcNow());
+                    var validReadings = new List<ReadingDtoForCreate>();
+                    var errors = new List<string>();
+
+                    foreach (var reading in batch.Readings)
+                    {
+                        var result = validator.Validate(reading);
+                        if (!result.IsValid)
+                        {
+                            errors.AddRange(result.Errors.Select(e => $"'{reading.Parameter}': {e.ErrorMessage}"));
+                            continue;
+                        }
+
+                        validReadings.Add(new ReadingDtoForCreate(
                             sensorId,
                             reading.Parameter,
                             reading.Description,
                             reading.Value,
                             reading.Unit,
                             reading.RecordedAt
-                        ))
-                        .ToList();
+                        ));
+                    }
 
-                    if (readingsToCreate.Count > 0)
+                    if (validReadings.Count > 0)
                     {
-                        await readingRepository.CreateManyAsync(readingsToCreate, ct);
+                        await readingRepository.CreateManyAsync(validReadings, ct);
 
-                        var maxRecordedAt = readingsToCreate.Max(r => r.RecordedAt);
+                        var maxRecordedAt = validReadings.Max(r => r.RecordedAt);
                         await healthRepository.RecordReadingAsync(sensorId, maxRecordedAt, ct);
                     }
 
                     return TypedResults.Ok(
-                        new ReadingBatchResult(batch.Readings.Count, readingsToCreate.Count, 0, [])
+                        new ReadingBatchResult(batch.Readings.Count, validReadings.Count, errors.Count, errors)
                     );
                 }
             )

--- a/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/ReadingBatchDto.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/ReadingBatchDto.cs
@@ -1,3 +1,5 @@
+using FluentValidation;
+
 namespace EcoData.Sensors.Contracts.Dtos;
 
 public sealed record ReadingBatchDtoForCreate(
@@ -19,3 +21,25 @@ public sealed record ReadingBatchResult(
     int Rejected,
     IReadOnlyList<string> Errors
 );
+
+public sealed class ReadingItemValidator : AbstractValidator<ReadingItemDto>
+{
+    public static readonly TimeSpan FutureTolerance = TimeSpan.FromMinutes(5);
+    public static readonly TimeSpan MaxAge = TimeSpan.FromDays(30);
+
+    public ReadingItemValidator(DateTimeOffset now)
+    {
+        var maxAllowedTime = now + FutureTolerance;
+        var minAllowedTime = now - MaxAge;
+
+        RuleFor(static x => x.Parameter)
+            .NotEmpty()
+            .WithMessage("Parameter is required");
+
+        RuleFor(x => x.RecordedAt)
+            .LessThanOrEqualTo(maxAllowedTime)
+            .WithMessage(x => $"Timestamp {x.RecordedAt:O} is in the future")
+            .GreaterThanOrEqualTo(minAllowedTime)
+            .WithMessage(x => $"Timestamp {x.RecordedAt:O} is older than 30 days");
+    }
+}

--- a/src/Features/Sensors/EcoData.Sensors.Contracts/EcoData.Sensors.Contracts.csproj
+++ b/src/Features/Sensors/EcoData.Sensors.Contracts/EcoData.Sensors.Contracts.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.SourceGenerator" Version="3.0.271" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Add FluentValidation to Sensors.Contracts
- Create `ReadingItemValidator` to validate reading timestamps
- Reject readings with timestamps in the future (5 min tolerance for clock drift)
- Reject readings older than 30 days
- Return validation errors in `ReadingBatchResult.Errors`

## Changes
- **Sensors.Contracts**: Added FluentValidation package and `ReadingItemValidator`
- **SensorReadingEndpoints**: Validate each reading before persisting, collect errors for invalid readings

Closes #96