### PR TITLE
feat: Add input validation for sensor registration

### DIFF
--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorEndpoints.cs
@@ -66,6 +66,7 @@ public static class SensorEndpoints
                 async Task<
                     Results<
                         Ok<SensorRegistrationResultDto>,
+                        ValidationProblem,
                         UnauthorizedHttpResult,
                         ForbidHttpResult,
                         Conflict<string>
@@ -79,6 +80,15 @@ public static class SensorEndpoints
                     CancellationToken ct
                 ) =>
                 {
+                    var validation = new RegisterSensorRequestValidator().Validate(request);
+                    if (!validation.IsValid)
+                    {
+                        var errors = validation.Errors
+                            .GroupBy(e => e.PropertyName)
+                            .ToDictionary(g => g.Key, g => g.Select(e => e.ErrorMessage).ToArray());
+                        return TypedResults.ValidationProblem(errors);
+                    }
+
                     var token = new RequestClaimToken(user);
                     if (!token.IsAuthenticated)
                     {

--- a/src/Features/Sensors/EcoData.Sensors.Contracts/Requests/RegisterSensorRequest.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Contracts/Requests/RegisterSensorRequest.cs
@@ -1,3 +1,5 @@
+using FluentValidation;
+
 namespace EcoData.Sensors.Contracts.Requests;
 
 public sealed record RegisterSensorRequest(
@@ -10,3 +12,37 @@ public sealed record RegisterSensorRequest(
     Guid MunicipalityId,
     Guid? SensorTypeId = null
 );
+
+public sealed class RegisterSensorRequestValidator : AbstractValidator<RegisterSensorRequest>
+{
+    public RegisterSensorRequestValidator()
+    {
+        RuleFor(static x => x.OrganizationId)
+            .NotEmpty()
+            .WithMessage("Organization is required");
+
+        RuleFor(static x => x.Name)
+            .NotEmpty()
+            .WithMessage("Name is required")
+            .MaximumLength(300)
+            .WithMessage("Name must be 300 characters or less");
+
+        RuleFor(static x => x.ExternalId)
+            .NotEmpty()
+            .WithMessage("External ID is required")
+            .MaximumLength(100)
+            .WithMessage("External ID must be 100 characters or less");
+
+        RuleFor(static x => x.Latitude)
+            .InclusiveBetween(-90m, 90m)
+            .WithMessage("Latitude must be between -90 and 90");
+
+        RuleFor(static x => x.Longitude)
+            .InclusiveBetween(-180m, 180m)
+            .WithMessage("Longitude must be between -180 and 180");
+
+        RuleFor(static x => x.MunicipalityId)
+            .NotEmpty()
+            .WithMessage("Municipality is required");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `RegisterSensorRequestValidator` with FluentValidation
- Validate latitude (-90 to 90), longitude (-180 to 180)
- Validate name (required, max 300 chars) and external ID (required, max 100 chars)
- Validate organization and municipality IDs are not empty
- Return ValidationProblem with detailed errors on invalid input

Closes #95