### PR TITLE
feat: Add Update and Delete endpoints for sensors

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
@@ -184,12 +184,20 @@ else
                     <div class="pa-6">
                         <MudStack Row Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-4">
                             <MudText Typo="Typo.h6">Sensor Fleet</MudText>
-                            <RequireOrganizationPermission Permission="@SensorPermissions.Sensor.Create" OrganizationId="Id">
-                                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
-                                           StartIcon="@Icons.Material.Filled.Add" OnClick="NavigateToCreateSensor">
-                                    Add Sensor
-                                </MudButton>
-                            </RequireOrganizationPermission>
+                            <MudStack Row Spacing="2">
+                                <RequireOrganizationPermission Permission="@SensorPermissions.Sensor.Update" OrganizationId="Id">
+                                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small"
+                                               StartIcon="@Icons.Material.Filled.Settings" OnClick="NavigateToSensors">
+                                        Manage Sensors
+                                    </MudButton>
+                                </RequireOrganizationPermission>
+                                <RequireOrganizationPermission Permission="@SensorPermissions.Sensor.Create" OrganizationId="Id">
+                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                                               StartIcon="@Icons.Material.Filled.Add" OnClick="NavigateToCreateSensor">
+                                        Add Sensor
+                                    </MudButton>
+                                </RequireOrganizationPermission>
+                            </MudStack>
                         </MudStack>
 
                         @if (!_viewModel.HasSensors)

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Components/SensorForm.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Components/SensorForm.razor
@@ -1,0 +1,255 @@
+@using System.ComponentModel.DataAnnotations
+@using EcoData.Locations.Contracts.Dtos
+@using EcoData.Locations.Contracts.Parameters
+@using EcoPortal.Client.Services
+@inject ILocationHttpClient LocationClient
+
+<MudStack Spacing="3">
+    @if (!string.IsNullOrEmpty(ErrorMessage))
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Filled" Dense="true">
+            @ErrorMessage
+        </MudAlert>
+    }
+
+    @if (!HideExternalId)
+    {
+        <MudTextField @bind-Value="Model.ExternalId"
+                      Label="External ID"
+                      Required="true"
+                      RequiredError="External ID is required"
+                      MaxLength="100"
+                      Counter="100"
+                      HelperText="Unique identifier for this sensor"
+                      Immediate="true"
+                      Disabled="IsLoading" />
+    }
+
+    <MudTextField @bind-Value="Model.Name"
+                  Label="Name"
+                  Required="true"
+                  RequiredError="Name is required"
+                  MaxLength="300"
+                  Counter="300"
+                  HelperText="Display name for the sensor"
+                  Immediate="true"
+                  Disabled="IsLoading" />
+
+    <MudStack Row="true" Spacing="2">
+        <MudNumericField @bind-Value="Model.Latitude"
+                         Label="Latitude"
+                         Required="true"
+                         Min="-90"
+                         Max="90"
+                         Step="0.000001M"
+                         Format="F6"
+                         HelperText="-90 to 90"
+                         Disabled="IsLoading"
+                         Style="flex: 1;" />
+
+        <MudNumericField @bind-Value="Model.Longitude"
+                         Label="Longitude"
+                         Required="true"
+                         Min="-180"
+                         Max="180"
+                         Step="0.000001M"
+                         Format="F6"
+                         HelperText="-180 to 180"
+                         Disabled="IsLoading"
+                         Style="flex: 1;" />
+    </MudStack>
+
+    <MudSelect T="StateDtoForList"
+               Label="State"
+               Value="_selectedState"
+               ValueChanged="OnStateChanged"
+               ToStringFunc="@(s => s?.Name ?? string.Empty)"
+               Disabled="IsLoading || _states is null"
+               HelperText="Select the state/territory">
+        @if (_states is not null)
+        {
+            @foreach (var state in _states)
+            {
+                <MudSelectItem Value="@state">@state.Name</MudSelectItem>
+            }
+        }
+    </MudSelect>
+
+    <MudAutocomplete T="MunicipalityDtoForList"
+                     Label="Municipality"
+                     Value="_selectedMunicipality"
+                     ValueChanged="OnMunicipalityChanged"
+                     SearchFunc="SearchMunicipalities"
+                     ToStringFunc="@(m => m?.Name ?? string.Empty)"
+                     Disabled="IsLoading || _selectedState is null"
+                     HelperText="@(_selectedState is null ? "Select a state first" : "Search for a municipality")"
+                     ResetValueOnEmptyText="true" />
+
+    <MudSwitch @bind-Value="Model.IsActive"
+               Label="Active"
+               Color="Color.Primary"
+               Disabled="IsLoading" />
+
+    <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2" Class="mt-4">
+        <MudButton Variant="Variant.Text"
+                   Color="Color.Default"
+                   OnClick="HandleCancel"
+                   Disabled="IsLoading">
+            Cancel
+        </MudButton>
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   OnClick="HandleSubmit"
+                   Disabled="IsLoading || !IsFormValid">
+            @if (IsLoading)
+            {
+                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+            }
+            @SubmitButtonText
+        </MudButton>
+    </MudStack>
+</MudStack>
+
+@code {
+    private List<StateDtoForList>? _states;
+    private StateDtoForList? _selectedState;
+    private MunicipalityDtoForList? _selectedMunicipality;
+    private Guid _lastLoadedMunicipalityId;
+
+    [Parameter]
+    public SensorFormModel Model { get; set; } = new();
+
+    [Parameter]
+    public string SubmitButtonText { get; set; } = "Save";
+
+    [Parameter]
+    public string? ErrorMessage { get; set; }
+
+    [Parameter]
+    public bool IsLoading { get; set; }
+
+    [Parameter]
+    public bool HideExternalId { get; set; }
+
+    [Parameter]
+    public EventCallback<SensorFormModel> OnSubmit { get; set; }
+
+    [Parameter]
+    public EventCallback OnCancel { get; set; }
+
+    private bool IsFormValid =>
+        !string.IsNullOrWhiteSpace(Model.Name) &&
+        (HideExternalId || !string.IsNullOrWhiteSpace(Model.ExternalId)) &&
+        Model.Latitude >= -90 && Model.Latitude <= 90 &&
+        Model.Longitude >= -180 && Model.Longitude <= 180 &&
+        Model.MunicipalityId != Guid.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStatesAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Model.MunicipalityId != Guid.Empty && Model.MunicipalityId != _lastLoadedMunicipalityId)
+        {
+            _lastLoadedMunicipalityId = Model.MunicipalityId;
+            await LoadMunicipalityAsync(Model.MunicipalityId);
+        }
+    }
+
+    private async Task LoadStatesAsync()
+    {
+        _states = [];
+        await foreach (var state in LocationClient.GetStatesAsync(new StateParameters(PageSize: 100)))
+        {
+            _states.Add(state);
+        }
+    }
+
+    private async Task LoadMunicipalityAsync(Guid municipalityId)
+    {
+        var municipality = await LocationClient.GetMunicipalityByIdAsync(municipalityId);
+        if (municipality is not null)
+        {
+            _selectedMunicipality = new MunicipalityDtoForList(
+                municipality.Id,
+                municipality.Name,
+                municipality.GeoJsonId,
+                municipality.CountyFipsCode,
+                municipality.CentroidLatitude,
+                municipality.CentroidLongitude
+            );
+
+            _selectedState = _states?.FirstOrDefault(s => s.Code == municipality.StateCode);
+        }
+    }
+
+    private void OnStateChanged(StateDtoForList? state)
+    {
+        _selectedState = state;
+        _selectedMunicipality = null;
+        Model.MunicipalityId = Guid.Empty;
+    }
+
+    private void OnMunicipalityChanged(MunicipalityDtoForList? municipality)
+    {
+        _selectedMunicipality = municipality;
+        Model.MunicipalityId = municipality?.Id ?? Guid.Empty;
+    }
+
+    private async Task<IEnumerable<MunicipalityDtoForList>> SearchMunicipalities(string? search, CancellationToken ct)
+    {
+        if (_selectedState is null)
+        {
+            return [];
+        }
+
+        var parameters = new MunicipalityParameters(
+            PageSize: 20,
+            Search: search,
+            StateCode: _selectedState.Code
+        );
+
+        var results = new List<MunicipalityDtoForList>();
+        await foreach (var municipality in LocationClient.GetMunicipalitiesAsync(parameters, ct))
+        {
+            results.Add(municipality);
+        }
+        return results;
+    }
+
+    private async Task HandleSubmit()
+    {
+        if (!IsFormValid)
+            return;
+
+        await OnSubmit.InvokeAsync(Model);
+    }
+
+    private async Task HandleCancel()
+    {
+        await OnCancel.InvokeAsync();
+    }
+
+    public class SensorFormModel
+    {
+        [Required(ErrorMessage = "External ID is required")]
+        [MaxLength(100)]
+        public string ExternalId { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Name is required")]
+        [MaxLength(300)]
+        public string Name { get; set; } = string.Empty;
+
+        [Range(-90, 90, ErrorMessage = "Latitude must be between -90 and 90")]
+        public decimal Latitude { get; set; }
+
+        [Range(-180, 180, ErrorMessage = "Longitude must be between -180 and 180")]
+        public decimal Longitude { get; set; }
+
+        public Guid MunicipalityId { get; set; }
+
+        public bool IsActive { get; set; } = true;
+    }
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPage.razor
@@ -8,10 +8,12 @@
 @using BlazingSingularity.Signals
 @using static EcoPortal.Client.Features.Sensors.Dialogs.ReadingFilterDialog
 @using EcoPortal.Client.Services
+@using EcoPortal.Client.Components
 @inject ISensorHttpClient SensorClient
 @inject ISensorReadingHttpClient ReadingClient
 @inject IDialogService DialogService
 @inject INavigationService Navigation
+@inject ISnackbar Snackbar
 
 <PageTitle>@(_sensor?.Name ?? "Sensor") - EcoData</PageTitle>
 
@@ -50,10 +52,18 @@ else
         <MudPaper Elevation="1" Class="pa-4 mb-4">
             <MudStack Spacing="2">
                 <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                    <MudText Typo="Typo.h5">@_sensor.Name</MudText>
-                    <MudChip T="string" Color="@(_sensor.IsActive ? Color.Success : Color.Default)" Size="Size.Small">
-                        @(_sensor.IsActive ? "Active" : "Inactive")
-                    </MudChip>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                        <MudText Typo="Typo.h5">@_sensor.Name</MudText>
+                        <MudChip T="string" Color="@(_sensor.IsActive ? Color.Success : Color.Default)" Size="Size.Small">
+                            @(_sensor.IsActive ? "Active" : "Inactive")
+                        </MudChip>
+                    </MudStack>
+                    <MudStack Row="true" Spacing="1">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary"
+                                       OnClick="NavigateToEdit" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                                       OnClick="ConfirmDelete" />
+                    </MudStack>
                 </MudStack>
 
                 <MudStack Row="true" Spacing="4" Class="mt-2">
@@ -239,5 +249,34 @@ else
         _fromDate = null;
         _toDate = null;
         _virtualizedList?.Refresh();
+    }
+
+    private void NavigateToEdit() => Navigation.NavigateTo($"/sensors/{SensorId}/edit");
+
+    private async Task ConfirmDelete()
+    {
+        var parameters = new DialogParameters<ConfirmDialog>
+        {
+            { x => x.ContentText, $"Are you sure you want to delete sensor '{_sensor!.Name}'? This will also delete all readings and health data." },
+            { x => x.ButtonText, "Delete" },
+            { x => x.Color, Color.Error }
+        };
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.ExtraSmall };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>("Delete Sensor", parameters, options);
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false })
+        {
+            var deleteResult = await SensorClient.DeleteAsync(SensorId);
+            deleteResult.Switch(
+                _ =>
+                {
+                    Snackbar.Add("Sensor deleted successfully", Severity.Success);
+                    Navigation.NavigateTo("/sensors");
+                },
+                _ => Snackbar.Add("Sensor not found", Severity.Error),
+                error => Snackbar.Add(error.Message, Severity.Error)
+            );
+        }
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorEditPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorEditPage.razor
@@ -1,0 +1,128 @@
+@page "/sensors/{SensorId:guid}/edit"
+@using EcoData.Sensors.Application.Client
+@using EcoData.Sensors.Contracts.Dtos
+@using EcoPortal.Client.Features.Sensors.Components
+@using EcoPortal.Client.Services
+@using BlazingSingularity.Commands
+@using static EcoPortal.Client.Features.Sensors.Components.SensorForm
+@inject ISensorHttpClient SensorClient
+@inject INavigationService Navigation
+@inject ISnackbar Snackbar
+
+<PageTitle>Edit Sensor - EcoData</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="pa-4">
+    @if (LoadCommand.IsLoading)
+    {
+        <MudPaper Elevation="1" Class="pa-6">
+            <MudSkeleton Width="200px" Height="32px" />
+            <MudSkeleton Width="100%" Height="56px" Class="mt-4" />
+            <MudSkeleton Width="100%" Height="56px" Class="mt-4" />
+            <MudSkeleton Width="100%" Height="56px" Class="mt-4" />
+        </MudPaper>
+    }
+    else if (_sensor is null)
+    {
+        <MudPaper Elevation="1" Class="pa-6">
+            <MudStack AlignItems="AlignItems.Center">
+                <MudIcon Icon="@Icons.Material.Filled.Error" Size="Size.Large" Color="Color.Error" />
+                <MudText Typo="Typo.h6" Color="Color.Error" Class="mt-2">Sensor not found</MudText>
+                <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="NavigateBack" Class="mt-4">
+                    Go Back
+                </MudButton>
+            </MudStack>
+        </MudPaper>
+    }
+    else
+    {
+        <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
+                   OnClick="NavigateBack" Class="mb-2">
+            Go Back
+        </MudButton>
+
+        <MudPaper Elevation="1" Class="pa-6">
+            <MudText Typo="Typo.h5" Class="mb-4">Edit Sensor</MudText>
+
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
+                External ID: <strong>@_sensor.ExternalId</strong>
+            </MudText>
+
+            <SensorForm Model="_formModel"
+                        SubmitButtonText="Save Changes"
+                        ErrorMessage="@_errorMessage"
+                        IsLoading="SaveCommand.IsLoading"
+                        HideExternalId="true"
+                        OnSubmit="HandleSubmit"
+                        OnCancel="NavigateBack" />
+        </MudPaper>
+    }
+</MudContainer>
+
+@code {
+    [Parameter]
+    public Guid SensorId { get; set; }
+
+    private SensorDtoForDetail? _sensor;
+    private SensorFormModel _formModel = new();
+    private string? _errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Navigation.SetFallback($"/sensors/{SensorId}");
+        await LoadCommand.ExecuteAsync();
+    }
+
+    [RelayCommand]
+    private async Task Load()
+    {
+        _sensor = await SensorClient.GetByIdAsync(SensorId);
+
+        if (_sensor is not null)
+        {
+            _formModel = new SensorFormModel
+            {
+                ExternalId = _sensor.ExternalId,
+                Name = _sensor.Name,
+                Latitude = _sensor.Latitude,
+                Longitude = _sensor.Longitude,
+                MunicipalityId = _sensor.MunicipalityId,
+                IsActive = _sensor.IsActive
+            };
+        }
+    }
+
+    private async Task HandleSubmit(SensorFormModel model)
+    {
+        await SaveCommand.ExecuteAsync();
+    }
+
+    [RelayCommand]
+    private async Task Save()
+    {
+        _errorMessage = null;
+
+        var request = new SensorDtoForUpdate(
+            _sensor!.ExternalId,
+            _formModel.Name.Trim(),
+            _formModel.Latitude,
+            _formModel.Longitude,
+            _formModel.MunicipalityId,
+            _formModel.IsActive
+        );
+
+        var result = await SensorClient.UpdateAsync(SensorId, request);
+
+        result.Switch(
+            _ =>
+            {
+                Snackbar.Add("Sensor updated successfully", Severity.Success);
+                Navigation.NavigateTo($"/sensors/{SensorId}", replace: true);
+            },
+            validation => _errorMessage = "Validation error: " + string.Join(", ", validation.Errors.Select(e => e.ErrorMessage)),
+            _ => _errorMessage = "Sensor not found",
+            forbidden => _errorMessage = forbidden.Message
+        );
+    }
+
+    private void NavigateBack() => Navigation.GoBack();
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/ILocationHttpClient.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/ILocationHttpClient.cs
@@ -14,4 +14,9 @@ public interface ILocationHttpClient
         MunicipalityParameters? parameters = null,
         CancellationToken cancellationToken = default
     );
+
+    Task<MunicipalityDtoForDetail?> GetMunicipalityByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/LocationHttpClient.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/LocationHttpClient.cs
@@ -46,4 +46,19 @@ public sealed class LocationHttpClient(HttpClient httpClient) : ILocationHttpCli
             cancellationToken
         )!;
     }
+
+    public async Task<MunicipalityDtoForDetail?> GetMunicipalityByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await httpClient.GetAsync($"api/municipalities/{id}", cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        return await response.Content.ReadFromJsonAsync<MunicipalityDtoForDetail>(cancellationToken);
+    }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/NavigationService.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/NavigationService.cs
@@ -9,7 +9,7 @@ public interface INavigationService
     string CurrentUri { get; }
     string CurrentPath { get; }
 
-    void NavigateTo(string uri);
+    void NavigateTo(string uri, bool replace = false);
     Task GoBackAsync(string? fallback = null);
     void GoBack(string? fallback = null);
 
@@ -45,9 +45,9 @@ public sealed class NavigationService : INavigationService, IDisposable
 
     public event Action? OnStateChanged;
 
-    public void NavigateTo(string uri)
+    public void NavigateTo(string uri, bool replace = false)
     {
-        _navigationManager.NavigateTo(uri);
+        _navigationManager.NavigateTo(uri, replace: replace);
     }
 
     public async Task GoBackAsync(string? fallback = null)

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorEndpoints.cs
@@ -168,6 +168,102 @@ public static class SensorEndpoints
             .RequireAuthorization()
             .WithName("RegisterSensor");
 
+        group
+            .MapPut(
+                "/{id:guid}",
+                async Task<
+                    Results<Ok<SensorDtoForDetail>, ValidationProblem, NotFound, UnauthorizedHttpResult, ForbidHttpResult>
+                > (
+                    Guid id,
+                    SensorDtoForUpdate request,
+                    ClaimsPrincipal user,
+                    ISensorRepository repository,
+                    IOrganizationPermissionService permissionService,
+                    CancellationToken ct
+                ) =>
+                {
+                    var validation = new SensorDtoForUpdateValidator().Validate(request);
+                    if (!validation.IsValid)
+                    {
+                        var errors = validation.Errors
+                            .GroupBy(e => e.PropertyName)
+                            .ToDictionary(g => g.Key, g => g.Select(e => e.ErrorMessage).ToArray());
+                        return TypedResults.ValidationProblem(errors);
+                    }
+
+                    var token = new RequestClaimToken(user);
+                    if (!token.IsAuthenticated)
+                    {
+                        return TypedResults.Unauthorized();
+                    }
+
+                    var existing = await repository.GetByIdAsync(id, ct);
+                    if (existing is null)
+                    {
+                        return TypedResults.NotFound();
+                    }
+
+                    var hasPermission = await permissionService.HasPermissionAsync(
+                        token.UserId!.Value,
+                        existing.OrganizationId,
+                        Permissions.Sensor.Update,
+                        ct
+                    );
+
+                    if (!hasPermission)
+                    {
+                        return TypedResults.Forbid();
+                    }
+
+                    var updated = await repository.UpdateAsync(id, request, ct);
+                    return updated is null ? TypedResults.NotFound() : TypedResults.Ok(updated);
+                }
+            )
+            .RequireAuthorization()
+            .WithName("UpdateSensor");
+
+        group
+            .MapDelete(
+                "/{id:guid}",
+                async Task<Results<NoContent, NotFound, UnauthorizedHttpResult, ForbidHttpResult>> (
+                    Guid id,
+                    ClaimsPrincipal user,
+                    ISensorRepository repository,
+                    IOrganizationPermissionService permissionService,
+                    CancellationToken ct
+                ) =>
+                {
+                    var token = new RequestClaimToken(user);
+                    if (!token.IsAuthenticated)
+                    {
+                        return TypedResults.Unauthorized();
+                    }
+
+                    var existing = await repository.GetByIdAsync(id, ct);
+                    if (existing is null)
+                    {
+                        return TypedResults.NotFound();
+                    }
+
+                    var hasPermission = await permissionService.HasPermissionAsync(
+                        token.UserId!.Value,
+                        existing.OrganizationId,
+                        Permissions.Sensor.Delete,
+                        ct
+                    );
+
+                    if (!hasPermission)
+                    {
+                        return TypedResults.Forbid();
+                    }
+
+                    var deleted = await repository.DeleteAsync(id, ct);
+                    return deleted ? TypedResults.NoContent() : TypedResults.NotFound();
+                }
+            )
+            .RequireAuthorization()
+            .WithName("DeleteSensor");
+
         return app;
     }
 }

--- a/src/Features/Sensors/EcoData.Sensors.Application.Client/ISensorHttpClient.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Application.Client/ISensorHttpClient.cs
@@ -27,4 +27,15 @@ public interface ISensorHttpClient
         Guid sensorId,
         CancellationToken cancellationToken = default
     );
+
+    Task<OneOf<SensorDtoForDetail, ValidationError, NotFoundError, ForbiddenError>> UpdateAsync(
+        Guid sensorId,
+        SensorDtoForUpdate request,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<OneOf<bool, NotFoundError, ForbiddenError>> DeleteAsync(
+        Guid sensorId,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorHttpClient.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorHttpClient.cs
@@ -95,4 +95,49 @@ public sealed class SensorHttpClient(HttpClient httpClient) : ISensorHttpClient
 
         return await response.Content.ReadFromJsonAsync<SensorDtoForDetail>(cancellationToken);
     }
+
+    public async Task<OneOf<SensorDtoForDetail, ValidationError, NotFoundError, ForbiddenError>> UpdateAsync(
+        Guid sensorId,
+        SensorDtoForUpdate request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await httpClient.PutAsJsonAsync($"api/sensors/{sensorId}", request, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<SensorDtoForDetail>(cancellationToken);
+            return result!;
+        }
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NotFound => new NotFoundError(),
+            HttpStatusCode.Forbidden => new ForbiddenError("You don't have permission to update this sensor"),
+            HttpStatusCode.BadRequest => new ValidationError(
+                await response.Content.ReadAsStringAsync(cancellationToken)
+            ),
+            _ => new ValidationError("Failed to update sensor")
+        };
+    }
+
+    public async Task<OneOf<bool, NotFoundError, ForbiddenError>> DeleteAsync(
+        Guid sensorId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await httpClient.DeleteAsync($"api/sensors/{sensorId}", cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return true;
+        }
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NotFound => new NotFoundError(),
+            HttpStatusCode.Forbidden => new ForbiddenError("You don't have permission to delete this sensor"),
+            _ => new NotFoundError()
+        };
+    }
 }

--- a/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/SensorDto.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/SensorDto.cs
@@ -1,3 +1,5 @@
+using FluentValidation;
+
 namespace EcoData.Sensors.Contracts.Dtos;
 
 public sealed record SensorDtoForList(
@@ -47,6 +49,36 @@ public sealed record SensorDtoForUpdate(
     Guid MunicipalityId,
     bool IsActive
 );
+
+public sealed class SensorDtoForUpdateValidator : AbstractValidator<SensorDtoForUpdate>
+{
+    public SensorDtoForUpdateValidator()
+    {
+        RuleFor(static x => x.Name)
+            .NotEmpty()
+            .WithMessage("Name is required")
+            .MaximumLength(300)
+            .WithMessage("Name must be 300 characters or less");
+
+        RuleFor(static x => x.ExternalId)
+            .NotEmpty()
+            .WithMessage("External ID is required")
+            .MaximumLength(100)
+            .WithMessage("External ID must be 100 characters or less");
+
+        RuleFor(static x => x.Latitude)
+            .InclusiveBetween(-90m, 90m)
+            .WithMessage("Latitude must be between -90 and 90");
+
+        RuleFor(static x => x.Longitude)
+            .InclusiveBetween(-180m, 180m)
+            .WithMessage("Longitude must be between -180 and 180");
+
+        RuleFor(static x => x.MunicipalityId)
+            .NotEmpty()
+            .WithMessage("Municipality is required");
+    }
+}
 
 public sealed record SensorRegistrationResultDto(
     Guid SensorId,

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/SensorRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/SensorRepository.cs
@@ -230,7 +230,7 @@ public sealed class SensorRepository(IDbContextFactory<SensorsDbContext> context
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 
-        var entity = await context.Sensors.FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+        var entity = await context.Sensors.AsTracking().FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
         if (entity is null)
         {
             return null;
@@ -265,7 +265,7 @@ public sealed class SensorRepository(IDbContextFactory<SensorsDbContext> context
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 
-        var entity = await context.Sensors.FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+        var entity = await context.Sensors.AsTracking().FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
         if (entity is null)
         {
             return false;


### PR DESCRIPTION
## Summary
- Add PUT /api/sensors/{id} endpoint for updating sensor properties
- Add DELETE /api/sensors/{id} endpoint for deleting sensors
- Add validation for update requests (same rules as registration)
- Add Edit and Delete buttons to sensor detail page UI
- Create EditSensorDialog for editing sensor properties

## Changes

### Backend
- **SensorEndpoints.cs**: Added PUT and DELETE endpoints with permission checks
- **SensorDto.cs**: Added `SensorDtoForUpdateValidator` with FluentValidation
- **ISensorHttpClient**: Added `UpdateAsync` and `DeleteAsync` methods
- **SensorHttpClient**: Implemented update and delete HTTP calls

### Frontend
- **EditSensorDialog.razor**: New dialog for editing sensor name, external ID, coordinates, and status
- **SensorDetailPage.razor**: Added Edit/Delete buttons with confirmation dialog for delete

## Authorization
Both endpoints check that the authenticated user has the appropriate permission (`sensor:update` or `sensor:delete`) for the sensor's organization.

Closes #94