### PR TITLE
fix: Clear return URL after consumption in navigation service

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/NavigationService.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/NavigationService.cs
@@ -94,6 +94,7 @@ public sealed class NavigationService : INavigationService, IDisposable
     public void SetReturnUrlOrFallback(string fallback)
     {
         _fallbackPath = _returnUrl ?? fallback;
+        _returnUrl = null;
         OnStateChanged?.Invoke();
     }
 


### PR DESCRIPTION
## Summary
- Fixes back button not working on OrganizationSensorsPage after returning from SensorDetailPage
- The return URL was persisting after being consumed, causing subsequent navigations to use a stale value

## Root Cause
When navigating with a return URL (e.g., clicking a sensor from org sensors page), `_returnUrl` was set but never cleared. On the next page load, `SetReturnUrlOrFallback()` would reuse the stale return URL instead of the page's fallback, causing the back button to navigate to the same page.

## Fix
Clear `_returnUrl` after it's consumed in `SetReturnUrlOrFallback()`.

## Test plan
- [ ] Navigate to `/organizations/{id}/sensors`
- [ ] Click a sensor to go to `/sensors/{sensorId}`
- [ ] Click back button - should return to org sensors page
- [ ] Click back button again - should navigate to `/organizations/{id}` (not stay on same page)

🤖 Generated with [Claude Code](https://claude.ai/code)