### PR TITLE
fix: Use local timezone for date filter in sensor readings

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPage.razor
@@ -212,13 +212,15 @@
 
     private ReadingParameters BuildParameters(Guid? cursor)
     {
+        var localOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.Now);
+
         return new ReadingParameters(
             PageSize: 50,
             Cursor: cursor,
             Search: string.IsNullOrWhiteSpace(SearchText) ? null : SearchText,
             Parameter: _parameterFilter,
-            FromDate: _fromDate.HasValue ? new DateTimeOffset(_fromDate.Value, TimeSpan.Zero) : null,
-            ToDate: _toDate.HasValue ? new DateTimeOffset(_toDate.Value.AddDays(1).AddTicks(-1), TimeSpan.Zero) : null
+            FromDate: _fromDate.HasValue ? new DateTimeOffset(_fromDate.Value, localOffset) : null,
+            ToDate: _toDate.HasValue ? new DateTimeOffset(_toDate.Value.AddDays(1).AddTicks(-1), localOffset) : null
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes date filter treating selected dates as UTC instead of local time.

## Problem

When filtering readings by date (e.g., March 17), readings recorded early in the day UTC would display as the previous day in local time (e.g., March 16 8:04 PM), but wouldn't match the filter.

## Solution

Use `TimeZoneInfo.Local.GetUtcOffset()` when creating the `DateTimeOffset` for filter parameters, so the filter matches what users see displayed.

## Test plan

- [ ] Filter by today's date and verify readings displayed as today are included