### PR TITLE
feat: Add Getting Started guides for onboarding

### DIFF
--- a/docs/getting-started/for-researchers.md
+++ b/docs/getting-started/for-researchers.md
@@ -1,0 +1,220 @@
+# Getting Started: For Researchers & Educators
+
+Welcome to EcoData! This guide helps professors, researchers, and lab coordinators set up and manage environmental monitoring projects with student teams.
+
+## Overview
+
+As a researcher or educator, you can:
+1. Create and manage organizations for your lab/class
+2. Approve student access requests
+3. Manage team roles and permissions
+4. Oversee sensor deployments
+5. Monitor data collection health
+
+---
+
+## Step 1: Create Your Organization
+
+1. Log in to your EcoData account
+2. Go to **Organizations** in the navigation
+3. Click **Create Organization**
+4. Fill in your organization details:
+
+| Field | Example |
+|-------|---------|
+| **Name** | UANL Environmental Engineering Lab |
+| **Description** | Water quality monitoring research group |
+
+5. Click **Create**
+
+You are automatically the **Owner** with full permissions.
+
+---
+
+## Step 2: Invite Your Team
+
+### Option A: Students Request Access
+
+Share your organization name with students and have them:
+1. Create an EcoData account
+2. Find your organization in the directory
+3. Click **Request Access**
+
+You'll see pending requests in your organization's **Access Requests** tab.
+
+### Option B: Direct Invitation (Coming Soon)
+
+Direct email invitations will be available in a future update.
+
+---
+
+## Step 3: Manage Access Requests
+
+1. Go to your organization page
+2. Click the **Access Requests** tab
+3. Review pending requests
+4. Click **Approve** or **Reject** for each request
+
+Approved members start with the **Viewer** role.
+
+---
+
+## Step 4: Assign Roles
+
+Different roles for different responsibilities:
+
+| Role | Can Do | Best For |
+|------|--------|----------|
+| **Viewer** | View sensors and readings | General students, observers |
+| **Editor** | Create and edit sensors | Students deploying sensors |
+| **Admin** | Manage members, all sensor ops | Teaching assistants, lab managers |
+| **Owner** | Full control, delete org | You (principal investigator) |
+
+To change a member's role:
+1. Go to your organization's **Members** tab
+2. Find the member
+3. Click the role dropdown
+4. Select the new role
+
+> **Tip:** Give "Editor" access to students who need to register their own sensors. Keep most students as "Viewers" if you're managing the sensors centrally.
+
+---
+
+## Step 5: Plan Your Sensor Network
+
+Before deploying sensors, consider:
+
+### Naming Convention
+Use consistent External IDs for easy identification:
+- `SITE-01`, `SITE-02`, `SITE-03`
+- `RIO-UPSTREAM`, `RIO-MIDSTREAM`, `RIO-DOWNSTREAM`
+- `LAB-STATION-A`, `LAB-STATION-B`
+
+### Reporting Intervals
+Choose based on your research needs:
+
+| Interval | Best For | Data Volume |
+|----------|----------|-------------|
+| 1 minute | High-resolution studies, events | ~1,440 readings/day |
+| 5 minutes | Standard monitoring | ~288 readings/day |
+| 15 minutes | Long-term trends | ~96 readings/day |
+| 1 hour | Low-power deployments | ~24 readings/day |
+
+### Health Monitoring
+The system automatically monitors sensor health:
+- **Stale threshold**: 3x your reporting interval
+- **Unhealthy threshold**: 12x your reporting interval
+
+Example: A 5-minute interval sensor becomes "Stale" after 15 minutes of silence, "Unhealthy" after 1 hour.
+
+---
+
+## Step 6: Monitor Your Network
+
+### Sensor Health Dashboard
+
+Check sensor status regularly:
+1. Go to your organization's **Sensors** tab
+2. Look for health status badges:
+   - **Healthy** - Operating normally
+   - **Stale** - May need attention
+   - **Unhealthy** - Likely offline, investigate
+
+### Common Issues
+
+| Symptom | Likely Cause | Solution |
+|---------|--------------|----------|
+| Sensor shows "Unknown" | Never received data | Check device configuration |
+| Sensor went "Stale" | Connectivity issue | Check WiFi/power at site |
+| Sensor is "Unhealthy" | Device failure | Visit site, check hardware |
+| Wrong readings | Sensor calibration | Recalibrate physical sensor |
+
+---
+
+## Step 7: Credential Management
+
+### If a Student Loses Their Token
+
+1. Go to the sensor's detail page
+2. Click **Regenerate Credentials** (requires Admin/Owner role)
+3. The old token is invalidated immediately
+4. Share the new credentials with the student
+
+> **Security Note:** Only regenerate credentials if the student confirms they've lost them. The old token stops working immediately.
+
+---
+
+## Best Practices for Classes
+
+### For Lab Courses
+
+1. **Pre-register sensors** yourself before class
+2. Give students the credentials on lab day
+3. Keep students as "Viewers" for data analysis
+4. Use consistent naming: `LAB-BENCH-01`, `LAB-BENCH-02`, etc.
+
+### For Field Research Projects
+
+1. Add students as "Editors" so they can register their own sensors
+2. Establish a naming convention beforehand
+3. Create a shared document for credential backup
+4. Schedule regular health checks
+
+### For Long-term Monitoring
+
+1. Use 15-minute or 1-hour intervals to conserve power
+2. Set up regular site visits for maintenance
+3. Monitor the health dashboard weekly
+4. Document sensor locations with photos
+
+---
+
+## Data Management
+
+### Accessing Data
+
+All sensor readings are accessible via:
+- **Web interface** - Browse and filter on sensor detail pages
+- **API** - Programmatic access for analysis scripts
+- **Export** - Download CSV files for offline analysis
+
+### API Access for Analysis
+
+```python
+import requests
+
+# Get readings for a sensor
+response = requests.get(
+    "https://your-server.com/api/sensors/{sensor_id}/readings/",
+    params={
+        "from": "2024-01-01",
+        "to": "2024-01-31",
+        "parameter": "pH"
+    }
+)
+readings = response.json()
+```
+
+---
+
+## Organization Settings
+
+### Blocking Users
+
+If you need to remove a problematic member:
+1. Go to **Members** tab
+2. Find the member
+3. Click **Remove**
+
+To prevent them from requesting access again:
+1. Go to **Blocked Users** tab
+2. Click **Block User**
+3. Enter their email
+
+---
+
+## Need Help?
+
+- Review the full [User Workflows Documentation](../user-workflows.md)
+- Check the [API Documentation](../creating-endpoints.md) for integration
+- Contact system administrators for technical issues

--- a/docs/getting-started/for-students.md
+++ b/docs/getting-started/for-students.md
@@ -1,0 +1,186 @@
+# Getting Started: For Students
+
+Welcome to EcoData! This guide will help you set up your environmental monitoring sensors and start collecting data for your research projects.
+
+## Overview
+
+As a student, you'll typically:
+1. Join your school's organization
+2. Register your sensor device
+3. Configure your hardware (ESP32, Arduino, etc.)
+4. View and analyze your collected data
+
+---
+
+## Step 1: Create Your Account
+
+1. Go to the **Register** page
+2. Enter your school email, display name, and password
+3. Click **Create Account**
+
+> **Tip:** Use your school email (.edu) so your professor can easily identify you.
+
+---
+
+## Step 2: Join Your Organization
+
+Your professor or lab coordinator has likely already created an organization for your class or research group.
+
+1. Go to **Organizations** in the navigation
+2. Browse or search for your school/lab organization
+3. Click on the organization to view details
+4. Click **Request Access**
+5. Wait for your professor/admin to approve your request
+
+> **Note:** You'll receive a notification when your request is approved. You'll start with "Viewer" access, which lets you see sensors and data. Ask your professor to upgrade you to "Editor" if you need to register sensors.
+
+---
+
+## Step 3: Register Your Sensor
+
+Once you have Editor permissions:
+
+1. Go to your organization's page
+2. Click the **Sensors** tab
+3. Click **Add Sensor**
+4. Fill in the registration form:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **External ID** | Your sensor's unique identifier | `ESP32-LAB-01` |
+| **Name** | A descriptive name | `Rio Santa Catarina Station 1` |
+| **Location** | Click on the map or enter coordinates | Lat: 25.6866, Lng: -100.3161 |
+| **Municipality** | Search and select | Monterrey |
+| **Reporting Interval** | How often your sensor sends data | Every 5 minutes |
+
+5. Click **Register Sensor**
+
+---
+
+## Step 4: Save Your Credentials (IMPORTANT!)
+
+After registration, you'll see a dialog with your sensor credentials:
+
+```
+Sensor ID: 01234567-89ab-cdef-0123-456789abcdef
+Access Token: eyJhbGciOiJIUzI1NiIs...
+```
+
+**CRITICAL: Copy and save these credentials immediately!**
+
+- The access token is shown **only once**
+- Your sensor needs this token to send data
+- If you lose it, you'll need to contact an admin to regenerate it
+
+> **Recommendation:** Save these in a secure note or your project's configuration file.
+
+---
+
+## Step 5: Configure Your Device
+
+### For ESP32 (Arduino IDE)
+
+```cpp
+// WiFi credentials
+const char* ssid = "YOUR_WIFI_SSID";
+const char* password = "YOUR_WIFI_PASSWORD";
+
+// EcoData API configuration
+const char* API_HOST = "your-ecodata-server.com";
+const char* SENSOR_ID = "YOUR_SENSOR_ID_HERE";
+const char* ACCESS_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+
+// Submit a reading
+void submitReading(float value, const char* parameter, const char* unit) {
+    HTTPClient http;
+
+    String url = "https://" + String(API_HOST) + "/api/sensors/" + SENSOR_ID + "/readings/";
+    http.begin(url);
+    http.addHeader("Content-Type", "application/json");
+    http.addHeader("Authorization", "Bearer " + String(ACCESS_TOKEN));
+
+    String payload = "{\"readings\":[{";
+    payload += "\"parameter\":\"" + String(parameter) + "\",";
+    payload += "\"value\":" + String(value) + ",";
+    payload += "\"unit\":\"" + String(unit) + "\",";
+    payload += "\"recordedAt\":\"" + getISOTimestamp() + "\"";
+    payload += "}]}";
+
+    int responseCode = http.POST(payload);
+    http.end();
+}
+```
+
+### Common Parameters to Monitor
+
+| Parameter | Unit | Description |
+|-----------|------|-------------|
+| pH | pH | Water acidity/alkalinity (0-14 scale) |
+| Temperature | °C | Water or air temperature |
+| Dissolved Oxygen | mg/L | Oxygen concentration in water |
+| Turbidity | NTU | Water clarity |
+| Conductivity | µS/cm | Electrical conductivity |
+
+---
+
+## Step 6: View Your Data
+
+Once your sensor starts reporting:
+
+1. Go to **Sensors** in the navigation
+2. Find and click on your sensor
+3. You'll see:
+   - **Sensor details** - Location, status, last reading time
+   - **Readings list** - All recorded measurements
+   - **Filters** - Filter by parameter or date range
+
+### Understanding Sensor Health
+
+Your sensor has a health status indicator:
+
+| Status | Meaning |
+|--------|---------|
+| **Healthy** | Sensor is reporting data as expected |
+| **Stale** | Sensor hasn't reported in a while (check connectivity) |
+| **Unhealthy** | Sensor has been silent too long (may be offline) |
+| **Unknown** | New sensor, no data received yet |
+
+---
+
+## Troubleshooting
+
+### "My sensor isn't showing any readings"
+
+1. Check your WiFi connection
+2. Verify the Sensor ID and Access Token are correct
+3. Check the serial monitor for error messages
+4. Make sure your sensor's clock is synchronized (for timestamps)
+
+### "I lost my access token"
+
+Contact your organization admin (professor/lab coordinator) to regenerate your sensor credentials.
+
+### "I can't register sensors"
+
+You need "Editor" permissions. Ask your organization admin to upgrade your role from "Viewer" to "Editor".
+
+### "My access request is still pending"
+
+Your organization admin needs to approve your request. Contact them directly if it's been more than a day.
+
+---
+
+## Next Steps
+
+- **Explore the map** - See all sensors on an interactive map
+- **Compare data** - Use filters to analyze trends over time
+- **Export data** - Download your readings for analysis in Excel or Python
+- **Check health** - Monitor your sensor's connectivity status
+
+---
+
+## Need Help?
+
+- Ask your professor or lab coordinator
+- Check the full [User Workflows Documentation](../user-workflows.md)
+- Review the API documentation for advanced usage

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/Components/PublicGuide.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/Components/PublicGuide.razor
@@ -1,0 +1,146 @@
+@using BlazorStaticNavigation
+
+<MudStack Spacing="4" Class="pa-2">
+    @* Overview *@
+    <MudText Typo="Typo.body1">
+        EcoData provides open access to environmental monitoring data collected across Puerto Rico.
+        No account is required to explore sensors and view data.
+    </MudText>
+
+    @* What You Can Do *@
+    <MudText Typo="Typo.subtitle1"><strong>What You Can Do</strong></MudText>
+    <MudGrid Spacing="2">
+        <MudItem xs="12" sm="6">
+            <MudPaper Elevation="0" Class="pa-4" Style="background: var(--mud-palette-background-grey); height: 100%;">
+                <MudStack Spacing="2">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                        <MudIcon Icon="@Icons.Material.Filled.Map" Color="Color.Primary" />
+                        <MudText Typo="Typo.subtitle2"><strong>Explore the Map</strong></MudText>
+                    </MudStack>
+                    <MudText Typo="Typo.body2">
+                        View all active sensors on an interactive map. See where monitoring is happening across Puerto Rico.
+                    </MudText>
+                    <MudButton Href="/map" Variant="Variant.Text" Color="Color.Primary" EndIcon="@Icons.Material.Filled.ArrowForward">
+                        Open Map
+                    </MudButton>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" sm="6">
+            <MudPaper Elevation="0" Class="pa-4" Style="background: var(--mud-palette-background-grey); height: 100%;">
+                <MudStack Spacing="2">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                        <MudIcon Icon="@Icons.Material.Filled.Sensors" Color="Color.Primary" />
+                        <MudText Typo="Typo.subtitle2"><strong>Browse Sensors</strong></MudText>
+                    </MudStack>
+                    <MudText Typo="Typo.body2">
+                        Search and filter sensors by location or name. View detailed information about each monitoring station.
+                    </MudText>
+                    <MudButton Href="/sensors" Variant="Variant.Text" Color="Color.Primary" EndIcon="@Icons.Material.Filled.ArrowForward">
+                        View Sensors
+                    </MudButton>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" sm="6">
+            <MudPaper Elevation="0" Class="pa-4" Style="background: var(--mud-palette-background-grey); height: 100%;">
+                <MudStack Spacing="2">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                        <MudIcon Icon="@Icons.Material.Filled.Analytics" Color="Color.Primary" />
+                        <MudText Typo="Typo.subtitle2"><strong>View Readings</strong></MudText>
+                    </MudStack>
+                    <MudText Typo="Typo.body2">
+                        Click on any sensor to see its recorded data. Filter by parameter type (pH, temperature, etc.) or date range.
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" sm="6">
+            <MudPaper Elevation="0" Class="pa-4" Style="background: var(--mud-palette-background-grey); height: 100%;">
+                <MudStack Spacing="2">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                        <MudIcon Icon="@Icons.Material.Filled.Business" Color="Color.Primary" />
+                        <MudText Typo="Typo.subtitle2"><strong>Discover Organizations</strong></MudText>
+                    </MudStack>
+                    <MudText Typo="Typo.body2">
+                        See which universities and research groups are contributing to the monitoring network.
+                    </MudText>
+                    <MudButton Href="/organizations/discover" Variant="Variant.Text" Color="Color.Primary" EndIcon="@Icons.Material.Filled.ArrowForward">
+                        Browse Organizations
+                    </MudButton>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+
+    @* What's Being Monitored *@
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1"><strong>What's Being Monitored</strong></MudText>
+    <MudText Typo="Typo.body2" Class="mb-2">
+        Sensors across Puerto Rico collect various environmental parameters:
+    </MudText>
+    <MudGrid Spacing="2">
+        <MudItem xs="6" sm="4" md="2">
+            <MudStack AlignItems="AlignItems.Center" Spacing="1">
+                <MudIcon Icon="@Icons.Material.Filled.Water" Color="Color.Info" />
+                <MudText Typo="Typo.body2" Align="Align.Center">pH Levels</MudText>
+            </MudStack>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudStack AlignItems="AlignItems.Center" Spacing="1">
+                <MudIcon Icon="@Icons.Material.Filled.Thermostat" Color="Color.Error" />
+                <MudText Typo="Typo.body2" Align="Align.Center">Temperature</MudText>
+            </MudStack>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudStack AlignItems="AlignItems.Center" Spacing="1">
+                <MudIcon Icon="@Icons.Material.Filled.BubbleChart" Color="Color.Success" />
+                <MudText Typo="Typo.body2" Align="Align.Center">Dissolved Oxygen</MudText>
+            </MudStack>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudStack AlignItems="AlignItems.Center" Spacing="1">
+                <MudIcon Icon="@Icons.Material.Filled.Opacity" Color="Color.Warning" />
+                <MudText Typo="Typo.body2" Align="Align.Center">Turbidity</MudText>
+            </MudStack>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudStack AlignItems="AlignItems.Center" Spacing="1">
+                <MudIcon Icon="@Icons.Material.Filled.ElectricBolt" Color="Color.Secondary" />
+                <MudText Typo="Typo.body2" Align="Align.Center">Conductivity</MudText>
+            </MudStack>
+        </MudItem>
+        <MudItem xs="6" sm="4" md="2">
+            <MudStack AlignItems="AlignItems.Center" Spacing="1">
+                <MudIcon Icon="@Icons.Material.Filled.Air" Color="Color.Primary" />
+                <MudText Typo="Typo.body2" Align="Align.Center">Air Quality</MudText>
+            </MudStack>
+        </MudItem>
+    </MudGrid>
+
+    @* Want to Contribute? *@
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1"><strong>Want to Contribute?</strong></MudText>
+    <MudText Typo="Typo.body2">
+        If you're a student or researcher interested in deploying sensors:
+    </MudText>
+    <MudStack Row="true" Spacing="2" Class="mt-2 flex-wrap">
+        <MudButton Href="/register" Variant="Variant.Filled" Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.PersonAdd">
+            Create an Account
+        </MudButton>
+        <MudButton Href="/organizations/discover" Variant="Variant.Outlined" Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Search">
+            Find Your Organization
+        </MudButton>
+    </MudStack>
+
+    @* About the Project *@
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1"><strong>About EcoData</strong></MudText>
+    <MudText Typo="Typo.body2">
+        EcoData is an initiative by Inter American University of Puerto Rico to modernize environmental
+        monitoring across the island. By making data openly accessible, we support research, education,
+        and informed decision-making for Puerto Rico's environmental future.
+    </MudText>
+</MudStack>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/Components/ResearcherGuide.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/Components/ResearcherGuide.razor
@@ -1,0 +1,201 @@
+@using BlazorStaticNavigation
+
+<MudStack Spacing="4" Class="pa-2">
+    @* Overview *@
+    <MudText Typo="Typo.body1">
+        As a researcher or educator, you can create organizations, manage student teams,
+        and oversee sensor deployments. Here's how to set up your research environment:
+    </MudText>
+
+    @* Step 1 *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Secondary">1</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Create Your Organization</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            After logging in, go to <MudLink Href="/organizations/my">My Organizations</MudLink> and click
+            <strong>Create Organization</strong>. Give it a clear name (e.g., "UANL Environmental Lab").
+        </MudText>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            You'll automatically be the <strong>Owner</strong> with full permissions.
+        </MudText>
+    </MudStack>
+
+    @* Step 2 *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Secondary">2</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Invite Your Team</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Share your organization name with students. They'll:
+        </MudText>
+        <ol class="ml-14" style="margin-top: 0.5rem;">
+            <li>Create an EcoData account</li>
+            <li>Find your organization in the directory</li>
+            <li>Click "Request Access"</li>
+        </ol>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Review pending requests in your organization's <strong>Access Requests</strong> tab.
+        </MudText>
+    </MudStack>
+
+    @* Step 3 - Roles *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Secondary">3</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Assign Appropriate Roles</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Members start as Viewers. Upgrade roles based on responsibilities:
+        </MudText>
+        <MudSimpleTable Dense="true" Hover="true" Class="ml-10" Style="max-width: 600px;">
+            <thead>
+                <tr>
+                    <th>Role</th>
+                    <th>Permissions</th>
+                    <th>Best For</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><MudChip T="string" Size="Size.Small" Color="Color.Default">Viewer</MudChip></td>
+                    <td>View sensors and data</td>
+                    <td>General students, observers</td>
+                </tr>
+                <tr>
+                    <td><MudChip T="string" Size="Size.Small" Color="Color.Info">Editor</MudChip></td>
+                    <td>Create and edit sensors</td>
+                    <td>Students deploying sensors</td>
+                </tr>
+                <tr>
+                    <td><MudChip T="string" Size="Size.Small" Color="Color.Warning">Admin</MudChip></td>
+                    <td>Manage members, all sensor ops</td>
+                    <td>Teaching assistants, lab managers</td>
+                </tr>
+                <tr>
+                    <td><MudChip T="string" Size="Size.Small" Color="Color.Primary">Owner</MudChip></td>
+                    <td>Full control</td>
+                    <td>Principal investigator (you)</td>
+                </tr>
+            </tbody>
+        </MudSimpleTable>
+    </MudStack>
+
+    @* Step 4 *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Secondary">4</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Plan Your Sensor Network</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Establish conventions before deployment:
+        </MudText>
+        <MudGrid Class="ml-10 mt-2">
+            <MudItem xs="12" md="6">
+                <MudPaper Elevation="0" Class="pa-3" Style="background: var(--mud-palette-background-grey);">
+                    <MudText Typo="Typo.subtitle2"><strong>Naming Convention</strong></MudText>
+                    <MudText Typo="Typo.body2">
+                        Use consistent External IDs:<br />
+                        <code>SITE-01</code>, <code>SITE-02</code>, <code>SITE-03</code><br />
+                        <code>RIO-UPSTREAM</code>, <code>RIO-DOWNSTREAM</code>
+                    </MudText>
+                </MudPaper>
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudPaper Elevation="0" Class="pa-3" Style="background: var(--mud-palette-background-grey);">
+                    <MudText Typo="Typo.subtitle2"><strong>Reporting Intervals</strong></MudText>
+                    <MudText Typo="Typo.body2">
+                        <strong>1 min</strong> - High-resolution events<br />
+                        <strong>5 min</strong> - Standard monitoring<br />
+                        <strong>15 min / 1 hr</strong> - Low-power, long-term
+                    </MudText>
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    </MudStack>
+
+    @* Step 5 *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Secondary">5</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Monitor Your Network</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Check sensor health regularly in your organization's Sensors tab. Health statuses help identify issues:
+        </MudText>
+        <MudSimpleTable Dense="true" Hover="true" Class="ml-10" Style="max-width: 500px;">
+            <tbody>
+                <tr>
+                    <td><MudChip T="string" Color="Color.Success" Size="Size.Small">Healthy</MudChip></td>
+                    <td>Operating normally</td>
+                </tr>
+                <tr>
+                    <td><MudChip T="string" Color="Color.Warning" Size="Size.Small">Stale</MudChip></td>
+                    <td>Delayed - check connectivity</td>
+                </tr>
+                <tr>
+                    <td><MudChip T="string" Color="Color.Error" Size="Size.Small">Unhealthy</MudChip></td>
+                    <td>Likely offline - visit site</td>
+                </tr>
+            </tbody>
+        </MudSimpleTable>
+    </MudStack>
+
+    @* Credential Management *@
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1"><strong>Managing Credentials</strong></MudText>
+    <MudAlert Severity="Severity.Info" Variant="Variant.Text" Dense="true">
+        If a student loses their sensor token, you can regenerate it from the sensor's detail page
+        (requires Admin or Owner role). The old token stops working immediately.
+    </MudAlert>
+
+    @* Best Practices *@
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1"><strong>Best Practices</strong></MudText>
+    <MudGrid Spacing="2">
+        <MudItem xs="12" md="4">
+            <MudPaper Elevation="0" Class="pa-3" Style="background: var(--mud-palette-background-grey);">
+                <MudStack Spacing="1">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <MudIcon Icon="@Icons.Material.Filled.School" Size="Size.Small" Color="Color.Primary" />
+                        <MudText Typo="Typo.subtitle2"><strong>For Lab Courses</strong></MudText>
+                    </MudStack>
+                    <MudText Typo="Typo.body2">
+                        Pre-register sensors yourself. Give students credentials on lab day.
+                        Keep them as Viewers for data analysis.
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="4">
+            <MudPaper Elevation="0" Class="pa-3" Style="background: var(--mud-palette-background-grey);">
+                <MudStack Spacing="1">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <MudIcon Icon="@Icons.Material.Filled.Terrain" Size="Size.Small" Color="Color.Primary" />
+                        <MudText Typo="Typo.subtitle2"><strong>For Field Research</strong></MudText>
+                    </MudStack>
+                    <MudText Typo="Typo.body2">
+                        Make students Editors so they can register their own sensors.
+                        Create a shared doc for credential backup.
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="4">
+            <MudPaper Elevation="0" Class="pa-3" Style="background: var(--mud-palette-background-grey);">
+                <MudStack Spacing="1">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <MudIcon Icon="@Icons.Material.Filled.Timeline" Size="Size.Small" Color="Color.Primary" />
+                        <MudText Typo="Typo.subtitle2"><strong>Long-term Monitoring</strong></MudText>
+                    </MudStack>
+                    <MudText Typo="Typo.body2">
+                        Use 15min+ intervals to conserve power.
+                        Schedule regular maintenance visits.
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+</MudStack>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/Components/StudentGuide.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/Components/StudentGuide.razor
@@ -1,0 +1,159 @@
+@using BlazorStaticNavigation
+
+<MudStack Spacing="4" Class="pa-2">
+    @* Overview *@
+    <MudText Typo="Typo.body1">
+        Welcome! As a student, you'll join your school's organization, register your sensors,
+        and start collecting environmental data. Here's how to get started:
+    </MudText>
+
+    @* Step 1 *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Primary">1</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Create Your Account</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Go to <MudLink Href="/register">Register</MudLink> and create an account using your school email.
+            This helps your professor identify you when approving access.
+        </MudText>
+    </MudStack>
+
+    @* Step 2 *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Primary">2</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Join Your Organization</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Browse <MudLink Href="/organizations/discover">Organizations</MudLink> to find your school or lab.
+            Click <strong>Request Access</strong> and wait for your professor to approve you.
+        </MudText>
+        <MudAlert Severity="Severity.Info" Variant="Variant.Text" Dense="true" Class="ml-10">
+            You'll start as a "Viewer". Ask your professor to upgrade you to "Editor" if you need to register sensors.
+        </MudAlert>
+    </MudStack>
+
+    @* Step 3 *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Primary">3</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Register Your Sensor</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Once you have Editor permissions, go to your organization's Sensors tab and click <strong>Add Sensor</strong>.
+            Fill in:
+        </MudText>
+        <MudSimpleTable Dense="true" Hover="true" Class="ml-10" Style="max-width: 500px;">
+            <tbody>
+                <tr>
+                    <td><strong>External ID</strong></td>
+                    <td>Your sensor's unique identifier (e.g., ESP32-LAB-01)</td>
+                </tr>
+                <tr>
+                    <td><strong>Name</strong></td>
+                    <td>A descriptive name for the sensor location</td>
+                </tr>
+                <tr>
+                    <td><strong>Location</strong></td>
+                    <td>Click on the map or enter coordinates</td>
+                </tr>
+                <tr>
+                    <td><strong>Reporting Interval</strong></td>
+                    <td>How often your sensor sends data</td>
+                </tr>
+            </tbody>
+        </MudSimpleTable>
+    </MudStack>
+
+    @* Step 4 - Critical *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Primary">4</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Save Your Credentials</strong></MudText>
+        </MudStack>
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Filled" Class="ml-10">
+            <strong>IMPORTANT:</strong> After registration, you'll receive a <strong>Sensor ID</strong> and
+            <strong>Access Token</strong>. Save these immediately! The token is shown only once.
+            If you lose it, contact your organization admin to regenerate it.
+        </MudAlert>
+    </MudStack>
+
+    @* Step 5 *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Primary">5</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>Configure Your Device</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Program your ESP32 or Arduino with the Sensor ID and Access Token. Here's a quick example:
+        </MudText>
+        <MudPaper Elevation="0" Class="ml-10 pa-3 code-block">
+            <pre style="margin: 0; font-size: 0.8rem; overflow-x: auto;"><code>// EcoData Configuration
+const char* SENSOR_ID = "your-sensor-id";
+const char* ACCESS_TOKEN = "your-access-token";
+const char* API_URL = "https://your-server/api/sensors/";
+
+// POST readings to: API_URL + SENSOR_ID + "/readings/"
+// Header: Authorization: Bearer ACCESS_TOKEN</code></pre>
+        </MudPaper>
+    </MudStack>
+
+    @* Step 6 *@
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudAvatar Size="Size.Small" Color="Color.Primary">6</MudAvatar>
+            <MudText Typo="Typo.subtitle1"><strong>View Your Data</strong></MudText>
+        </MudStack>
+        <MudText Typo="Typo.body2" Class="ml-10">
+            Once your sensor starts reporting, view readings on the sensor detail page.
+            Use filters to search by parameter (pH, Temperature, etc.) or date range.
+        </MudText>
+    </MudStack>
+
+    @* Health Status Info *@
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1"><strong>Understanding Sensor Health</strong></MudText>
+    <MudStack Row="true" Spacing="2" Class="flex-wrap">
+        <MudChip T="string" Color="Color.Success" Size="Size.Small">Healthy</MudChip>
+        <MudText Typo="Typo.body2">Reporting as expected</MudText>
+    </MudStack>
+    <MudStack Row="true" Spacing="2" Class="flex-wrap">
+        <MudChip T="string" Color="Color.Warning" Size="Size.Small">Stale</MudChip>
+        <MudText Typo="Typo.body2">Delayed reporting - check connectivity</MudText>
+    </MudStack>
+    <MudStack Row="true" Spacing="2" Class="flex-wrap">
+        <MudChip T="string" Color="Color.Error" Size="Size.Small">Unhealthy</MudChip>
+        <MudText Typo="Typo.body2">Likely offline - investigate device</MudText>
+    </MudStack>
+
+    @* Troubleshooting *@
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1"><strong>Common Issues</strong></MudText>
+    <MudSimpleTable Dense="true" Hover="true">
+        <thead>
+            <tr>
+                <th>Problem</th>
+                <th>Solution</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>No readings appearing</td>
+                <td>Check WiFi, verify Sensor ID and Token are correct</td>
+            </tr>
+            <tr>
+                <td>Lost access token</td>
+                <td>Contact your organization admin to regenerate</td>
+            </tr>
+            <tr>
+                <td>Can't register sensors</td>
+                <td>Ask admin to upgrade you from Viewer to Editor</td>
+            </tr>
+            <tr>
+                <td>Access request pending</td>
+                <td>Contact your professor directly</td>
+            </tr>
+        </tbody>
+    </MudSimpleTable>
+</MudStack>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/_Imports.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/_Imports.razor
@@ -1,0 +1,3 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using MudBlazor

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -53,6 +53,9 @@
             <MudButton Href="@SensorMapPage.Path" Color="Color.Inherit" Variant="Variant.Text">
                 Map
             </MudButton>
+            <MudButton Href="@GettingStartedPage.Path" Color="Color.Inherit" Variant="Variant.Text">
+                Getting Started
+            </MudButton>
         </div>
 
         <MudSpacer />
@@ -124,6 +127,7 @@
                 }
             </MudNavGroup>
             <MudNavLink Href="@SensorMapPage.Path" Icon="@Icons.Material.Outlined.Map">Map</MudNavLink>
+            <MudNavLink Href="@GettingStartedPage.Path" Icon="@Icons.Material.Outlined.Help">Getting Started</MudNavLink>
         </MudNavMenu>
 
         <MudSpacer />

--- a/src/Apps/EcoPortal/EcoPortal.Client/Pages/GettingStartedPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Pages/GettingStartedPage.razor
@@ -1,0 +1,115 @@
+@page "/getting-started"
+@using BlazorStaticNavigation
+
+<PageTitle>Getting Started - EcoData</PageTitle>
+
+<div class="getting-started-page">
+    <MudContainer MaxWidth="MaxWidth.Large" Class="py-6">
+        @* Header Section *@
+        <MudStack Spacing="2" Class="mb-6">
+            <h1 class="serif-headline">Getting Started</h1>
+            <MudText Typo="Typo.body1" Color="Color.Secondary">
+                Choose your role below to see a personalized guide for using EcoData.
+            </MudText>
+        </MudStack>
+
+        @* Role Selection Cards *@
+        <MudExpansionPanels MultiExpansion="false" Elevation="0" Class="guide-panels">
+            @* For Students *@
+            <MudExpansionPanel Class="guide-panel">
+                <TitleContent>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                        <MudAvatar Color="Color.Primary" Variant="Variant.Filled">
+                            <MudIcon Icon="@Icons.Material.Filled.School" />
+                        </MudAvatar>
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.h6">For Students</MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                                Register sensors, collect data, and complete your research projects
+                            </MudText>
+                        </MudStack>
+                    </MudStack>
+                </TitleContent>
+                <ChildContent>
+                    <StudentGuide />
+                </ChildContent>
+            </MudExpansionPanel>
+
+            @* For Researchers & Educators *@
+            <MudExpansionPanel Class="guide-panel">
+                <TitleContent>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                        <MudAvatar Color="Color.Secondary" Variant="Variant.Filled">
+                            <MudIcon Icon="@Icons.Material.Filled.Science" />
+                        </MudAvatar>
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.h6">For Researchers & Educators</MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                                Manage organizations, approve students, and oversee sensor networks
+                            </MudText>
+                        </MudStack>
+                    </MudStack>
+                </TitleContent>
+                <ChildContent>
+                    <ResearcherGuide />
+                </ChildContent>
+            </MudExpansionPanel>
+
+            @* For the Public *@
+            <MudExpansionPanel Class="guide-panel">
+                <TitleContent>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                        <MudAvatar Color="Color.Tertiary" Variant="Variant.Filled">
+                            <MudIcon Icon="@Icons.Material.Filled.Public" />
+                        </MudAvatar>
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.h6">For the Public</MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                                Explore environmental data and learn about monitoring efforts
+                            </MudText>
+                        </MudStack>
+                    </MudStack>
+                </TitleContent>
+                <ChildContent>
+                    <PublicGuide />
+                </ChildContent>
+            </MudExpansionPanel>
+        </MudExpansionPanels>
+
+        @* Quick Links Section *@
+        <MudPaper Elevation="0" Class="mt-6 pa-5 quick-links-card">
+            <MudStack Spacing="3">
+                <MudText Typo="Typo.h6">Quick Links</MudText>
+                <MudGrid Spacing="2">
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudButton Href="/sensors" Variant="Variant.Outlined" FullWidth="true"
+                                   StartIcon="@Icons.Material.Outlined.Sensors" Color="Color.Primary">
+                            Browse Sensors
+                        </MudButton>
+                    </MudItem>
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudButton Href="/map" Variant="Variant.Outlined" FullWidth="true"
+                                   StartIcon="@Icons.Material.Outlined.Map" Color="Color.Primary">
+                            View Map
+                        </MudButton>
+                    </MudItem>
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudButton Href="/organizations/discover" Variant="Variant.Outlined" FullWidth="true"
+                                   StartIcon="@Icons.Material.Outlined.Business" Color="Color.Primary">
+                            Find Organizations
+                        </MudButton>
+                    </MudItem>
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudButton Href="/register" Variant="Variant.Outlined" FullWidth="true"
+                                   StartIcon="@Icons.Material.Outlined.PersonAdd" Color="Color.Primary">
+                            Create Account
+                        </MudButton>
+                    </MudItem>
+                </MudGrid>
+            </MudStack>
+        </MudPaper>
+    </MudContainer>
+</div>
+
+@code {
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/_Imports.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/_Imports.razor
@@ -12,3 +12,4 @@
 @using EcoPortal.Client.Components
 @using EcoPortal.Client.Features.Organizations.Components
 @using EcoPortal.Client.Features.Sensors.Components
+@using EcoPortal.Client.Features.GettingStarted.Components


### PR DESCRIPTION
## Summary

- Add in-app Getting Started page (`/getting-started`) with role-based expandable guides
- Create guides for three user types: Students, Researchers/Educators, and the Public
- Add static markdown documentation in `docs/getting-started/`
- Add navigation links to both desktop and mobile menus

## What's Included

### For Students
Step-by-step guide covering:
- Account creation
- Joining organizations and requesting access
- Registering sensors
- Saving credentials (with warnings about one-time token display)
- Configuring ESP32/Arduino devices
- Viewing data and understanding health status

### For Researchers & Educators
Guide covering:
- Creating and managing organizations
- Approving student access requests
- Assigning roles (Viewer, Editor, Admin, Owner)
- Planning sensor networks and naming conventions
- Monitoring sensor health
- Best practices for labs, field research, and long-term monitoring

### For the Public
Guide covering:
- Exploring the sensor map
- Browsing sensors and viewing readings
- Understanding what's being monitored
- How to get involved

## Test plan
- [ ] Navigate to `/getting-started` and verify the page loads
- [ ] Click each expandable section and verify content displays
- [ ] Check navigation links work on both desktop and mobile views
- [ ] Verify quick links at bottom of page navigate correctly

🤖 Generated with [Claude Code](https://claude.ai/code)