### PR TITLE
Add sensor configuration page and standardize container layouts

### DIFF
--- a/scripts/send_readings_dev.py
+++ b/scripts/send_readings_dev.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Sensor reading simulator for EcoData (Development).
+Sends random readings to the local API using a sensor JWT token.
+"""
+
+import requests
+import random
+import time
+from datetime import datetime, timezone
+
+# Configuration - Development defaults
+BASE_URL = "https://localhost:5000"
+INTERVAL = 30
+JWT_TOKEN = ""
+SENSOR_ID = ""
+
+# Simulated parameters
+PARAMETERS = [
+    {"parameter": "temperature", "unit": "°C", "min": 20.0, "max": 35.0, "description": "Air temperature"},
+    {"parameter": "humidity", "unit": "%", "min": 40.0, "max": 90.0, "description": "Relative humidity"},
+    {"parameter": "pm25", "unit": "µg/m³", "min": 5.0, "max": 50.0, "description": "PM2.5 particulate matter"},
+    {"parameter": "co2", "unit": "ppm", "min": 400.0, "max": 800.0, "description": "Carbon dioxide"},
+]
+
+
+def generate_reading(param_config: dict) -> dict:
+    """Generate a random reading for a parameter."""
+    return {
+        "parameter": param_config["parameter"],
+        "description": param_config["description"],
+        "value": round(random.uniform(param_config["min"], param_config["max"]), 2),
+        "unit": param_config["unit"],
+        "recordedAt": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def send_readings():
+    """Send a batch of readings to the API."""
+    url = f"{BASE_URL}/api/sensors/{SENSOR_ID}/readings"
+    headers = {
+        "Authorization": f"Bearer {JWT_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+    readings = [generate_reading(param) for param in PARAMETERS]
+    payload = {
+        "sensorId": SENSOR_ID,
+        "readings": readings,
+    }
+
+    try:
+        # Disable SSL verification for local development
+        response = requests.post(url, json=payload, headers=headers, verify=False)
+        response.raise_for_status()
+        result = response.json()
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] Sent {result['accepted']}/{result['totalSubmitted']} readings")
+        if result.get("errors"):
+            for error in result["errors"]:
+                print(f"  Error: {error}")
+    except requests.exceptions.RequestException as e:
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] Error: {e}")
+
+
+def parse_jwt_sensor_id(token: str) -> str | None:
+    """Extract sensor_id from JWT token payload."""
+    try:
+        import base64
+        import json
+        # JWT is header.payload.signature - we want the payload
+        payload = token.split(".")[1]
+        # Add padding if needed
+        padding = 4 - len(payload) % 4
+        if padding != 4:
+            payload += "=" * padding
+        decoded = base64.urlsafe_b64decode(payload)
+        data = json.loads(decoded)
+        return data.get("sensor_id") or data.get("sub")
+    except Exception:
+        return None
+
+
+def main():
+    global JWT_TOKEN, SENSOR_ID
+
+    print("Development Sensor Simulator")
+    print("============================\n")
+
+    # Get JWT token from input
+    JWT_TOKEN = input("Paste JWT token: ").strip()
+
+    if not JWT_TOKEN:
+        print("Error: JWT token required")
+        return
+
+    # Extract sensor ID from JWT
+    SENSOR_ID = parse_jwt_sensor_id(JWT_TOKEN)
+
+    if not SENSOR_ID:
+        print("Error: Could not extract sensor ID from token")
+        return
+
+    # Suppress SSL warnings for local dev
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    print(f"\nAPI URL:   {BASE_URL}")
+    print(f"Sensor ID: {SENSOR_ID}")
+    print(f"Interval:  {INTERVAL} seconds")
+    print("\nPress Ctrl+C to stop\n")
+
+    while True:
+        send_readings()
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/EcoDataPageLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/EcoDataPageLayout.razor
@@ -1,7 +1,7 @@
 @using EcoPortal.Client.Services
 @inject INavigationService Navigation
 
-<MudContainer MaxWidth="@MaxWidth" Class="@ContainerClass">
+<div class="page-container mt-4 mb-8">
     @if (!string.IsNullOrEmpty(FallbackUrl))
     {
         <MudButton Variant="Variant.Text"
@@ -18,7 +18,7 @@
             <MudStack Row Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                 @if (!string.IsNullOrEmpty(Title))
                 {
-                    <MudText Typo="@TitleTypo">@Title</MudText>
+                    <MudText Typo="Typo.h5">@Title</MudText>
                 }
 
                 @if (Actions is not null)
@@ -36,7 +36,7 @@
     <div class="page-content">
         @ChildContent
     </div>
-</MudContainer>
+</div>
 
 @code {
     [Parameter]
@@ -46,16 +46,10 @@
     public string? FallbackUrl { get; set; }
 
     [Parameter]
-    public MaxWidth MaxWidth { get; set; } = MaxWidth.Large;
-
-    [Parameter]
     public RenderFragment? Actions { get; set; }
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
-
-    private string ContainerClass => MaxWidth == MaxWidth.Small ? "pa-4" : "page-container mt-4 mb-8";
-    private Typo TitleTypo => MaxWidth == MaxWidth.Small ? Typo.h5 : Typo.h4;
 
     protected override void OnInitialized()
     {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationSensors/Pages/OrganizationSensorCreatePage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationSensors/Pages/OrganizationSensorCreatePage.razor
@@ -19,7 +19,7 @@
 
 <PageTitle>Add Sensor - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Add Sensor" FallbackUrl="@($"/organizations/{OrganizationId}/sensors")" MaxWidth="MaxWidth.Small">
+<EcoDataPageLayout Title="Add Sensor" FallbackUrl="@($"/organizations/{OrganizationId}/sensors")">
     <ChildContent>
         @if (LoadCommand.IsLoading)
         {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationCreatePage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationCreatePage.razor
@@ -11,7 +11,7 @@
 
 <PageTitle>Create Organization - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Create Organization" FallbackUrl="/organizations/discover" MaxWidth="MaxWidth.Small">
+<EcoDataPageLayout Title="Create Organization" FallbackUrl="/organizations/discover">
     <ChildContent>
         <MudPaper Elevation="1" Class="pa-6 rounded-lg">
             <OrganizationForm Model="_model" SubmitButtonText="Create" ErrorMessage="@_errorMessage"

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationEditPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationEditPage.razor
@@ -15,7 +15,7 @@
 
 <PageTitle>Edit Organization - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Edit Organization" FallbackUrl="@($"/organizations/{Id}")" MaxWidth="MaxWidth.Small">
+<EcoDataPageLayout Title="Edit Organization" FallbackUrl="@($"/organizations/{Id}")">
     <ChildContent>
         @if (LoadCommand.IsLoading)
         {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorConfigurePage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorConfigurePage.razor
@@ -1,0 +1,359 @@
+@page "/sensors/{SensorId:guid}/configure"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
+@using EcoData.Sensors.Application.Client
+@using EcoData.Sensors.Contracts.Dtos
+@using EcoData.Locations.Application.Client
+@using EcoData.Locations.Contracts.Dtos
+@using EcoPortal.Client.Services
+@using EcoPortal.Client.Components
+@using BlazingSingularity.Commands
+@using SensorPermissions = EcoData.Sensors.Contracts.Permissions
+@inject ISensorHttpClient SensorClient
+@inject ISensorHealthHttpClient HealthClient
+@inject IMunicipalityHttpClient MunicipalityClient
+@inject INavigationService Navigation
+@inject ISnackbar Snackbar
+@inject PermissionContextService PermissionContext
+@inject AuthStateService AuthState
+
+<PageTitle>Configure Sensor - EcoData</PageTitle>
+
+<EcoDataPageLayout Title="Configure Sensor" FallbackUrl="@($"/sensors/{SensorId}")">
+    <ChildContent>
+        @if (LoadCommand.IsLoading)
+        {
+            <MudStack Spacing="4">
+                <MudPaper Elevation="0" Class="pa-6 rounded-lg border-solid border mud-border-lines-default">
+                    <MudSkeleton Width="150px" Height="24px" Class="mb-4" />
+                    <MudGrid>
+                        @for (var i = 0; i < 6; i++)
+                        {
+                            <MudItem xs="12" sm="6">
+                                <MudSkeleton Width="80px" Height="14px" />
+                                <MudSkeleton Width="150px" Height="20px" Class="mt-1" />
+                            </MudItem>
+                        }
+                    </MudGrid>
+                </MudPaper>
+                <MudPaper Elevation="0" Class="pa-6 rounded-lg border-solid border mud-border-lines-default">
+                    <MudSkeleton Width="200px" Height="24px" Class="mb-4" />
+                    <MudSkeleton Width="100%" Height="56px" Class="mt-4" />
+                    <MudSkeleton Width="100%" Height="56px" Class="mt-4" />
+                </MudPaper>
+            </MudStack>
+        }
+        else if (_sensor is null || !_hasPermission)
+        {
+            <MudPaper Elevation="0" Class="pa-6 rounded-lg border-solid border mud-border-lines-default">
+                <MudStack AlignItems="AlignItems.Center">
+                    <MudIcon Icon="@Icons.Material.Filled.Error" Size="Size.Large" Color="Color.Error" />
+                    <MudText Typo="Typo.h6" Color="Color.Error" Class="mt-2">
+                        @(_sensor is null ? "Sensor not found" : "You don't have permission to configure this sensor")
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+        }
+        else
+        {
+            <MudStack Spacing="4">
+                @* Sensor Details Card *@
+                <MudPaper Elevation="0" Class="pa-6 rounded-lg border-solid border mud-border-lines-default">
+                    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-4">
+                        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                            <MudIcon Icon="@Icons.Material.Filled.Sensors" Color="Color.Primary" />
+                            <MudText Typo="Typo.h6">Sensor Details</MudText>
+                        </MudStack>
+                        <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small"
+                                   StartIcon="@Icons.Material.Filled.Edit" OnClick="NavigateToEdit">
+                            Edit Details
+                        </MudButton>
+                    </MudStack>
+
+                    <MudGrid Spacing="3">
+                        <MudItem xs="12" sm="6" md="4">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Name</MudText>
+                            <MudText Typo="Typo.body1">@_sensor.Name</MudText>
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">External ID</MudText>
+                            <MudText Typo="Typo.body1" Class="font-monospace">@_sensor.ExternalId</MudText>
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Status</MudText>
+                            <MudChip T="string" Color="@(_sensor.IsActive ? Color.Success : Color.Default)" Size="Size.Small">
+                                @(_sensor.IsActive ? "Active" : "Inactive")
+                            </MudChip>
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Location</MudText>
+                            <MudText Typo="Typo.body1">
+                                @if (_municipality is not null)
+                                {
+                                    @_municipality.Name@(", ")@_municipality.StateCode
+                                }
+                                else
+                                {
+                                    @_sensor.Latitude.ToString("F4")@(", ")@_sensor.Longitude.ToString("F4")
+                                }
+                            </MudText>
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Coordinates</MudText>
+                            <MudText Typo="Typo.body1" Class="font-monospace">
+                                @_sensor.Latitude.ToString("F6"), @_sensor.Longitude.ToString("F6")
+                            </MudText>
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Created</MudText>
+                            <MudText Typo="Typo.body1">@_sensor.CreatedAt.LocalDateTime.ToString("MMM d, yyyy")</MudText>
+                        </MudItem>
+                        @if (_sensor.DataSourceName is not null)
+                        {
+                            <MudItem xs="12" sm="6" md="4">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Data Source</MudText>
+                                <MudText Typo="Typo.body1">@_sensor.DataSourceName</MudText>
+                            </MudItem>
+                        }
+                    </MudGrid>
+                </MudPaper>
+
+                @* Health Monitoring Configuration Card *@
+                <MudPaper Elevation="0" Class="pa-6 rounded-lg border-solid border mud-border-lines-default">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="mb-4">
+                        <MudIcon Icon="@Icons.Material.Filled.MonitorHeart" Color="Color.Primary" />
+                        <MudText Typo="Typo.h6">Health Monitoring</MudText>
+                    </MudStack>
+
+                    @if (_healthConfig is null)
+                    {
+                        <MudStack AlignItems="AlignItems.Center" Class="pa-4" Spacing="2">
+                            <MudIcon Icon="@Icons.Material.Filled.HealthAndSafety" Size="Size.Large" Color="Color.Secondary" />
+                            <MudText Typo="Typo.body1" Color="Color.Secondary">
+                                Health monitoring is not configured for this sensor.
+                            </MudText>
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                       StartIcon="@Icons.Material.Filled.Add" OnClick="EnableHealthMonitoring"
+                                       Disabled="SaveCommand.IsLoading">
+                                Enable Health Monitoring
+                            </MudButton>
+                        </MudStack>
+                    }
+                    else
+                    {
+                        <MudForm @ref="_form">
+                            <MudGrid Spacing="3">
+                                <MudItem xs="12">
+                                    <MudSwitch @bind-Value="_isMonitoringEnabled" Color="Color.Primary"
+                                               Label="Enable Health Monitoring" />
+                                </MudItem>
+
+                                <MudItem xs="12" sm="6" md="4">
+                                    <MudNumericField @bind-Value="_expectedIntervalSeconds" Label="Expected Interval"
+                                                     Variant="Variant.Outlined" Adornment="Adornment.End"
+                                                     AdornmentText="seconds" Min="1" Required="true"
+                                                     HelperText="How often the sensor should report data" />
+                                </MudItem>
+
+                                <MudItem xs="12" sm="6" md="4">
+                                    <MudNumericField @bind-Value="_staleThresholdSeconds" Label="Stale Threshold"
+                                                     Variant="Variant.Outlined" Adornment="Adornment.End"
+                                                     AdornmentText="seconds" Min="1" Required="true"
+                                                     HelperText="Time before sensor is marked as stale" />
+                                </MudItem>
+
+                                <MudItem xs="12" sm="6" md="4">
+                                    <MudNumericField @bind-Value="_unhealthyThresholdSeconds" Label="Unhealthy Threshold"
+                                                     Variant="Variant.Outlined" Adornment="Adornment.End"
+                                                     AdornmentText="seconds" Min="1" Required="true"
+                                                     HelperText="Time before sensor is marked as unhealthy" />
+                                </MudItem>
+                            </MudGrid>
+
+                            @if (!string.IsNullOrEmpty(_errorMessage))
+                            {
+                                <MudAlert Severity="Severity.Error" Class="mt-4">@_errorMessage</MudAlert>
+                            }
+
+                            <MudStack Row="true" Justify="Justify.FlexEnd" Class="mt-6">
+                                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                           StartIcon="@Icons.Material.Filled.Save" OnClick="SaveHealthConfig"
+                                           Disabled="SaveCommand.IsLoading">
+                                    @if (SaveCommand.IsLoading)
+                                    {
+                                        <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                                        @:Saving...
+                                    }
+                                    else
+                                    {
+                                        @:Save Changes
+                                    }
+                                </MudButton>
+                            </MudStack>
+                        </MudForm>
+                    }
+                </MudPaper>
+
+                @* Health Status Card (if monitoring is enabled) *@
+                @if (_healthStatus is not null)
+                {
+                    <MudPaper Elevation="0" Class="pa-6 rounded-lg border-solid border mud-border-lines-default">
+                        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="mb-4">
+                            <MudIcon Icon="@Icons.Material.Filled.Analytics" Color="Color.Primary" />
+                            <MudText Typo="Typo.h6">Current Health Status</MudText>
+                        </MudStack>
+
+                        <MudGrid Spacing="3">
+                            <MudItem xs="12" sm="6" md="3">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Status</MudText>
+                                <MudChip T="string" Color="@GetHealthStatusColor()" Size="Size.Small">
+                                    @_healthStatus.Status
+                                </MudChip>
+                            </MudItem>
+                            <MudItem xs="12" sm="6" md="3">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Last Reading</MudText>
+                                <MudText Typo="Typo.body1">
+                                    @(_healthStatus.LastReadingAt?.LocalDateTime.ToString("g") ?? "Never")
+                                </MudText>
+                            </MudItem>
+                            <MudItem xs="12" sm="6" md="3">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Consecutive Failures</MudText>
+                                <MudText Typo="Typo.body1">@_healthStatus.ConsecutiveFailures</MudText>
+                            </MudItem>
+                            <MudItem xs="12" sm="6" md="3">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Last Updated</MudText>
+                                <MudText Typo="Typo.body1">@_healthStatus.UpdatedAt.LocalDateTime.ToString("g")</MudText>
+                            </MudItem>
+                            @if (!string.IsNullOrEmpty(_healthStatus.LastErrorMessage))
+                            {
+                                <MudItem xs="12">
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">Last Error</MudText>
+                                    <MudAlert Severity="Severity.Warning" Dense="true">
+                                        @_healthStatus.LastErrorMessage
+                                    </MudAlert>
+                                </MudItem>
+                            }
+                        </MudGrid>
+                    </MudPaper>
+                }
+            </MudStack>
+        }
+    </ChildContent>
+</EcoDataPageLayout>
+
+@code {
+    private MudForm? _form;
+    private SensorDtoForDetail? _sensor;
+    private MunicipalityDtoForDetail? _municipality;
+    private SensorHealthConfigDtoForDetail? _healthConfig;
+    private SensorHealthStatusDtoForDetail? _healthStatus;
+    private string? _errorMessage;
+    private bool _hasPermission;
+
+    // Form fields
+    private int _expectedIntervalSeconds = 300;
+    private int _staleThresholdSeconds = 600;
+    private int _unhealthyThresholdSeconds = 1800;
+    private bool _isMonitoringEnabled = true;
+
+    [Parameter]
+    public Guid SensorId { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadCommand.ExecuteAsync();
+    }
+
+    [RelayCommand]
+    private async Task Load()
+    {
+        _sensor = await SensorClient.GetByIdAsync(SensorId);
+
+        if (_sensor is null) return;
+
+        // Check permission
+        if (!AuthState.IsInitialized)
+        {
+            await AuthState.InitializeAsync();
+        }
+
+        _hasPermission = AuthState.IsGlobalAdmin ||
+            await PermissionContext.HasPermissionAsync(_sensor.OrganizationId, SensorPermissions.Sensor.Update);
+
+        if (!_hasPermission) return;
+
+        // Load municipality
+        _municipality = await MunicipalityClient.GetByIdAsync(_sensor.MunicipalityId);
+
+        // Load health config
+        var configResult = await HealthClient.GetSensorHealthConfigAsync(SensorId);
+        configResult.Switch(
+            config =>
+            {
+                _healthConfig = config;
+                _expectedIntervalSeconds = config.ExpectedIntervalSeconds;
+                _staleThresholdSeconds = config.StaleThresholdSeconds;
+                _unhealthyThresholdSeconds = config.UnhealthyThresholdSeconds;
+                _isMonitoringEnabled = config.IsMonitoringEnabled;
+            },
+            _ => _healthConfig = null // Config doesn't exist yet
+        );
+
+        // Load health status
+        var statusResult = await HealthClient.GetSensorHealthAsync(SensorId);
+        statusResult.Switch(
+            status => _healthStatus = status,
+            _ => _healthStatus = null
+        );
+    }
+
+    private async Task EnableHealthMonitoring()
+    {
+        // Set default values and save
+        _expectedIntervalSeconds = 300;
+        _staleThresholdSeconds = 600;
+        _unhealthyThresholdSeconds = 1800;
+        _isMonitoringEnabled = true;
+
+        await SaveHealthConfig();
+    }
+
+    private async Task SaveHealthConfig()
+    {
+        await SaveCommand.ExecuteAsync();
+    }
+
+    [RelayCommand]
+    private async Task Save()
+    {
+        _errorMessage = null;
+
+        var config = new SensorHealthConfigDtoForCreate(
+            _expectedIntervalSeconds,
+            _staleThresholdSeconds,
+            _unhealthyThresholdSeconds,
+            _isMonitoringEnabled
+        );
+
+        var result = await HealthClient.UpdateHealthConfigAsync(SensorId, config);
+
+        result.Switch(
+            updatedConfig =>
+            {
+                _healthConfig = updatedConfig;
+                Snackbar.Add("Health configuration saved successfully", Severity.Success);
+            },
+            problem => _errorMessage = problem.Detail ?? "Failed to save health configuration"
+        );
+    }
+
+    private void NavigateToEdit() => Navigation.NavigateTo($"/sensors/{SensorId}/edit", $"/sensors/{SensorId}/configure");
+
+    private Color GetHealthStatusColor() => _healthStatus?.Status switch
+    {
+        "Healthy" => Color.Success,
+        "Stale" => Color.Warning,
+        "Unhealthy" => Color.Error,
+        _ => Color.Default
+    };
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailAuthenticated.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailAuthenticated.razor
@@ -245,8 +245,8 @@
                 <QuickActionCard Icon="@Icons.Material.Filled.Download" Title="Export Data" Description="CSV, JSON, or PDF" />
                 <RequireOrganizationPermission Permission="@SensorPermissions.Sensor.Update"
                                                OrganizationId="Sensor.OrganizationId">
-                    <QuickActionCard Icon="@Icons.Material.Filled.Settings" Title="Configure Sensor" Description="Edit settings"
-                                     OnClick="NavigateToEdit" />
+                    <QuickActionCard Icon="@Icons.Material.Filled.Settings" Title="Configure Sensor" Description="Health & settings"
+                                     OnClick="NavigateToConfigure" />
                 </RequireOrganizationPermission>
             </div>
         </MudPaper>
@@ -321,6 +321,8 @@
         _ = _statsFetch.FetchAsync();
     }
 
+    private void NavigateToConfigure() => Navigation.NavigateTo($"/sensors/{Sensor.Id}/configure", $"/sensors/{Sensor.Id}");
+
     private void NavigateToEdit() => Navigation.NavigateTo($"/sensors/{Sensor.Id}/edit", $"/sensors/{Sensor.Id}");
 
     private async Task ConfirmDelete()
@@ -349,3 +351,4 @@
         }
     }
 }
+

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorEditPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorEditPage.razor
@@ -17,7 +17,7 @@
 
 <PageTitle>Edit Sensor - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Edit Sensor" FallbackUrl="@($"/sensors/{SensorId}")" MaxWidth="MaxWidth.Small">
+<EcoDataPageLayout Title="Edit Sensor" FallbackUrl="@($"/sensors/{SensorId}")">
     <ChildContent>
         @if (LoadCommand.IsLoading)
         {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorReadingsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorReadingsPage.razor
@@ -34,7 +34,7 @@
         }
         else
         {
-            <MudPaper Elevation="0" Class="pa-4 rounded-lg" Style="border: 1px solid var(--mud-palette-lines-default);">
+            <MudPaper Elevation="0" Class="pa-4 rounded-lg">
                 <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-4">
                     <MudStack Spacing="0">
                         <MudText Typo="Typo.h6">@_sensor.Name</MudText>
@@ -42,8 +42,8 @@
                     </MudStack>
                 </MudStack>
                 <SensorReadingsList @ref="_readingsList" SensorId="SensorId" ShowFilter="true"
-                                    OnFilterClick="OpenFilterDialog" ParameterFilter="@_parameterFilter"
-                                    FromDate="@_fromDate" ToDate="@_toDate" />
+                                    OnFilterClick="OpenFilterDialog" ParameterFilter="@_parameterFilter" FromDate="@_fromDate"
+                                    ToDate="@_toDate" />
             </MudPaper>
         }
     </ChildContent>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -140,9 +140,16 @@
     </MudDrawer>
 
     <MudMainContent Class="main-content">
-        <MudContainer MaxWidth="MaxWidth.Large" Class="py-6 px-4 content-container">
+        @if (IsHomePage)
+        {
             @Body
-        </MudContainer>
+        }
+        else
+        {
+            <MudContainer MaxWidth="MaxWidth.Large" Class="py-6 px-4 content-container">
+                @Body
+            </MudContainer>
+        }
         <Footer />
     </MudMainContent>
 </MudLayout>
@@ -150,6 +157,15 @@
 @code {
     private bool _drawerOpen = false;
     private bool _isDarkMode;
+
+    private bool IsHomePage
+    {
+        get
+        {
+            var uri = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+            return string.IsNullOrEmpty(uri) || uri == "/" || uri.StartsWith("?") || uri.StartsWith("#");
+        }
+    }
 
     private void ToggleDrawer() => _drawerOpen = !_drawerOpen;
     private void ToggleTheme() => _isDarkMode = !_isDarkMode;

--- a/src/Apps/EcoPortal/EcoPortal.Server/Workers/SensorHealthMonitorWorker.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Server/Workers/SensorHealthMonitorWorker.cs
@@ -17,7 +17,7 @@ public sealed class SensorHealthMonitorWorker(
     ILogger<SensorHealthMonitorWorker> logger
 ) : BackgroundService
 {
-    private static readonly TimeSpan CheckInterval = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan CheckInterval = TimeSpan.FromSeconds(30);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {

--- a/src/Features/Sensors/EcoData.Sensors.Application.Client/ISensorHealthHttpClient.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Application.Client/ISensorHealthHttpClient.cs
@@ -25,4 +25,10 @@ public interface ISensorHealthHttpClient
         Guid sensorId,
         CancellationToken cancellationToken = default
     );
+
+    Task<OneOf<SensorHealthConfigDtoForDetail, ProblemDetail>> UpdateHealthConfigAsync(
+        Guid sensorId,
+        SensorHealthConfigDtoForCreate config,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorHealthHttpClient.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorHealthHttpClient.cs
@@ -67,4 +67,19 @@ public sealed class SensorHealthHttpClient(HttpClient httpClient) : ISensorHealt
         var result = await response.Content.ReadFromJsonAsync<SensorHealthConfigDtoForDetail>(cancellationToken);
         return result!;
     }
+
+    public async Task<OneOf<SensorHealthConfigDtoForDetail, ProblemDetail>> UpdateHealthConfigAsync(
+        Guid sensorId,
+        SensorHealthConfigDtoForCreate config,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await httpClient.PutAsJsonAsync($"/api/sensors/{sensorId}/health/config", config, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+            return await response.ReadProblemAsync(cancellationToken);
+
+        var result = await response.Content.ReadFromJsonAsync<SensorHealthConfigDtoForDetail>(cancellationToken);
+        return result!;
+    }
 }

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/SensorHealthRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/SensorHealthRepository.cs
@@ -442,9 +442,16 @@ public sealed class SensorHealthRepository(IDbContextFactory<SensorsDbContext> c
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 
+        // Only monitor push-based sensors that are not already unhealthy
+        // - Healthy sensors: check if they've become stale
+        // - Stale sensors: check if they've become unhealthy
+        // - Unhealthy sensors: skip (can only become healthy when they report via RecordReadingAsync)
         return await context
             .SensorHealthStatuses.Where(s =>
-                s.Sensor!.HealthConfig != null && s.Sensor.HealthConfig.IsMonitoringEnabled
+                s.Sensor!.ReportingMode == ReportingMode.Push &&
+                s.Status != SensorHealthStatusType.Unhealthy &&
+                s.Sensor.HealthConfig != null &&
+                s.Sensor.HealthConfig.IsMonitoringEnabled
             )
             .Select(s => new MonitoredSensorHealthStatusDto(
                 s.Id,


### PR DESCRIPTION
## Summary
- Add new **Sensor Configuration Page** (`/sensors/{id}/configure`) for managing health monitoring settings
- **Standardize container layouts** across the app - HomePage gets full-bleed, other pages use consistent `MaxWidth.Large` container
- **Optimize health monitoring** - only query push-based, non-unhealthy sensors

## Changes

### Sensor Configuration Page
- View sensor details (name, external ID, location, status, coordinates, created date)
- Configure health monitoring thresholds:
  - Expected interval (seconds)
  - Stale threshold (seconds)
  - Unhealthy threshold (seconds)
  - Enable/disable monitoring
- View current health status (if available)
- "Edit Details" button to navigate to edit page

### Container Standardization
- `MainLayout`: Container is now conditional - skipped for HomePage to allow full-bleed sections
- `EcoDataPageLayout`: Removed nested `MudContainer`, now uses simple div with consistent styling
- Form pages: Removed `MaxWidth="MaxWidth.Small"` parameter - all pages now use same width

### Health Monitoring Optimization
- `SensorHealthRepository.GetMonitoredStatusesWithConfigAsync`: 
  - Only fetches push-based sensors (pull-based have different monitoring)
  - Skips unhealthy sensors (can only recover when they report data via `RecordReadingAsync`)

### Other
- Added `UpdateHealthConfigAsync` to `ISensorHealthHttpClient`
- Added `send_readings_dev.py` script for local development testing

## Test plan
- [ ] Navigate to sensor detail page and click "Configure Sensor" quick action
- [ ] Verify sensor details are displayed correctly
- [ ] Enable health monitoring and save configuration
- [ ] Verify health status card appears after configuration
- [ ] Test "Edit Details" button navigates to edit page
- [ ] Verify HomePage still has full-bleed sections
- [ ] Verify form pages (create/edit org, create/edit sensor) use full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)