### PR TITLE
feat: Add EcoData.NativeUi component library

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/EcoPortal.Client.csproj
+++ b/src/Apps/EcoPortal/EcoPortal.Client/EcoPortal.Client.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Contracts\EcoData.Locations.Contracts.csproj" />
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Application.Client\EcoData.Locations.Application.Client.csproj" />
     <ProjectReference Include="..\..\..\Features\Common\EcoData.Common.Pagination.Blazor\EcoData.Common.Pagination.Blazor.csproj" />
+    <ProjectReference Include="..\..\..\Features\Common\EcoData.NativeUi\EcoData.NativeUi.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Dialogs/RequestAccessDialog.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Dialogs/RequestAccessDialog.razor
@@ -14,13 +14,22 @@
     <DialogContent>
         <MudForm @ref="_form" @bind-IsValid="_isValid">
             <MudStack Spacing="4">
-                <MudText Typo="Typo.body2" Color="Color.Secondary">
-                    Select an organization to request access. An administrator will review your request.
-                </MudText>
-                <OrganizationSelect @bind-Value="_selectedOrganization"
-                                    Label="Organization"
-                                    Required="true"
-                                    RequiredError="Please select an organization" />
+                @if (IsOrganizationPreselected)
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        Request access to <strong>@PreselectedOrganization!.Name</strong>. An administrator will review your request.
+                    </MudText>
+                }
+                else
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        Select an organization to request access. An administrator will review your request.
+                    </MudText>
+                    <OrganizationSelect @bind-Value="_selectedOrganization"
+                                        Label="Organization"
+                                        Required="true"
+                                        RequiredError="Please select an organization" />
+                }
                 <MudTextField @bind-Value="_requestMessage"
                               Label="Message (Optional)"
                               Placeholder="Why would you like to join this organization?"
@@ -49,10 +58,24 @@
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = null!;
 
+    [Parameter]
+    public OrganizationDtoForList? PreselectedOrganization { get; set; }
+
     private MudForm _form = null!;
     private bool _isValid;
     private OrganizationDtoForList? _selectedOrganization;
     private string? _requestMessage;
+
+    private bool IsOrganizationPreselected => PreselectedOrganization is not null;
+
+    protected override void OnInitialized()
+    {
+        if (PreselectedOrganization is not null)
+        {
+            _selectedOrganization = PreselectedOrganization;
+            _isValid = true; // No required fields when org is preselected
+        }
+    }
 
     private void Cancel() => MudDialog.Cancel();
 

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
@@ -16,9 +16,11 @@
 @using BlazingSingularity.Commands
 @using BlazingSingularity.Fetch
 @implements IDisposable
+@using EcoPortal.Client.Features.OrganizationAccessRequests.Dialogs
 @using OrgPermissions = EcoData.Organization.Contracts.Permissions
 @using SensorPermissions = EcoData.Sensors.Contracts.Permissions
 @inject IOrganizationHttpClient OrganizationClient
+@inject AuthStateService AuthState
 @inject ISensorHttpClient SensorClient
 @inject IOrganizationMemberHttpClient MemberClient
 @inject INavigationService Navigation
@@ -125,10 +127,23 @@
                                 </MudTooltip>
                                 <RequireOrganizationPermission Permission="@OrgPermissions.Organization.Update"
                                                                OrganizationId="Id">
-                                    <MudTooltip Text="Edit Organization">
-                                        <MudIconButton Icon="@Icons.Material.Outlined.Edit" Color="Color.Primary"
-                                                       Variant="Variant.Filled" Size="Size.Medium" OnClick="NavigateToEdit" />
-                                    </MudTooltip>
+                                    <Authorized>
+                                        <MudTooltip Text="Edit Organization">
+                                            <MudIconButton Icon="@Icons.Material.Outlined.Edit" Color="Color.Primary"
+                                                           Variant="Variant.Filled" Size="Size.Medium" OnClick="NavigateToEdit" />
+                                        </MudTooltip>
+                                    </Authorized>
+                                    <NotAuthorized>
+                                        @if (AuthState.IsAuthenticated)
+                                        {
+                                            <MudTooltip Text="Request to join this organization">
+                                                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                                                           StartIcon="@Icons.Material.Outlined.PersonAdd" OnClick="OpenRequestAccessDialog">
+                                                    Request Access
+                                                </MudButton>
+                                            </MudTooltip>
+                                        }
+                                    </NotAuthorized>
                                 </RequireOrganizationPermission>
                                 <RequireOrganizationPermission Permission="@OrgPermissions.Organization.Delete"
                                                                OrganizationId="Id">
@@ -473,6 +488,29 @@
     public void Dispose()
     {
         _organizationFetch.Dispose();
+    }
+
+    private async Task OpenRequestAccessDialog()
+    {
+        if (_organizationFetch.Data is null) return;
+
+        var org = _organizationFetch.Data;
+        var orgForList = new OrganizationDtoForList(
+            Id: org.Id,
+            Name: org.Name,
+            ProfilePictureUrl: org.ProfilePictureUrl,
+            CardPictureUrl: org.CardPictureUrl,
+            AboutUs: org.AboutUs,
+            WebsiteUrl: org.WebsiteUrl,
+            CreatedAt: org.CreatedAt
+        );
+
+        var parameters = new DialogParameters<RequestAccessDialog>
+        {
+            { x => x.PreselectedOrganization, orgForList }
+        };
+
+        await DialogService.ShowAsync<RequestAccessDialog>("Request Access", parameters);
     }
 
     private void NavigateToEdit() => Navigation.NavigateTo($"/organizations/{Id}/edit", $"/organizations/{Id}");

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -19,9 +19,9 @@
 <MudLayout>
     <MudAppBar Elevation="0" Fixed="true" Class="app-bar-blur">
 
-        @* Mobile: Back button only (hidden on md+) *@
+        @* Mobile: Back button only (hidden on md+ and on Home page) *@
         <div class="d-flex d-md-none">
-            @if (Navigation.CanGoBack)
+            @if (Navigation.CanGoBack && !IsHomePage)
             {
                 <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Color="Color.Dark"
                                Class="back-btn-mobile" OnClick="NavigateBackAsync" />
@@ -73,6 +73,8 @@
                     </ActivatorContent>
                     <ChildContent>
                         <MudMenuItem Icon="@Icons.Material.Outlined.Person">Profile</MudMenuItem>
+                        <MudMenuItem Href="/organizations/my" Icon="@Icons.Material.Outlined.Business">My Organizations</MudMenuItem>
+                        <MudMenuItem Href="/organizations/requests" Icon="@Icons.Material.Outlined.HowToReg">My Access Requests</MudMenuItem>
                         <MudDivider />
                         <MudMenuItem OnClick="LogoutAsync" Icon="@Icons.Material.Outlined.Logout">Sign Out</MudMenuItem>
                     </ChildContent>

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiEmptyState.razor
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiEmptyState.razor
@@ -1,0 +1,65 @@
+@namespace EcoData.NativeUi
+
+<div class="@GetContainerClass()">
+    @if (!string.IsNullOrEmpty(Icon))
+    {
+        <div class="nui-empty-icon">
+            <MudIcon Icon="@Icon" Size="Size.Large" Color="Color.Secondary" />
+        </div>
+    }
+    <MudText Typo="Typo.h6" Class="nui-empty-title">@Title</MudText>
+    @if (!string.IsNullOrEmpty(Description))
+    {
+        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="nui-empty-description">
+            @Description
+        </MudText>
+    }
+    @if (ActionContent is not null)
+    {
+        <div class="nui-empty-action">
+            @ActionContent
+        </div>
+    }
+    else if (!string.IsNullOrEmpty(ActionText))
+    {
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   OnClick="OnActionClick"
+                   Class="nui-empty-action-btn">
+            @ActionText
+        </MudButton>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public string Title { get; set; } = default!;
+
+    [Parameter]
+    public string? Description { get; set; }
+
+    [Parameter]
+    public string? Icon { get; set; }
+
+    [Parameter]
+    public string? ActionText { get; set; }
+
+    [Parameter]
+    public EventCallback OnActionClick { get; set; }
+
+    [Parameter]
+    public RenderFragment? ActionContent { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string GetContainerClass()
+    {
+        var classes = new List<string> { "nui-empty-state" };
+
+        if (!string.IsNullOrEmpty(Class))
+            classes.Add(Class);
+
+        return string.Join(" ", classes);
+    }
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiEmptyState.razor.css
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiEmptyState.razor.css
@@ -1,0 +1,37 @@
+.nui-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 48px 24px;
+    gap: 8px;
+}
+
+.nui-empty-icon {
+    width: 64px;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--mud-palette-background-grey);
+    border-radius: 50%;
+    margin-bottom: 8px;
+}
+
+::deep .nui-empty-title {
+    font-weight: 600;
+    color: var(--mud-palette-text-primary);
+}
+
+::deep .nui-empty-description {
+    max-width: 320px;
+}
+
+.nui-empty-action {
+    margin-top: 16px;
+}
+
+::deep .nui-empty-action-btn {
+    margin-top: 16px;
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiIconBox.razor
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiIconBox.razor
@@ -1,0 +1,72 @@
+@namespace EcoData.NativeUi
+
+<div class="@GetContainerClass()">
+    <MudIcon Icon="@Icon" Size="@GetIconSize()" />
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public string Icon { get; set; } = default!;
+
+    [Parameter]
+    public Color Color { get; set; } = Color.Default;
+
+    [Parameter]
+    public NuiIconBoxSize Size { get; set; } = NuiIconBoxSize.Medium;
+
+    [Parameter]
+    public NuiIconBoxShape Shape { get; set; } = NuiIconBoxShape.Rounded;
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string GetContainerClass()
+    {
+        var colorClass = Color switch
+        {
+            Color.Primary => "nui-iconbox-primary",
+            Color.Secondary => "nui-iconbox-secondary",
+            Color.Info => "nui-iconbox-info",
+            Color.Success => "nui-iconbox-success",
+            Color.Warning => "nui-iconbox-warning",
+            Color.Error => "nui-iconbox-error",
+            _ => "nui-iconbox-default"
+        };
+
+        var sizeClass = Size switch
+        {
+            NuiIconBoxSize.Small => "nui-iconbox-sm",
+            NuiIconBoxSize.Large => "nui-iconbox-lg",
+            NuiIconBoxSize.ExtraLarge => "nui-iconbox-xl",
+            _ => ""
+        };
+
+        var shapeClass = Shape switch
+        {
+            NuiIconBoxShape.Circle => "nui-iconbox-circle",
+            NuiIconBoxShape.Square => "nui-iconbox-square",
+            _ => ""
+        };
+
+        var classes = new List<string> { "nui-iconbox", colorClass };
+
+        if (!string.IsNullOrEmpty(sizeClass))
+            classes.Add(sizeClass);
+
+        if (!string.IsNullOrEmpty(shapeClass))
+            classes.Add(shapeClass);
+
+        if (!string.IsNullOrEmpty(Class))
+            classes.Add(Class);
+
+        return string.Join(" ", classes);
+    }
+
+    private Size GetIconSize() => Size switch
+    {
+        NuiIconBoxSize.Small => MudBlazor.Size.Small,
+        NuiIconBoxSize.Large => MudBlazor.Size.Medium,
+        NuiIconBoxSize.ExtraLarge => MudBlazor.Size.Large,
+        _ => MudBlazor.Size.Small
+    };
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiIconBox.razor.css
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiIconBox.razor.css
@@ -1,0 +1,73 @@
+.nui-iconbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+}
+
+/* Size variants */
+.nui-iconbox-sm {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+}
+
+.nui-iconbox-lg {
+    width: 52px;
+    height: 52px;
+    border-radius: 12px;
+}
+
+.nui-iconbox-xl {
+    width: 64px;
+    height: 64px;
+    border-radius: 16px;
+}
+
+/* Shape variants */
+.nui-iconbox-circle {
+    border-radius: 50%;
+}
+
+.nui-iconbox-square {
+    border-radius: 0;
+}
+
+/* Color variants */
+.nui-iconbox-default {
+    background-color: var(--mud-palette-background-grey);
+    color: var(--mud-palette-text-secondary);
+}
+
+.nui-iconbox-primary {
+    background-color: var(--mud-palette-primary-lighten);
+    color: var(--mud-palette-primary);
+}
+
+.nui-iconbox-secondary {
+    background-color: var(--mud-palette-secondary-lighten);
+    color: var(--mud-palette-secondary);
+}
+
+.nui-iconbox-info {
+    background-color: var(--mud-palette-info-lighten);
+    color: var(--mud-palette-info);
+}
+
+.nui-iconbox-success {
+    background-color: var(--mud-palette-success-lighten);
+    color: var(--mud-palette-success);
+}
+
+.nui-iconbox-warning {
+    background-color: var(--mud-palette-warning-lighten);
+    color: var(--mud-palette-warning);
+}
+
+.nui-iconbox-error {
+    background-color: var(--mud-palette-error-lighten);
+    color: var(--mud-palette-error);
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiIconBoxEnums.cs
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiIconBoxEnums.cs
@@ -1,0 +1,16 @@
+namespace EcoData.NativeUi;
+
+public enum NuiIconBoxSize
+{
+    Small,
+    Medium,
+    Large,
+    ExtraLarge
+}
+
+public enum NuiIconBoxShape
+{
+    Rounded,
+    Circle,
+    Square
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiListItem.razor
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiListItem.razor
@@ -1,0 +1,101 @@
+@namespace EcoData.NativeUi
+
+<div class="@GetContainerClass()" @onclick="HandleClick">
+    @if (!string.IsNullOrEmpty(Icon))
+    {
+        <div class="@GetIconBoxClass()">
+            <MudIcon Icon="@Icon" Size="IconSize" />
+        </div>
+    }
+    <div class="nui-list-item-content">
+        <span class="nui-list-item-title">@Title</span>
+        @if (!string.IsNullOrEmpty(Subtitle))
+        {
+            <span class="nui-list-item-subtitle">@Subtitle</span>
+        }
+    </div>
+    @if (ShowChevron)
+    {
+        <MudIcon Icon="@Icons.Material.Filled.ChevronRight" Size="Size.Small" Class="nui-list-item-chevron" />
+    }
+    @if (TrailingContent is not null)
+    {
+        <div class="nui-list-item-trailing">
+            @TrailingContent
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public string Title { get; set; } = default!;
+
+    [Parameter]
+    public string? Subtitle { get; set; }
+
+    [Parameter]
+    public string? Icon { get; set; }
+
+    [Parameter]
+    public Size IconSize { get; set; } = Size.Small;
+
+    [Parameter]
+    public Color IconColor { get; set; } = Color.Default;
+
+    [Parameter]
+    public bool ShowChevron { get; set; } = true;
+
+    [Parameter]
+    public bool Bordered { get; set; }
+
+    [Parameter]
+    public EventCallback OnClick { get; set; }
+
+    [Parameter]
+    public RenderFragment? TrailingContent { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private bool IsClickable => OnClick.HasDelegate;
+
+    private string GetContainerClass()
+    {
+        var classes = new List<string> { "nui-list-item" };
+
+        if (IsClickable)
+            classes.Add("nui-list-item-clickable");
+
+        if (Bordered)
+            classes.Add("nui-list-item-bordered");
+
+        if (!string.IsNullOrEmpty(Class))
+            classes.Add(Class);
+
+        return string.Join(" ", classes);
+    }
+
+    private string GetIconBoxClass()
+    {
+        var colorClass = IconColor switch
+        {
+            Color.Primary => "nui-icon-primary",
+            Color.Secondary => "nui-icon-secondary",
+            Color.Info => "nui-icon-info",
+            Color.Success => "nui-icon-success",
+            Color.Warning => "nui-icon-warning",
+            Color.Error => "nui-icon-error",
+            _ => "nui-icon-default"
+        };
+
+        return $"nui-list-item-icon {colorClass}";
+    }
+
+    private async Task HandleClick()
+    {
+        if (OnClick.HasDelegate)
+        {
+            await OnClick.InvokeAsync();
+        }
+    }
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiListItem.razor.css
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiListItem.razor.css
@@ -1,0 +1,104 @@
+.nui-list-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    border-radius: 10px;
+    transition: background-color 0.15s ease;
+}
+
+.nui-list-item-clickable {
+    cursor: pointer;
+}
+
+.nui-list-item-clickable:hover {
+    background-color: var(--mud-palette-action-default-hover);
+}
+
+.nui-list-item-bordered {
+    border: 1px solid var(--mud-palette-lines-default);
+}
+
+/* Icon box */
+.nui-list-item-icon {
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    transition: all 0.15s ease;
+}
+
+/* Icon color variants */
+.nui-icon-default {
+    background-color: var(--mud-palette-background-grey);
+    color: var(--mud-palette-text-secondary);
+}
+
+.nui-icon-primary {
+    background-color: var(--mud-palette-primary-lighten);
+    color: var(--mud-palette-primary);
+}
+
+.nui-icon-secondary {
+    background-color: var(--mud-palette-secondary-lighten);
+    color: var(--mud-palette-secondary);
+}
+
+.nui-icon-info {
+    background-color: var(--mud-palette-info-lighten);
+    color: var(--mud-palette-info);
+}
+
+.nui-icon-success {
+    background-color: var(--mud-palette-success-lighten);
+    color: var(--mud-palette-success);
+}
+
+.nui-icon-warning {
+    background-color: var(--mud-palette-warning-lighten);
+    color: var(--mud-palette-warning);
+}
+
+.nui-icon-error {
+    background-color: var(--mud-palette-error-lighten);
+    color: var(--mud-palette-error);
+}
+
+/* Content */
+.nui-list-item-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.nui-list-item-title {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--mud-palette-text-primary);
+}
+
+.nui-list-item-subtitle {
+    font-size: 12px;
+    color: var(--mud-palette-text-secondary);
+}
+
+/* Chevron */
+::deep .nui-list-item-chevron {
+    flex-shrink: 0;
+    color: var(--mud-palette-text-disabled);
+    transition: color 0.15s ease;
+}
+
+.nui-list-item-clickable:hover ::deep .nui-list-item-chevron {
+    color: var(--mud-palette-text-secondary);
+}
+
+/* Trailing content */
+.nui-list-item-trailing {
+    flex-shrink: 0;
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiSectionHeader.razor
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiSectionHeader.razor
@@ -1,0 +1,60 @@
+@namespace EcoData.NativeUi
+
+<div class="@GetContainerClass()">
+    <div class="nui-section-header-content">
+        <MudText Typo="@TitleTypo" Class="nui-section-title">@Title</MudText>
+        @if (!string.IsNullOrEmpty(Subtitle))
+        {
+            <MudText Typo="Typo.body2" Color="Color.Secondary">@Subtitle</MudText>
+        }
+    </div>
+    @if (ActionContent is not null)
+    {
+        <div class="nui-section-header-action">
+            @ActionContent
+        </div>
+    }
+    else if (!string.IsNullOrEmpty(ActionText))
+    {
+        <MudButton Variant="Variant.Text"
+                   Color="Color.Primary"
+                   Size="Size.Small"
+                   OnClick="OnActionClick"
+                   Class="nui-section-action-btn">
+            @ActionText
+        </MudButton>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public string Title { get; set; } = default!;
+
+    [Parameter]
+    public string? Subtitle { get; set; }
+
+    [Parameter]
+    public Typo TitleTypo { get; set; } = Typo.h6;
+
+    [Parameter]
+    public string? ActionText { get; set; }
+
+    [Parameter]
+    public EventCallback OnActionClick { get; set; }
+
+    [Parameter]
+    public RenderFragment? ActionContent { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string GetContainerClass()
+    {
+        var classes = new List<string> { "nui-section-header" };
+
+        if (!string.IsNullOrEmpty(Class))
+            classes.Add(Class);
+
+        return string.Join(" ", classes);
+    }
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiSectionHeader.razor.css
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiSectionHeader.razor.css
@@ -1,0 +1,27 @@
+.nui-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.nui-section-header-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+::deep .nui-section-title {
+    font-weight: 600;
+}
+
+.nui-section-header-action {
+    flex-shrink: 0;
+}
+
+::deep .nui-section-action-btn {
+    text-transform: none;
+    font-weight: 500;
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiStatusBadge.razor
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiStatusBadge.razor
@@ -1,0 +1,70 @@
+@namespace EcoData.NativeUi
+
+<div class="@GetBadgeClass()">
+    @if (ShowDot)
+    {
+        <span class="@GetDotClass()"></span>
+    }
+    <span class="nui-status-text">@Text</span>
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public string Text { get; set; } = default!;
+
+    [Parameter]
+    public NuiStatusType Status { get; set; } = NuiStatusType.Default;
+
+    [Parameter]
+    public bool ShowDot { get; set; }
+
+    [Parameter]
+    public bool Animate { get; set; }
+
+    [Parameter]
+    public NuiStatusSize Size { get; set; } = NuiStatusSize.Medium;
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string GetBadgeClass()
+    {
+        var statusClass = Status switch
+        {
+            NuiStatusType.Active => "nui-status-active",
+            NuiStatusType.Inactive => "nui-status-inactive",
+            NuiStatusType.Pending => "nui-status-pending",
+            NuiStatusType.Success => "nui-status-success",
+            NuiStatusType.Warning => "nui-status-warning",
+            NuiStatusType.Error => "nui-status-error",
+            _ => "nui-status-default"
+        };
+
+        var sizeClass = Size switch
+        {
+            NuiStatusSize.Small => "nui-status-sm",
+            NuiStatusSize.Large => "nui-status-lg",
+            _ => ""
+        };
+
+        var classes = new List<string> { "nui-status-badge", statusClass };
+
+        if (!string.IsNullOrEmpty(sizeClass))
+            classes.Add(sizeClass);
+
+        if (!string.IsNullOrEmpty(Class))
+            classes.Add(Class);
+
+        return string.Join(" ", classes);
+    }
+
+    private string GetDotClass()
+    {
+        var classes = new List<string> { "nui-status-dot" };
+
+        if (Animate)
+            classes.Add("nui-status-dot-animate");
+
+        return string.Join(" ", classes);
+    }
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiStatusBadge.razor.css
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiStatusBadge.razor.css
@@ -1,0 +1,97 @@
+.nui-status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 9999px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    line-height: 1;
+}
+
+/* Size variants */
+.nui-status-sm {
+    padding: 2px 8px;
+    font-size: 10px;
+    gap: 4px;
+}
+
+.nui-status-lg {
+    padding: 6px 14px;
+    font-size: 12px;
+    gap: 8px;
+}
+
+/* Status variants */
+.nui-status-default {
+    background-color: var(--mud-palette-background-grey);
+    color: var(--mud-palette-text-secondary);
+}
+
+.nui-status-active {
+    background-color: rgba(14, 165, 233, 0.1);
+    color: #0c4a6e;
+}
+
+.nui-status-inactive {
+    background-color: rgba(120, 113, 108, 0.1);
+    color: #78716c;
+}
+
+.nui-status-pending {
+    background-color: rgba(251, 191, 36, 0.1);
+    color: #92400e;
+}
+
+.nui-status-success {
+    background-color: var(--mud-palette-success-lighten);
+    color: var(--mud-palette-success-darken);
+}
+
+.nui-status-warning {
+    background-color: var(--mud-palette-warning-lighten);
+    color: var(--mud-palette-warning-darken);
+}
+
+.nui-status-error {
+    background-color: var(--mud-palette-error-lighten);
+    color: var(--mud-palette-error-darken);
+}
+
+/* Dot */
+.nui-status-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: currentColor;
+}
+
+.nui-status-sm .nui-status-dot {
+    width: 5px;
+    height: 5px;
+}
+
+.nui-status-lg .nui-status-dot {
+    width: 8px;
+    height: 8px;
+}
+
+/* Animated dot */
+.nui-status-dot-animate {
+    animation: nui-pulse 2s infinite;
+}
+
+@keyframes nui-pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}
+
+.nui-status-text {
+    line-height: 1;
+}

--- a/src/Features/Common/EcoData.NativeUi/Components/NuiStatusType.cs
+++ b/src/Features/Common/EcoData.NativeUi/Components/NuiStatusType.cs
@@ -1,0 +1,19 @@
+namespace EcoData.NativeUi;
+
+public enum NuiStatusType
+{
+    Default,
+    Active,
+    Inactive,
+    Pending,
+    Success,
+    Warning,
+    Error
+}
+
+public enum NuiStatusSize
+{
+    Small,
+    Medium,
+    Large
+}

--- a/src/Features/Common/EcoData.NativeUi/EcoData.NativeUi.csproj
+++ b/src/Features/Common/EcoData.NativeUi/EcoData.NativeUi.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.4" />
+    <PackageReference Include="MudBlazor" Version="9.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Features/Common/EcoData.NativeUi/_Imports.razor
+++ b/src/Features/Common/EcoData.NativeUi/_Imports.razor
@@ -1,0 +1,3 @@
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Routing
+@using MudBlazor


### PR DESCRIPTION
## Summary
- Introduces a new Blazor class library (`EcoData.NativeUi`) for reusable UI components
- Establishes a foundation for consistent UI patterns across the application
- Reduces need for custom CSS by providing pre-styled, configurable components

## Components
| Component | Description |
|-----------|-------------|
| **NuiListItem** | Unified list item (replaces QuickActionCard/ActionListItem) with icon, title, subtitle, and optional chevron |
| **NuiStatusBadge** | Status indicators with variants (Active, Inactive, Pending, Success, Warning, Error) |
| **NuiIconBox** | Colored icon container with size (sm/md/lg/xl) and shape (rounded/circle/square) options |
| **NuiSectionHeader** | Section titles with optional subtitle and action button |
| **NuiEmptyState** | Consistent empty/no-data messaging with icon, description, and CTA |

## Usage Example
```razor
@using EcoData.NativeUi

<NuiListItem Title="My Organizations"
             Subtitle="View your organizations"
             Icon="@Icons.Material.Filled.Business"
             IconColor="Color.Primary"
             OnClick="@(() => Nav.NavigateTo("/organizations/my"))" />

<NuiStatusBadge Text="Active" Status="NuiStatusType.Active" ShowDot Animate />
```

## Test plan
- [x] Project builds successfully
- [ ] Verify components render correctly in EcoPortal.Client
- [ ] Test all component variants and props