### PR TITLE
feat: Implement robust tab-based navigation system

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/EcoDataPageLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/EcoDataPageLayout.razor
@@ -2,7 +2,7 @@
 @inject INavigationService Navigation
 
 <div class="page-container mt-4 mb-8">
-    @if (!string.IsNullOrEmpty(FallbackUrl))
+    @if (!string.IsNullOrEmpty(ParentPath))
     {
         <MudButton Variant="Variant.Text"
                    StartIcon="@Icons.Material.Filled.ArrowBack"
@@ -57,7 +57,7 @@
     public string? Title { get; set; }
 
     [Parameter]
-    public string? FallbackUrl { get; set; }
+    public string? ParentPath { get; set; }
 
     [Parameter]
     public RenderFragment? Actions { get; set; }
@@ -65,22 +65,11 @@
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
-    private bool _fallbackSet;
-
     protected override void OnAfterRender(bool firstRender)
     {
-        if (firstRender && !_fallbackSet)
+        if (firstRender && ParentPath is not null)
         {
-            _fallbackSet = true;
-            // Prioritize return URL from navigation over the page's hardcoded fallback
-            if (FallbackUrl is not null)
-            {
-                Navigation.SetReturnUrlOrFallback(FallbackUrl);
-            }
-            else
-            {
-                Navigation.SetFallback(null);
-            }
+            Navigation.SetParentPath(ParentPath);
         }
     }
 

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/HealthAlerts/Pages/AlertDetailPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/HealthAlerts/Pages/AlertDetailPage.razor
@@ -7,7 +7,7 @@
 
 <PageTitle>Alert Details - EcoData</PageTitle>
 
-<EcoDataPageLayout FallbackUrl="/alerts">
+<EcoDataPageLayout ParentPath="/alerts">
     <ChildContent>
         @if (_loading)
         {
@@ -124,7 +124,7 @@
     {
         if (_alert is not null)
         {
-            Navigation.NavigateTo($"/sensors/{_alert.SensorId}", $"/alerts/{AlertId}");
+            Navigation.NavigateTo($"/sensors/{_alert.SensorId}");
         }
     }
 

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/MyAccessRequestsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/MyAccessRequestsPage.razor
@@ -177,7 +177,7 @@
 
     private void NavigateToBrowse() => Navigation.NavigateTo("/organizations/discover");
 
-    private void NavigateToOrganization(Guid organizationId) => Navigation.NavigateTo($"/organizations/{organizationId}", "/organizations/requests");
+    private void NavigateToOrganization(Guid organizationId) => Navigation.NavigateTo($"/organizations/{organizationId}");
 
     private async Task OpenRequestAccessDialog()
     {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/OrganizationAccessRequestsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/OrganizationAccessRequestsPage.razor
@@ -18,7 +18,7 @@
 
 <PageTitle>Requests - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Requests" FallbackUrl="@($"/organizations/{OrganizationId}/team")">
+<EcoDataPageLayout Title="Requests" ParentPath="@($"/organizations/{OrganizationId}/team")">
     <ChildContent>
         <RequireOrganizationPermission OrganizationId="OrganizationId" Permission="EcoData.Organization.Contracts.Permissions.Organization.ManageMembers">
             <Authorized>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Pages/OrganizationTeamPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Pages/OrganizationTeamPage.razor
@@ -22,7 +22,7 @@
 
 <PageTitle>Members - @(_organization?.Name ?? "Organization") - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Team" FallbackUrl="@($"/organizations/{OrganizationId}")">
+<EcoDataPageLayout Title="Team" ParentPath="@($"/organizations/{OrganizationId}")">
     <Actions>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Inbox"
                    Href="@($"/organizations/{OrganizationId}/requests")">

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationSensors/Pages/OrganizationSensorCreatePage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationSensors/Pages/OrganizationSensorCreatePage.razor
@@ -19,7 +19,7 @@
 
 <PageTitle>Add Sensor - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Add Sensor" FallbackUrl="@($"/organizations/{OrganizationId}/sensors")">
+<EcoDataPageLayout Title="Add Sensor" ParentPath="@($"/organizations/{OrganizationId}/sensors")">
     <ChildContent>
         @if (LoadCommand.IsLoading)
         {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationSensors/Pages/OrganizationSensorsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationSensors/Pages/OrganizationSensorsPage.razor
@@ -16,7 +16,7 @@
 
 <PageTitle>Sensors - @(_organization?.Name ?? "Organization") - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Sensors" FallbackUrl="@($"/organizations/{OrganizationId}")">
+<EcoDataPageLayout Title="Sensors" ParentPath="@($"/organizations/{OrganizationId}")">
     <Actions>
         <RequireOrganizationPermission Permission="@Permissions.Sensor.Create" OrganizationId="OrganizationId">
             <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
@@ -54,10 +54,10 @@
         );
     }
 
-    private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{OrganizationId}/sensors/create", $"/organizations/{OrganizationId}/sensors");
+    private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{OrganizationId}/sensors/create");
 
     private void NavigateToDetail(SensorDtoForList sensor)
     {
-        Navigation.NavigateTo($"/sensors/{sensor.Id}", $"/organizations/{OrganizationId}/sensors");
+        Navigation.NavigateTo($"/sensors/{sensor.Id}");
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/DiscoverOrganizationsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/DiscoverOrganizationsPage.razor
@@ -116,7 +116,7 @@
 
     private void NavigateToDetails(OrganizationDtoForList organization)
     {
-        Navigation.NavigateTo($"/organizations/{organization.Id}", "/organizations/discover");
+        Navigation.NavigateTo($"/organizations/{organization.Id}");
     }
 
     private void ClearSearch()

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/MyOrganizationsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/MyOrganizationsPage.razor
@@ -111,6 +111,6 @@
 
     private void NavigateToOrganization(MyOrganizationDto organization)
     {
-        Navigation.NavigateTo($"/organizations/{organization.Id}", "/organizations/my");
+        Navigation.NavigateTo($"/organizations/{organization.Id}");
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationCreatePage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationCreatePage.razor
@@ -11,7 +11,7 @@
 
 <PageTitle>Create Organization - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Create Organization" FallbackUrl="/organizations/discover">
+<EcoDataPageLayout Title="Create Organization" ParentPath="/organizations/discover">
     <ChildContent>
         <MudPaper Elevation="1" Class="pa-6 rounded-lg">
             <OrganizationForm Model="_model" SubmitButtonText="Create" ErrorMessage="@_errorMessage"

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
@@ -30,7 +30,7 @@
 
 <PageTitle>@(_viewModel?.PageTitle ?? "Organization - EcoData")</PageTitle>
 
-<EcoDataPageLayout FallbackUrl="/organizations/discover">
+<EcoDataPageLayout ParentPath="/organizations/discover">
     <ChildContent>
         @if (_viewModel is null && _organizationFetch.IsLoading)
         {
@@ -513,14 +513,12 @@
         await DialogService.ShowAsync<RequestAccessDialog>("Request Access", parameters);
     }
 
-    private void NavigateToEdit() => Navigation.NavigateTo($"/organizations/{Id}/edit", $"/organizations/{Id}");
-    private void NavigateToSensors() => Navigation.NavigateTo($"/organizations/{Id}/sensors", $"/organizations/{Id}");
-    private void NavigateToTeam() => Navigation.NavigateTo($"/organizations/{Id}/team", $"/organizations/{Id}");
-    private void NavigateToMap() => Navigation.NavigateTo($"/organizations/{Id}/map", $"/organizations/{Id}");
-    private void NavigateToSensor(SensorDtoForList sensor) => Navigation.NavigateTo($"/sensors/{sensor.Id}",
-    $"/organizations/{Id}");
-    private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{Id}/sensors/create",
-    $"/organizations/{Id}");
+    private void NavigateToEdit() => Navigation.NavigateTo($"/organizations/{Id}/edit");
+    private void NavigateToSensors() => Navigation.NavigateTo($"/organizations/{Id}/sensors");
+    private void NavigateToTeam() => Navigation.NavigateTo($"/organizations/{Id}/team");
+    private void NavigateToMap() => Navigation.NavigateTo($"/organizations/{Id}/map");
+    private void NavigateToSensor(SensorDtoForList sensor) => Navigation.NavigateTo($"/sensors/{sensor.Id}");
+    private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{Id}/sensors/create");
 
     private async Task ConfirmDelete()
     {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationEditPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationEditPage.razor
@@ -15,7 +15,7 @@
 
 <PageTitle>Edit Organization - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Edit Organization" FallbackUrl="@($"/organizations/{Id}")">
+<EcoDataPageLayout Title="Edit Organization" ParentPath="@($"/organizations/{Id}")">
     <ChildContent>
         @if (LoadCommand.IsLoading)
         {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationMapPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationMapPage.razor
@@ -149,7 +149,7 @@
 
     private void NavigateToSensor(Guid sensorId)
     {
-        Navigation.NavigateTo($"/sensors/{sensorId}", $"/organizations/{Id}/map");
+        Navigation.NavigateTo($"/sensors/{sensorId}");
     }
 
     private void NavigateBack()

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorConfigurePage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorConfigurePage.razor
@@ -19,7 +19,7 @@
 
 <PageTitle>Configure Sensor - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Configure Sensor" FallbackUrl="@($"/sensors/{SensorId}")">
+<EcoDataPageLayout Title="Configure Sensor" ParentPath="@($"/sensors/{SensorId}")">
     <ChildContent>
         @if (LoadCommand.IsLoading)
         {
@@ -347,7 +347,7 @@
         );
     }
 
-    private void NavigateToEdit() => Navigation.NavigateTo($"/sensors/{SensorId}/edit", $"/sensors/{SensorId}/configure");
+    private void NavigateToEdit() => Navigation.NavigateTo($"/sensors/{SensorId}/edit");
 
     private Color GetHealthStatusColor() => _healthStatus?.Status switch
     {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/Components/SensorReadingsPreview.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/Components/SensorReadingsPreview.razor
@@ -2,8 +2,9 @@
 @using EcoData.Sensors.Contracts.Parameters
 @using EcoData.Sensors.Application.Client
 @using EcoPortal.Client.Features.Sensors.Components
+@using EcoPortal.Client.Services
 @inject ISensorReadingHttpClient ReadingClient
-@inject NavigationManager NavigationManager
+@inject INavigationService Navigation
 
 @if (_loading)
 {
@@ -95,6 +96,6 @@ else
 
     private void NavigateToReadings()
     {
-        NavigationManager.NavigateTo($"/sensors/{SensorId}/readings");
+        Navigation.NavigateTo($"/sensors/{SensorId}/readings");
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailAuthenticated.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailAuthenticated.razor
@@ -321,9 +321,9 @@
         _ = _statsFetch.FetchAsync();
     }
 
-    private void NavigateToConfigure() => Navigation.NavigateTo($"/sensors/{Sensor.Id}/configure", $"/sensors/{Sensor.Id}");
+    private void NavigateToConfigure() => Navigation.NavigateTo($"/sensors/{Sensor.Id}/configure");
 
-    private void NavigateToEdit() => Navigation.NavigateTo($"/sensors/{Sensor.Id}/edit", $"/sensors/{Sensor.Id}");
+    private void NavigateToEdit() => Navigation.NavigateTo($"/sensors/{Sensor.Id}/edit");
 
     private async Task ConfirmDelete()
     {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailPage.razor
@@ -7,7 +7,7 @@
 
 <PageTitle>@(_sensor?.Name ?? "Sensor") - EcoData</PageTitle>
 
-<EcoDataPageLayout FallbackUrl="/sensors">
+<EcoDataPageLayout ParentPath="/sensors">
     <ChildContent>
         @if (_loading)
         {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorEditPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorEditPage.razor
@@ -17,7 +17,7 @@
 
 <PageTitle>Edit Sensor - EcoData</PageTitle>
 
-<EcoDataPageLayout Title="Edit Sensor" FallbackUrl="@($"/sensors/{SensorId}")">
+<EcoDataPageLayout Title="Edit Sensor" ParentPath="@($"/sensors/{SensorId}")">
     <ChildContent>
         @if (LoadCommand.IsLoading)
         {
@@ -128,7 +128,7 @@
             _ =>
             {
                 Snackbar.Add("Sensor updated successfully", Severity.Success);
-                Navigation.NavigateTo($"/sensors/{SensorId}", replace: true);
+                Navigation.NavigateWithReplace($"/sensors/{SensorId}");
             },
             problem => _errorMessage = problem.Detail ?? "Failed to update sensor"
         );

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorReadingsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorReadingsPage.razor
@@ -11,7 +11,7 @@
 
 <PageTitle>@(_sensor?.Name ?? "Sensor") Readings - EcoData</PageTitle>
 
-<EcoDataPageLayout FallbackUrl="@($"/sensors/{SensorId}")">
+<EcoDataPageLayout ParentPath="@($"/sensors/{SensorId}")">
     <ChildContent>
         @if (_loading)
         {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorsPage.razor
@@ -22,6 +22,6 @@
 @code {
     private void NavigateToDetail(SensorDtoForList sensor)
     {
-        Navigation.NavigateTo($"/sensors/{sensor.Id}", "/sensors");
+        Navigation.NavigateTo($"/sensors/{sensor.Id}");
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -8,7 +8,6 @@
 @inject AuthStateService AuthState
 @inject ClientAuthStateProvider AuthStateProvider
 @inject INavigationService Navigation
-@inject NavigationManager NavigationManager
 @implements IDisposable
 
 <MudThemeProvider Theme="AppThemes.Azure" IsDarkMode="_isDarkMode" />
@@ -112,29 +111,29 @@
 @* Mobile Bottom Navigation (hidden on md+) - Outside MudLayout for stability *@
 <div class="d-md-none bottom-nav">
     <MudStack Row="true" Justify="Justify.SpaceAround" AlignItems="AlignItems.Center" Class="bottom-nav-container">
-        <MudButton Variant="Variant.Text" Color="@GetBottomNavColor("/")" Class="bottom-nav-item"
-                   OnClick="@(() => NavigateToBottomNav("/"))">
+        <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Home)" Class="bottom-nav-item"
+                   OnClick="@(() => NavigateToBottomNav(NavigationTab.Home))">
             <MudStack AlignItems="AlignItems.Center" Spacing="0">
                 <MudIcon Icon="@Icons.Material.Filled.Home" Size="Size.Medium" />
                 <MudText Typo="Typo.caption">Home</MudText>
             </MudStack>
         </MudButton>
-        <MudButton Variant="Variant.Text" Color="@GetBottomNavColor("/monitor")" Class="bottom-nav-item"
-                   OnClick="@(() => NavigateToBottomNav("/monitor"))">
+        <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Monitor)" Class="bottom-nav-item"
+                   OnClick="@(() => NavigateToBottomNav(NavigationTab.Monitor))">
             <MudStack AlignItems="AlignItems.Center" Spacing="0">
                 <MudIcon Icon="@Icons.Material.Filled.Sensors" Size="Size.Medium" />
                 <MudText Typo="Typo.caption">Monitor</MudText>
             </MudStack>
         </MudButton>
-        <MudButton Variant="Variant.Text" Color="@GetBottomNavColor("/orgs")" Class="bottom-nav-item"
-                   OnClick="@(() => NavigateToBottomNav("/orgs"))">
+        <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Orgs)" Class="bottom-nav-item"
+                   OnClick="@(() => NavigateToBottomNav(NavigationTab.Orgs))">
             <MudStack AlignItems="AlignItems.Center" Spacing="0">
                 <MudIcon Icon="@Icons.Material.Filled.Groups" Size="Size.Medium" />
                 <MudText Typo="Typo.caption">Orgs</MudText>
             </MudStack>
         </MudButton>
-        <MudButton Variant="Variant.Text" Color="@GetBottomNavColor("/account")" Class="bottom-nav-item"
-                   OnClick="@(() => NavigateToBottomNav("/account"))">
+        <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Account)" Class="bottom-nav-item"
+                   OnClick="@(() => NavigateToBottomNav(NavigationTab.Account))">
             <MudStack AlignItems="AlignItems.Center" Spacing="0">
                 <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Medium" />
                 <MudText Typo="Typo.caption">Account</MudText>
@@ -148,14 +147,7 @@
     private string _pageTransitionClass = "";
     private string _navigationKey = Guid.NewGuid().ToString();
 
-    private bool IsHomePage
-    {
-        get
-        {
-            var uri = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
-            return string.IsNullOrEmpty(uri) || uri == "/" || uri.StartsWith("?") || uri.StartsWith("#");
-        }
-    }
+    private bool IsHomePage => Navigation.CurrentTab == NavigationTab.Home;
 
     private async Task NavigateBackAsync()
     {
@@ -167,11 +159,15 @@
         AuthState.SetAuthStateProvider(AuthStateProvider);
         AuthState.OnAuthStateChanged += HandleAuthStateChanged;
         Navigation.OnStateChanged += HandleNavigationStateChanged;
-        NavigationManager.LocationChanged += HandleLocationChanged;
         await AuthState.InitializeAsync();
     }
 
-    private void HandleLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    private void HandleAuthStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleNavigationStateChanged()
     {
         _pageTransitionClass = Navigation.Direction switch
         {
@@ -183,16 +179,6 @@
         InvokeAsync(StateHasChanged);
     }
 
-    private void HandleAuthStateChanged()
-    {
-        InvokeAsync(StateHasChanged);
-    }
-
-    private void HandleNavigationStateChanged()
-    {
-        InvokeAsync(StateHasChanged);
-    }
-
     private string GetUserInitial()
     {
         var name = AuthState.CurrentUser?.DisplayName;
@@ -201,36 +187,22 @@
 
     private string GetNavLinkClass(string path)
     {
-        var currentUri = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        var currentPath = Navigation.CurrentPath;
         var isActive = path == "/"
-            ? string.IsNullOrEmpty(currentUri) || currentUri == "/"
-            : currentUri.StartsWith(path.TrimStart('/'), StringComparison.OrdinalIgnoreCase);
+            ? currentPath == "/"
+            : currentPath.StartsWith(path, StringComparison.OrdinalIgnoreCase);
 
         return isActive ? "nav-link-active" : "nav-link";
     }
 
-    private Color GetBottomNavColor(string path)
+    private Color GetBottomNavColor(NavigationTab tab)
     {
-        var currentUri = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
-
-        var isActive = path switch
-        {
-            "/" => string.IsNullOrEmpty(currentUri) || currentUri == "/",
-            "/monitor" => currentUri.StartsWith("monitor", StringComparison.OrdinalIgnoreCase)
-                       || currentUri.StartsWith("sensors", StringComparison.OrdinalIgnoreCase)
-                       || currentUri.StartsWith("alerts", StringComparison.OrdinalIgnoreCase),
-            "/orgs" => currentUri.StartsWith("orgs", StringComparison.OrdinalIgnoreCase)
-                    || currentUri.StartsWith("organizations", StringComparison.OrdinalIgnoreCase)
-                    || currentUri.StartsWith("access-requests", StringComparison.OrdinalIgnoreCase),
-            _ => currentUri.StartsWith(path.TrimStart('/'), StringComparison.OrdinalIgnoreCase)
-        };
-
-        return isActive ? Color.Primary : Color.Default;
+        return Navigation.CurrentTab == tab ? Color.Primary : Color.Default;
     }
 
-    private void NavigateToBottomNav(string path)
+    private void NavigateToBottomNav(NavigationTab tab)
     {
-        NavigationManager.NavigateTo(path);
+        Navigation.NavigateToTab(tab);
     }
 
     [RelayCommand]
@@ -248,6 +220,5 @@
     {
         AuthState.OnAuthStateChanged -= HandleAuthStateChanged;
         Navigation.OnStateChanged -= HandleNavigationStateChanged;
-        NavigationManager.LocationChanged -= HandleLocationChanged;
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Pages/AccountPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Pages/AccountPage.razor
@@ -4,7 +4,7 @@
 @using EcoPortal.Client.Components
 @using EcoPortal.Client.Services
 @inject AuthStateService AuthState
-@inject NavigationManager NavigationManager
+@inject INavigationService Navigation
 
 <PageTitle>Account - EcoData</PageTitle>
 
@@ -107,7 +107,7 @@
     private async Task Logout()
     {
         await AuthState.LogoutAsync();
-        NavigationManager.NavigateTo("/");
+        Navigation.NavigateToTab(NavigationTab.Home);
     }
 
     private async Task LogoutAsync()

--- a/src/Apps/EcoPortal/EcoPortal.Client/Pages/LoginPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Pages/LoginPage.razor
@@ -6,7 +6,7 @@
 @using BlazingSingularity
 @using BlazingSingularity.Commands
 @inject AuthStateService AuthState
-@inject NavigationManager Navigation
+@inject INavigationService Navigation
 
 <PageTitle>Login - EcoData</PageTitle>
 

--- a/src/Apps/EcoPortal/EcoPortal.Client/Pages/NotFoundPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Pages/NotFoundPage.razor
@@ -1,5 +1,6 @@
 @page "/not-found"
-@inject NavigationManager Navigation
+@using EcoPortal.Client.Services
+@inject INavigationService Navigation
 
 <PageTitle>Page Not Found - EcoData</PageTitle>
 
@@ -38,6 +39,6 @@
 @code {
     private void GoBack()
     {
-        Navigation.NavigateTo("/");
+        Navigation.NavigateToTab(NavigationTab.Home);
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Pages/RegisterPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Pages/RegisterPage.razor
@@ -5,8 +5,9 @@
 @using EcoData.Identity.Contracts.Requests
 @using BlazingSingularity
 @using BlazingSingularity.Commands
+@using EcoPortal.Client.Services
 @inject IAuthHttpClient AuthClient
-@inject NavigationManager Navigation
+@inject INavigationService Navigation
 
 <PageTitle>Register - EcoData</PageTitle>
 

--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/NavigationService.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/NavigationService.cs
@@ -11,126 +11,182 @@ public enum NavigationDirection
     Back
 }
 
+public enum NavigationTab
+{
+    Home,
+    Monitor,
+    Orgs,
+    Account
+}
+
 public interface INavigationService
 {
+    // State (read-only)
     string CurrentUri { get; }
     string CurrentPath { get; }
-    string? ReturnUrl { get; }
+    NavigationTab CurrentTab { get; }
+    bool CanGoBack { get; }
     NavigationDirection Direction { get; }
 
-    void NavigateTo(string uri, bool replace = false);
-    void NavigateTo(string uri, string returnUrl);
-    Task GoBackAsync(string? fallback = null);
-    void GoBack(string? fallback = null);
+    // Navigation methods - these are the ONLY ways to navigate
+    void NavigateTo(string uri);
+    void NavigateWithReplace(string uri);
+    void NavigateToTab(NavigationTab tab);
+    Task GoBackAsync();
+    void GoBack();
 
-    void SetFallback(string? path);
-    void SetReturnUrlOrFallback(string fallback);
-    bool CanGoBack { get; }
+    // For deep link handling - pages can set their logical parent
+    void SetParentPath(string parentPath);
 
     event Action? OnStateChanged;
 }
 
 public sealed class NavigationService : INavigationService, IDisposable
 {
-    private readonly NavigationManager _navigationManager;
-    private readonly IJSRuntime _jsRuntime;
-    private readonly List<string> _history = [];
-    private string? _fallbackPath;
-    private string? _returnUrl;
+    private readonly NavigationManager _nav;  // Private, never exposed
+    private readonly IJSRuntime _js;
+
+    private NavigationTab _currentTab;
+    private int _depth;                    // 0 = at tab root
+    private string? _parentPath;           // For deep link back navigation
     private bool _isNavigatingBack;
     private NavigationDirection _direction = NavigationDirection.None;
 
     public NavigationService(NavigationManager navigationManager, IJSRuntime jsRuntime)
     {
-        _navigationManager = navigationManager;
-        _jsRuntime = jsRuntime;
-        _navigationManager.LocationChanged += OnLocationChanged;
+        _nav = navigationManager;
+        _js = jsRuntime;
+        _nav.LocationChanged += OnLocationChanged;
 
         // Initialize with current path
-        _history.Add(GetPathFromUri(_navigationManager.Uri));
+        var currentPath = GetPathFromUri(_nav.Uri);
+        _currentTab = GetTabFromPath(currentPath);
+        _depth = IsTabRoot(currentPath) ? 0 : 1; // Deep link starts at depth 1
     }
 
-    public string CurrentUri => _navigationManager.Uri;
+    public string CurrentUri => _nav.Uri;
 
-    public string CurrentPath => GetPathFromUri(_navigationManager.Uri);
+    public string CurrentPath => GetPathFromUri(_nav.Uri);
 
-    public string? ReturnUrl => _returnUrl;
+    public NavigationTab CurrentTab => _currentTab;
 
-    public bool CanGoBack => _history.Count > 1 || _fallbackPath is not null;
+    public bool CanGoBack => _depth > 0 || _parentPath is not null;
 
     public NavigationDirection Direction => _direction;
 
     public event Action? OnStateChanged;
 
-    public void NavigateTo(string uri, bool replace = false)
+    public void NavigateTo(string uri)
     {
-        _returnUrl = null; // Clear return URL for regular navigation
-        _navigationManager.NavigateTo(uri, replace: replace);
+        _parentPath = null;  // Clear - will be set by page if needed
+        _nav.NavigateTo(uri);
     }
 
-    public void NavigateTo(string uri, string returnUrl)
+    public void NavigateWithReplace(string uri)
     {
-        _returnUrl = returnUrl;
-        _navigationManager.NavigateTo(uri);
+        // Don't increment depth on replace
+        _nav.NavigateTo(uri, replace: true);
     }
 
-    public async Task GoBackAsync(string? fallback = null)
+    public void NavigateToTab(NavigationTab tab)
     {
-        // Prioritize explicit fallback over browser history
-        // This prevents going back to forms after create operations
-        var fallbackPath = fallback ?? _fallbackPath;
-        if (fallbackPath is not null)
+        _depth = 0;
+        _parentPath = null;
+        _currentTab = tab;
+        _nav.NavigateTo(GetTabRoot(tab));
+    }
+
+    public async Task GoBackAsync()
+    {
+        if (_depth > 0)
         {
-            _navigationManager.NavigateTo(fallbackPath);
-        }
-        else if (_history.Count > 1)
-        {
-            // Only use browser history when no fallback is set
             _isNavigatingBack = true;
-            await _jsRuntime.InvokeVoidAsync("history.back");
+            await _js.InvokeVoidAsync("history.back");
         }
+        else if (_parentPath is not null)
+        {
+            // Deep link - go to logical parent
+            _isNavigatingBack = true;
+            _nav.NavigateTo(_parentPath);
+        }
+        // At tab root with no parent - do nothing (button hidden anyway)
     }
 
-    public void GoBack(string? fallback = null)
+    public void GoBack()
     {
-        _ = GoBackAsync(fallback);
+        _ = GoBackAsync();
     }
 
-    public void SetFallback(string? path)
+    public void SetParentPath(string parentPath)
     {
-        _fallbackPath = path;
-        OnStateChanged?.Invoke();
-    }
-
-    public void SetReturnUrlOrFallback(string fallback)
-    {
-        _fallbackPath = _returnUrl ?? fallback;
-        _returnUrl = null;
-        OnStateChanged?.Invoke();
+        // Called by pages on init for deep link support
+        if (_depth == 0)
+        {
+            _parentPath = parentPath;
+            OnStateChanged?.Invoke();
+        }
     }
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
         var newPath = GetPathFromUri(e.Location);
+        var newTab = GetTabFromPath(newPath);
+        var isTabRoot = IsTabRoot(newPath);
 
-        if (_isNavigatingBack)
+        if (newTab != _currentTab)
         {
-            // Remove the current page from history when navigating back
-            if (_history.Count > 0)
-            {
-                _history.RemoveAt(_history.Count - 1);
-            }
-            _isNavigatingBack = false;
+            // Tab changed
+            _currentTab = newTab;
+            _depth = isTabRoot ? 0 : 1;  // Deep link = depth 1
+            _direction = NavigationDirection.Forward;
+        }
+        else if (_isNavigatingBack)
+        {
+            _depth = Math.Max(0, _depth - 1);
             _direction = NavigationDirection.Back;
+            _isNavigatingBack = false;
+        }
+        else if (!isTabRoot)
+        {
+            // Forward navigation within tab
+            _depth++;
+            _direction = NavigationDirection.Forward;
         }
         else
         {
-            // Add new path to history for forward navigation
-            _history.Add(newPath);
+            // Navigated to tab root (not back) - reset depth
+            _depth = 0;
             _direction = NavigationDirection.Forward;
         }
 
+        _parentPath = null;  // Will be set by new page if needed
         OnStateChanged?.Invoke();
+    }
+
+    private static NavigationTab GetTabFromPath(string path) => path switch
+    {
+        "/" or "" => NavigationTab.Home,
+        _ when path.StartsWith("/monitor") || path.StartsWith("/sensors") || path.StartsWith("/alerts")
+            => NavigationTab.Monitor,
+        _ when path.StartsWith("/orgs") || path.StartsWith("/organizations") || path.StartsWith("/access-requests")
+            => NavigationTab.Orgs,
+        _ when path.StartsWith("/account") || path.StartsWith("/login") || path.StartsWith("/register")
+            => NavigationTab.Account,
+        _ => NavigationTab.Home
+    };
+
+    private static string GetTabRoot(NavigationTab tab) => tab switch
+    {
+        NavigationTab.Home => "/",
+        NavigationTab.Monitor => "/monitor",
+        NavigationTab.Orgs => "/orgs",
+        NavigationTab.Account => "/account",
+        _ => "/"
+    };
+
+    private static bool IsTabRoot(string path)
+    {
+        return path is "/" or "" or "/monitor" or "/orgs" or "/account";
     }
 
     private static string GetPathFromUri(string uri)
@@ -141,6 +197,6 @@ public sealed class NavigationService : INavigationService, IDisposable
 
     public void Dispose()
     {
-        _navigationManager.LocationChanged -= OnLocationChanged;
+        _nav.LocationChanged -= OnLocationChanged;
     }
 }


### PR DESCRIPTION
## Summary

- Replaces unreliable history-based navigation with depth-tracked, tab-aware system
- All navigation now goes through `INavigationService`, preventing state desync
- Adds `NavigationTab` enum and `NavigateToTab()` for proper tab switching
- Renames `FallbackUrl` to `ParentPath` for deep link back navigation support

## Changes

### NavigationService.cs
- Added `NavigationTab` enum (Home, Monitor, Orgs, Account)
- Track `_depth` counter instead of full history stack
- Added `SetParentPath()` for pages to declare their logical parent
- Added `NavigateToTab()` which resets depth to 0
- Added `NavigateWithReplace()` for history replacement
- `CanGoBack` = `_depth > 0 || _parentPath != null`

### MainLayout.razor
- Bottom nav uses `NavigateToTab(NavigationTab.X)` instead of paths
- Removed direct `NavigationManager` dependency

### All Pages
- Renamed `FallbackUrl` to `ParentPath` (12 pages)
- Removed return URL parameters from `NavigateTo()` calls
- All pages now use `INavigationService` instead of `NavigationManager`

## Test plan

- [ ] Bottom nav: Monitor > Sensors > sensor detail > bottom nav Home > back button hidden
- [ ] Hierarchical: Orgs > org detail > edit > back > back > at Orgs tab root
- [ ] Deep link: Direct to `/sensors/123` > back button visible > goes to `/monitor`
- [ ] Replace: Edit sensor > save (replace) > back goes to list, not edit form
- [ ] Browser back: Matches in-app back button behavior

🤖 Generated with [Claude Code](https://claude.ai/code)