### PR TITLE
refactor: Replace hardcoded organization role names with constants

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/OrganizationAccessRequestsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/OrganizationAccessRequestsPage.razor
@@ -1,4 +1,5 @@
 @page "/organizations/{OrganizationId:guid}/requests"
+@using EcoData.Organization.Contracts
 @using EcoData.Organization.Contracts.Dtos
 @using EcoData.Organization.Contracts.Parameters
 @using EcoData.Organization.Contracts.Requests
@@ -188,7 +189,7 @@
     {
         var parameters = new DialogParameters<ConfirmDialog>
         {
-            { x => x.ContentText, $"Approve access request from {request.UserDisplayName}? They will be added as a Viewer." },
+            { x => x.ContentText, $"Approve access request from {request.UserDisplayName}? They will be added as a {DefaultOrganizationRoles.Viewer}." },
             { x => x.ButtonText, "Approve" },
             { x => x.Color, Color.Success }
         };

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Components/MemberListItem.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Components/MemberListItem.razor
@@ -1,3 +1,4 @@
+@using EcoData.Organization.Contracts
 @using EcoData.Organization.Contracts.Dtos
 
 <MudPaper Elevation="0" Class="pa-3 border-b">
@@ -23,7 +24,7 @@
                      Size="Size.Small"
                      Color="@GetRoleColor(Member.RoleName)"
                      Variant="Variant.Filled">
-                @if (Member.RoleName == "Admin")
+                @if (Member.RoleName == DefaultOrganizationRoles.Admin)
                 {
                     <MudIcon Icon="@Icons.Material.Filled.Shield" Size="Size.Small" Class="mr-1" />
                 }
@@ -80,8 +81,8 @@
 
     private static Color GetRoleColor(string role) => role switch
     {
-        "Admin" => Color.Warning,
-        "Contributor" => Color.Info,
+        DefaultOrganizationRoles.Admin => Color.Warning,
+        DefaultOrganizationRoles.Contributor => Color.Info,
         _ => Color.Default
     };
 

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Dialogs/ChangeRoleDialog.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Dialogs/ChangeRoleDialog.razor
@@ -1,3 +1,4 @@
+@using EcoData.Organization.Contracts
 @using EcoData.Organization.Contracts.Dtos
 
 <MudDialog>
@@ -16,9 +17,9 @@
                        @bind-Value="_role"
                        Label="Role"
                        Variant="Variant.Outlined">
-                <MudSelectItem Value="@("Viewer")">Viewer</MudSelectItem>
-                <MudSelectItem Value="@("Contributor")">Contributor</MudSelectItem>
-                <MudSelectItem Value="@("Admin")">Admin</MudSelectItem>
+                <MudSelectItem Value="@DefaultOrganizationRoles.Viewer">Viewer</MudSelectItem>
+                <MudSelectItem Value="@DefaultOrganizationRoles.Contributor">Contributor</MudSelectItem>
+                <MudSelectItem Value="@DefaultOrganizationRoles.Admin">Admin</MudSelectItem>
             </MudSelect>
         </MudStack>
     </DialogContent>
@@ -41,9 +42,9 @@
     public string MemberName { get; set; } = string.Empty;
 
     [Parameter]
-    public string CurrentRole { get; set; } = "Viewer";
+    public string CurrentRole { get; set; } = DefaultOrganizationRoles.Viewer;
 
-    private string _role = "Viewer";
+    private string _role = DefaultOrganizationRoles.Viewer;
 
     protected override void OnInitialized()
     {

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationAccessRequestEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationAccessRequestEndpoints.cs
@@ -5,6 +5,7 @@ using EcoData.Organization.Contracts.Dtos;
 using EcoData.Organization.Contracts.Parameters;
 using EcoData.Organization.Contracts.Requests;
 using EcoData.Organization.DataAccess.Interfaces;
+using DefaultRoles = EcoData.Organization.Contracts.DefaultOrganizationRoles;
 using EcoData.Organization.Database.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -246,7 +247,7 @@ public static class OrganizationAccessRequestEndpoints
                         await memberRepository.CreateAsync(
                             organizationId,
                             existingRequest.UserId,
-                            "Viewer",
+                            DefaultRoles.Viewer,
                             ct
                         );
                     }

--- a/src/Features/Organization/EcoData.Organization.Contracts/DefaultOrganizationRoles.cs
+++ b/src/Features/Organization/EcoData.Organization.Contracts/DefaultOrganizationRoles.cs
@@ -1,0 +1,14 @@
+namespace EcoData.Organization.Contracts;
+
+/// <summary>
+/// Default role names seeded when creating a new organization.
+/// Note: Organizations can create custom roles at runtime; these constants
+/// represent only the standard roles created by default.
+/// </summary>
+public static class DefaultOrganizationRoles
+{
+    public const string Owner = "Owner";
+    public const string Admin = "Admin";
+    public const string Contributor = "Contributor";
+    public const string Viewer = "Viewer";
+}

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using EcoData.Organization.Contracts;
 using EcoData.Organization.Contracts.Dtos;
 using EcoData.Organization.Contracts.Parameters;
 using EcoData.Organization.DataAccess.Interfaces;
@@ -123,28 +124,28 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
             {
                 Id = Guid.CreateVersion7(),
                 OrganizationId = entity.Id,
-                Name = "Owner",
+                Name = DefaultOrganizationRoles.Owner,
                 CreatedAt = now,
             },
             new OrganizationRole
             {
                 Id = Guid.CreateVersion7(),
                 OrganizationId = entity.Id,
-                Name = "Admin",
+                Name = DefaultOrganizationRoles.Admin,
                 CreatedAt = now,
             },
             new OrganizationRole
             {
                 Id = Guid.CreateVersion7(),
                 OrganizationId = entity.Id,
-                Name = "Contributor",
+                Name = DefaultOrganizationRoles.Contributor,
                 CreatedAt = now,
             },
             new OrganizationRole
             {
                 Id = Guid.CreateVersion7(),
                 OrganizationId = entity.Id,
-                Name = "Viewer",
+                Name = DefaultOrganizationRoles.Viewer,
                 CreatedAt = now,
             },
         };


### PR DESCRIPTION
## Summary
- Create `DefaultOrganizationRoles` constants class with `Owner`, `Admin`, `Contributor`, and `Viewer`
- Replace all hardcoded organization role strings with constants to prevent typos and improve maintainability
- Updates API layer (OrganizationRepository, OrganizationAccessRequestEndpoints) and UI layer (ChangeRoleDialog, MemberListItem, OrganizationAccessRequestsPage)

## Test plan
- [ ] Verify organizations are created with correct default roles
- [ ] Verify access request approval adds user as Viewer
- [ ] Verify role change dialog shows correct options
- [ ] Verify member list displays correct role colors

Closes #63