### PR TITLE
fix: Move navbar title styling to NuiNativeNavbar component

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -25,7 +25,8 @@
             <div class="d-flex align-center" style="flex: 1;">
                 @if (!IsHomePage)
                 {
-                    <NuiNativeNavbar ShowActions="false" TitleClass="page-title flex-grow-1 text-center" />
+                    <NuiNativeNavbar ShowBackButton="true" ShowTitle="false" ShowActions="false" />
+                    <span class="page-title">@Navbar.State.Title</span>
                 }
                 else
                 {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor.css
@@ -19,14 +19,10 @@
     letter-spacing: -0.025em;
 }
 
-/* Mobile page title */
-.page-title {
-    font-family: 'Newsreader', serif;
-    font-weight: 700;
-    font-size: 1.5rem;
-    color: var(--mud-palette-primary);
-    letter-spacing: -0.025em;
-    white-space: nowrap;
+/* Mobile page title - layout classes only, font styles come from NuiNativeNavbar */
+::deep .page-title {
+    flex-grow: 1;
+    text-align: center;
 }
 
 /* Nav link styling */

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor.css
@@ -19,10 +19,14 @@
     letter-spacing: -0.025em;
 }
 
-/* Mobile page title - layout classes only, font styles come from NuiNativeNavbar */
-::deep .page-title {
-    flex-grow: 1;
-    text-align: center;
+/* Mobile page title */
+.page-title {
+    font-family: 'Newsreader', serif;
+    font-weight: 700;
+    font-size: 1.5rem;
+    color: var(--mud-palette-primary);
+    letter-spacing: -0.025em;
+    white-space: nowrap;
 }
 
 /* Nav link styling */

--- a/src/Features/Common/EcoData.NativeUi/Components/NativeNavbar/NuiNativeNavbar.razor
+++ b/src/Features/Common/EcoData.NativeUi/Components/NativeNavbar/NuiNativeNavbar.razor
@@ -15,7 +15,7 @@
 @* Title *@
 @if (ShowTitle && Navbar.State.Title is not null)
 {
-    <span class="@TitleClass">
+    <span class="nui-navbar-title @TitleClass">
         @Navbar.State.Title
     </span>
 }

--- a/src/Features/Common/EcoData.NativeUi/Components/NativeNavbar/NuiNativeNavbar.razor.css
+++ b/src/Features/Common/EcoData.NativeUi/Components/NativeNavbar/NuiNativeNavbar.razor.css
@@ -1,0 +1,8 @@
+.nui-navbar-title {
+    font-family: 'Newsreader', serif;
+    font-weight: 700;
+    font-size: 1.5rem;
+    color: var(--mud-palette-primary);
+    letter-spacing: -0.025em;
+    white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
- Move title font styling from MainLayout to NuiNativeNavbar component
- The styling now comes from the NativeUi library instead of the consuming app
- MainLayout's `TitleClass` parameter now only provides layout classes (flex-grow, text-align)

## Problem
After migrating to NuiNativeNavbar, the mobile page title lost its styling because MainLayout's scoped CSS couldn't reach elements inside the child component.

## Solution
Add `NuiNativeNavbar.razor.css` with the `nui-navbar-title` class containing the font styling, so it's always applied regardless of which app uses the component.