### PR TITLE
feat: Add Wildlife repositories for species and conservation data

### DIFF
--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/Dtos/ConservationDtos.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/Dtos/ConservationDtos.cs
@@ -1,0 +1,27 @@
+using EcoData.Common.i18n;
+
+namespace EcoData.Wildlife.Contracts.Dtos;
+
+public sealed record FwsActionDtoForList(
+    Guid Id,
+    string Code,
+    IReadOnlyList<LocaleValue> Name
+);
+
+public sealed record NrcsPracticeDtoForList(
+    Guid Id,
+    string Code,
+    IReadOnlyList<LocaleValue> Name
+);
+
+public sealed record FwsLinkDtoForDetail(
+    Guid Id,
+    Guid SpeciesId,
+    FwsActionDtoForList FwsAction,
+    NrcsPracticeDtoForList NrcsPractice,
+    IReadOnlyList<LocaleValue> Justification
+);
+
+public sealed record ConservationLinksDtoForSpecies(
+    IReadOnlyList<FwsLinkDtoForDetail> Links
+);

--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/Dtos/SpeciesCategoryDtos.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/Dtos/SpeciesCategoryDtos.cs
@@ -1,0 +1,16 @@
+using EcoData.Common.i18n;
+
+namespace EcoData.Wildlife.Contracts.Dtos;
+
+public sealed record SpeciesCategoryDtoForList(
+    Guid Id,
+    string Code,
+    IReadOnlyList<LocaleValue> Name
+);
+
+public sealed record SpeciesCategoryDtoForDetail(
+    Guid Id,
+    string Code,
+    IReadOnlyList<LocaleValue> Name,
+    int SpeciesCount
+);

--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/Dtos/SpeciesDtos.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/Dtos/SpeciesDtos.cs
@@ -1,0 +1,48 @@
+using EcoData.Common.i18n;
+
+namespace EcoData.Wildlife.Contracts.Dtos;
+
+public sealed record SpeciesDtoForList(
+    Guid Id,
+    IReadOnlyList<LocaleValue> CommonName,
+    string ScientificName,
+    bool IsFauna,
+    string GRank,
+    string SRank
+);
+
+public sealed record SpeciesDtoForDetail(
+    Guid Id,
+    IReadOnlyList<LocaleValue> CommonName,
+    string ScientificName,
+    bool IsFauna,
+    string ElCode,
+    string GRank,
+    string SRank,
+    string? ImageSourceUrl,
+    bool HasProfileImage,
+    IReadOnlyList<SpeciesCategoryDtoForList> Categories,
+    IReadOnlyList<Guid> MunicipalityIds
+);
+
+public sealed record SpeciesDtoForCreate(
+    IReadOnlyList<LocaleValue> CommonName,
+    string ScientificName,
+    bool IsFauna,
+    string ElCode,
+    string GRank,
+    string SRank,
+    string? ImageSourceUrl,
+    byte[]? ProfileImageData,
+    string? ProfileImageContentType
+);
+
+public sealed record SpeciesDtoForUpdate(
+    IReadOnlyList<LocaleValue> CommonName,
+    string ScientificName,
+    bool IsFauna,
+    string ElCode,
+    string GRank,
+    string SRank,
+    string? ImageSourceUrl
+);

--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/Parameters/SpeciesParameters.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/Parameters/SpeciesParameters.cs
@@ -1,0 +1,12 @@
+using EcoData.Common.Pagination;
+
+namespace EcoData.Wildlife.Contracts.Parameters;
+
+public sealed record SpeciesParameters(
+    int PageSize = 20,
+    Guid? Cursor = null,
+    string? Search = null,
+    Guid? CategoryId = null,
+    Guid? MunicipalityId = null,
+    bool? IsFauna = null
+) : CursorParameters(PageSize, Cursor);

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/DependencyInjection.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/DependencyInjection.cs
@@ -1,3 +1,5 @@
+using EcoData.Wildlife.DataAccess.Interfaces;
+using EcoData.Wildlife.DataAccess.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EcoData.Wildlife.DataAccess;
@@ -6,10 +8,9 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddWildlifeDataAccess(this IServiceCollection services)
     {
-        // Repositories will be registered here as they are implemented
-        // Example:
-        // services.AddScoped<ISpeciesRepository, SpeciesRepository>();
-        // services.AddScoped<ISightingRepository, SightingRepository>();
+        services.AddScoped<ISpeciesRepository, SpeciesRepository>();
+        services.AddScoped<ISpeciesCategoryRepository, SpeciesCategoryRepository>();
+        services.AddScoped<IConservationRepository, ConservationRepository>();
 
         return services;
     }

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Interfaces/IConservationRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Interfaces/IConservationRepository.cs
@@ -1,0 +1,15 @@
+using EcoData.Wildlife.Contracts.Dtos;
+
+namespace EcoData.Wildlife.DataAccess.Interfaces;
+
+public interface IConservationRepository
+{
+    Task<IReadOnlyList<FwsActionDtoForList>> GetAllFwsActionsAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<NrcsPracticeDtoForList>> GetAllNrcsPracticesAsync(CancellationToken cancellationToken = default);
+
+    Task<ConservationLinksDtoForSpecies> GetLinksForSpeciesAsync(
+        Guid speciesId,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Interfaces/ISpeciesCategoryRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Interfaces/ISpeciesCategoryRepository.cs
@@ -1,0 +1,12 @@
+using EcoData.Wildlife.Contracts.Dtos;
+
+namespace EcoData.Wildlife.DataAccess.Interfaces;
+
+public interface ISpeciesCategoryRepository
+{
+    Task<IReadOnlyList<SpeciesCategoryDtoForList>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<SpeciesCategoryDtoForDetail?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<SpeciesCategoryDtoForDetail?> GetByCodeAsync(string code, CancellationToken cancellationToken = default);
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
@@ -1,0 +1,28 @@
+using EcoData.Wildlife.Contracts.Dtos;
+using EcoData.Wildlife.Contracts.Parameters;
+
+namespace EcoData.Wildlife.DataAccess.Interfaces;
+
+public interface ISpeciesRepository
+{
+    Task<SpeciesDtoForDetail?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<SpeciesDtoForList> GetSpeciesAsync(
+        SpeciesParameters parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<int> GetCountAsync(SpeciesParameters parameters, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SpeciesDtoForList>> GetByMunicipalityAsync(
+        Guid municipalityId,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<IReadOnlyList<SpeciesDtoForList>> GetByCategoryAsync(
+        Guid categoryId,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<byte[]?> GetProfileImageAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/ConservationRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/ConservationRepository.cs
@@ -1,0 +1,58 @@
+using EcoData.Wildlife.Contracts.Dtos;
+using EcoData.Wildlife.DataAccess.Interfaces;
+using EcoData.Wildlife.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace EcoData.Wildlife.DataAccess.Repositories;
+
+public sealed class ConservationRepository(IDbContextFactory<WildlifeDbContext> contextFactory)
+    : IConservationRepository
+{
+    public async Task<IReadOnlyList<FwsActionDtoForList>> GetAllFwsActionsAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .FwsActions
+            .OrderBy(a => a.Code)
+            .Select(a => new FwsActionDtoForList(a.Id, a.Code, a.Name))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<NrcsPracticeDtoForList>> GetAllNrcsPracticesAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .NrcsPractices
+            .OrderBy(p => p.Code)
+            .Select(p => new NrcsPracticeDtoForList(p.Id, p.Code, p.Name))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<ConservationLinksDtoForSpecies> GetLinksForSpeciesAsync(
+        Guid speciesId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var links = await context
+            .FwsLinks
+            .Where(l => l.SpeciesId == speciesId)
+            .Select(l => new FwsLinkDtoForDetail(
+                l.Id,
+                l.SpeciesId,
+                new FwsActionDtoForList(l.FwsAction.Id, l.FwsAction.Code, l.FwsAction.Name),
+                new NrcsPracticeDtoForList(l.NrcsPractice.Id, l.NrcsPractice.Code, l.NrcsPractice.Name),
+                l.Justification
+            ))
+            .ToListAsync(cancellationToken);
+
+        return new ConservationLinksDtoForSpecies(links);
+    }
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/SpeciesCategoryRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/SpeciesCategoryRepository.cs
@@ -1,0 +1,61 @@
+using EcoData.Wildlife.Contracts.Dtos;
+using EcoData.Wildlife.DataAccess.Interfaces;
+using EcoData.Wildlife.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace EcoData.Wildlife.DataAccess.Repositories;
+
+public sealed class SpeciesCategoryRepository(IDbContextFactory<WildlifeDbContext> contextFactory)
+    : ISpeciesCategoryRepository
+{
+    public async Task<IReadOnlyList<SpeciesCategoryDtoForList>> GetAllAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .SpeciesCategories
+            .OrderBy(c => c.Code)
+            .Select(c => new SpeciesCategoryDtoForList(c.Id, c.Code, c.Name))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<SpeciesCategoryDtoForDetail?> GetByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .SpeciesCategories
+            .Where(c => c.Id == id)
+            .Select(c => new SpeciesCategoryDtoForDetail(
+                c.Id,
+                c.Code,
+                c.Name,
+                c.SpeciesLinks.Count
+            ))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<SpeciesCategoryDtoForDetail?> GetByCodeAsync(
+        string code,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .SpeciesCategories
+            .Where(c => c.Code == code)
+            .Select(c => new SpeciesCategoryDtoForDetail(
+                c.Id,
+                c.Code,
+                c.Name,
+                c.SpeciesLinks.Count
+            ))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
@@ -1,0 +1,180 @@
+using System.Runtime.CompilerServices;
+using EcoData.Wildlife.Contracts.Dtos;
+using EcoData.Wildlife.Contracts.Parameters;
+using EcoData.Wildlife.DataAccess.Interfaces;
+using EcoData.Wildlife.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace EcoData.Wildlife.DataAccess.Repositories;
+
+public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> contextFactory)
+    : ISpeciesRepository
+{
+    public async Task<SpeciesDtoForDetail?> GetByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .Species.Where(s => s.Id == id)
+            .Select(s => new SpeciesDtoForDetail(
+                s.Id,
+                s.CommonName,
+                s.ScientificName,
+                s.IsFauna,
+                s.ElCode,
+                s.GRank,
+                s.SRank,
+                s.ImageSourceUrl,
+                s.ProfileImageData != null,
+                s.CategoryLinks
+                    .Select(cl => new SpeciesCategoryDtoForList(
+                        cl.Category.Id,
+                        cl.Category.Code,
+                        cl.Category.Name
+                    ))
+                    .ToList(),
+                s.MunicipalitySpecies.Select(ms => ms.MunicipalityId).ToList()
+            ))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async IAsyncEnumerable<SpeciesDtoForList> GetSpeciesAsync(
+        SpeciesParameters parameters,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.Species.AsQueryable();
+
+        query = ApplyFilters(query, parameters);
+
+        if (parameters.Cursor.HasValue)
+        {
+            query = query.Where(s => s.Id < parameters.Cursor.Value);
+        }
+
+        await foreach (
+            var species in query
+                .OrderByDescending(s => s.Id)
+                .Take(parameters.PageSize + 1)
+                .Select(static s => new SpeciesDtoForList(
+                    s.Id,
+                    s.CommonName,
+                    s.ScientificName,
+                    s.IsFauna,
+                    s.GRank,
+                    s.SRank
+                ))
+                .AsAsyncEnumerable()
+                .WithCancellation(cancellationToken)
+        )
+        {
+            yield return species;
+        }
+    }
+
+    public async Task<int> GetCountAsync(
+        SpeciesParameters parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.Species.AsQueryable();
+        query = ApplyFilters(query, parameters);
+
+        return await query.CountAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SpeciesDtoForList>> GetByMunicipalityAsync(
+        Guid municipalityId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .MunicipalitySpecies.Where(ms => ms.MunicipalityId == municipalityId)
+            .Select(ms => new SpeciesDtoForList(
+                ms.Species.Id,
+                ms.Species.CommonName,
+                ms.Species.ScientificName,
+                ms.Species.IsFauna,
+                ms.Species.GRank,
+                ms.Species.SRank
+            ))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SpeciesDtoForList>> GetByCategoryAsync(
+        Guid categoryId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .SpeciesCategoryLinks.Where(scl => scl.CategoryId == categoryId)
+            .Select(scl => new SpeciesDtoForList(
+                scl.Species.Id,
+                scl.Species.CommonName,
+                scl.Species.ScientificName,
+                scl.Species.IsFauna,
+                scl.Species.GRank,
+                scl.Species.SRank
+            ))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<byte[]?> GetProfileImageAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .Species.Where(s => s.Id == id)
+            .Select(s => s.ProfileImageData)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static IQueryable<Database.Models.Species> ApplyFilters(
+        IQueryable<Database.Models.Species> query,
+        SpeciesParameters parameters
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(parameters.Search))
+        {
+            var search = parameters.Search.Trim().ToLower();
+            query = query.Where(s =>
+                s.ScientificName.ToLower().Contains(search)
+            );
+        }
+
+        if (parameters.IsFauna.HasValue)
+        {
+            query = query.Where(s => s.IsFauna == parameters.IsFauna.Value);
+        }
+
+        if (parameters.CategoryId.HasValue)
+        {
+            query = query.Where(s =>
+                s.CategoryLinks.Any(cl => cl.CategoryId == parameters.CategoryId.Value)
+            );
+        }
+
+        if (parameters.MunicipalityId.HasValue)
+        {
+            query = query.Where(s =>
+                s.MunicipalitySpecies.Any(ms => ms.MunicipalityId == parameters.MunicipalityId.Value)
+            );
+        }
+
+        return query;
+    }
+}


### PR DESCRIPTION
## Summary
- Implement repository pattern for Wildlife module data access layer
- Add DTOs and parameters for type-safe species data transfer
- Support filtering by category, municipality, fauna/flora type, and search text

## Changes
**Contracts (DTOs/Parameters):**
- `SpeciesDtoForList` / `SpeciesDtoForDetail` - species data transfer objects
- `SpeciesCategoryDtoForList` / `SpeciesCategoryDtoForDetail` - category DTOs
- `ConservationLinksDtoForSpecies`, `FwsLinkDtoForDetail`, etc. - conservation data DTOs
- `SpeciesParameters` - cursor-based pagination and filtering parameters

**DataAccess (Interfaces):**
- `ISpeciesRepository` - species queries with filtering, pagination, image retrieval
- `ISpeciesCategoryRepository` - category lookups by ID/code
- `IConservationRepository` - FWS actions and NRCS practices

**DataAccess (Implementations):**
- All repositories use `IDbContextFactory<WildlifeDbContext>` pattern
- Projection-based queries returning DTOs (not entities)
- `IAsyncEnumerable` for streaming large result sets

## Test plan
- [ ] Build succeeds with `dotnet build`
- [ ] Repository DI registration verified in DependencyInjection.cs