### PR TITLE
feat: Add Wildlife API endpoints

### DIFF
--- a/src/Features/Wildlife/EcoData.Wildlife.Api/EcoData.Wildlife.Api.csproj
+++ b/src/Features/Wildlife/EcoData.Wildlife.Api/EcoData.Wildlife.Api.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EcoData.Wildlife.Application.Server\EcoData.Wildlife.Application.Server.csproj" />
+    <ProjectReference Include="..\EcoData.Wildlife.DataAccess\EcoData.Wildlife.DataAccess.csproj" />
     <ProjectReference Include="..\..\Locations\EcoData.Locations.DataAccess\EcoData.Locations.DataAccess.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/ConservationEndpoints.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/ConservationEndpoints.cs
@@ -1,0 +1,65 @@
+using EcoData.Wildlife.Contracts.Dtos;
+using EcoData.Wildlife.DataAccess.Interfaces;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+
+namespace EcoData.Wildlife.Api.Endpoints;
+
+public static class ConservationEndpoints
+{
+    public static IEndpointRouteBuilder MapConservationEndpoints(this IEndpointRouteBuilder app)
+    {
+        var fwsGroup = app.MapGroup("/api/fws-actions").WithTags("FWS Actions");
+
+        fwsGroup
+            .MapGet(
+                "/",
+                async Task<Ok<IReadOnlyList<FwsActionDtoForList>>> (
+                    IConservationRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var actions = await repository.GetAllFwsActionsAsync(ct);
+                    return TypedResults.Ok(actions);
+                }
+            )
+            .WithName("GetFwsActions");
+
+        var nrcsGroup = app.MapGroup("/api/nrcs-practices").WithTags("NRCS Practices");
+
+        nrcsGroup
+            .MapGet(
+                "/",
+                async Task<Ok<IReadOnlyList<NrcsPracticeDtoForList>>> (
+                    IConservationRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var practices = await repository.GetAllNrcsPracticesAsync(ct);
+                    return TypedResults.Ok(practices);
+                }
+            )
+            .WithName("GetNrcsPractices");
+
+        var linksGroup = app.MapGroup("/api/conservation-links").WithTags("Conservation Links");
+
+        linksGroup
+            .MapGet(
+                "/species/{speciesId:guid}",
+                async Task<Ok<ConservationLinksDtoForSpecies>> (
+                    Guid speciesId,
+                    IConservationRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var links = await repository.GetLinksForSpeciesAsync(speciesId, ct);
+                    return TypedResults.Ok(links);
+                }
+            )
+            .WithName("GetConservationLinksForSpecies");
+
+        return app;
+    }
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesCategoryEndpoints.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesCategoryEndpoints.cs
@@ -1,0 +1,66 @@
+using EcoData.Wildlife.Contracts.Dtos;
+using EcoData.Wildlife.DataAccess.Interfaces;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+
+namespace EcoData.Wildlife.Api.Endpoints;
+
+public static class SpeciesCategoryEndpoints
+{
+    public static IEndpointRouteBuilder MapSpeciesCategoryEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/species-categories").WithTags("Species Categories");
+
+        group
+            .MapGet(
+                "/",
+                async Task<Ok<IReadOnlyList<SpeciesCategoryDtoForList>>> (
+                    ISpeciesCategoryRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var categories = await repository.GetAllAsync(ct);
+                    return TypedResults.Ok(categories);
+                }
+            )
+            .WithName("GetSpeciesCategories");
+
+        group
+            .MapGet(
+                "/{id:guid}",
+                async Task<Results<Ok<SpeciesCategoryDtoForDetail>, NotFound>> (
+                    Guid id,
+                    ISpeciesCategoryRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var category = await repository.GetByIdAsync(id, ct);
+                    return category is null
+                        ? TypedResults.NotFound()
+                        : TypedResults.Ok(category);
+                }
+            )
+            .WithName("GetSpeciesCategoryById");
+
+        group
+            .MapGet(
+                "/by-code/{code}",
+                async Task<Results<Ok<SpeciesCategoryDtoForDetail>, NotFound>> (
+                    string code,
+                    ISpeciesCategoryRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var category = await repository.GetByCodeAsync(code, ct);
+                    return category is null
+                        ? TypedResults.NotFound()
+                        : TypedResults.Ok(category);
+                }
+            )
+            .WithName("GetSpeciesCategoryByCode");
+
+        return app;
+    }
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesEndpoints.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesEndpoints.cs
@@ -1,0 +1,109 @@
+using EcoData.Wildlife.Contracts.Dtos;
+using EcoData.Wildlife.Contracts.Parameters;
+using EcoData.Wildlife.DataAccess.Interfaces;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+
+namespace EcoData.Wildlife.Api.Endpoints;
+
+public static class SpeciesEndpoints
+{
+    public static IEndpointRouteBuilder MapSpeciesEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/species").WithTags("Species");
+
+        group
+            .MapGet(
+                "/",
+                (
+                    [AsParameters] SpeciesParameters parameters,
+                    ISpeciesRepository repository,
+                    CancellationToken ct
+                ) => repository.GetSpeciesAsync(parameters, ct)
+            )
+            .WithName("GetSpecies");
+
+        group
+            .MapGet(
+                "/count",
+                async (
+                    [AsParameters] SpeciesParameters parameters,
+                    ISpeciesRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var count = await repository.GetCountAsync(parameters, ct);
+                    return TypedResults.Ok(new { count });
+                }
+            )
+            .WithName("GetSpeciesCount");
+
+        group
+            .MapGet(
+                "/{id:guid}",
+                async Task<Results<Ok<SpeciesDtoForDetail>, NotFound>> (
+                    Guid id,
+                    ISpeciesRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var species = await repository.GetByIdAsync(id, ct);
+                    return species is null
+                        ? TypedResults.NotFound()
+                        : TypedResults.Ok(species);
+                }
+            )
+            .WithName("GetSpeciesById");
+
+        group
+            .MapGet(
+                "/{id:guid}/image",
+                async Task<Results<FileContentHttpResult, NotFound>> (
+                    Guid id,
+                    ISpeciesRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var imageData = await repository.GetProfileImageAsync(id, ct);
+                    return imageData is null
+                        ? TypedResults.NotFound()
+                        : TypedResults.File(imageData, "image/jpeg");
+                }
+            )
+            .WithName("GetSpeciesImage");
+
+        group
+            .MapGet(
+                "/by-municipality/{municipalityId:guid}",
+                async Task<Ok<IReadOnlyList<SpeciesDtoForList>>> (
+                    Guid municipalityId,
+                    ISpeciesRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var species = await repository.GetByMunicipalityAsync(municipalityId, ct);
+                    return TypedResults.Ok(species);
+                }
+            )
+            .WithName("GetSpeciesByMunicipality");
+
+        group
+            .MapGet(
+                "/by-category/{categoryId:guid}",
+                async Task<Ok<IReadOnlyList<SpeciesDtoForList>>> (
+                    Guid categoryId,
+                    ISpeciesRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var species = await repository.GetByCategoryAsync(categoryId, ct);
+                    return TypedResults.Ok(species);
+                }
+            )
+            .WithName("GetSpeciesByCategory");
+
+        return app;
+    }
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Api/WildlifeApiExtensions.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Api/WildlifeApiExtensions.cs
@@ -1,3 +1,4 @@
+using EcoData.Wildlife.Api.Endpoints;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 
@@ -7,10 +8,9 @@ public static class WildlifeApiExtensions
 {
     public static IEndpointRouteBuilder MapWildlifeApiEndpoints(this IEndpointRouteBuilder app)
     {
-        // Endpoints will be mapped here as they are implemented
-        // Example:
-        // app.MapSpeciesEndpoints();
-        // app.MapSightingEndpoints();
+        app.MapSpeciesEndpoints();
+        app.MapSpeciesCategoryEndpoints();
+        app.MapConservationEndpoints();
 
         return app;
     }


### PR DESCRIPTION
## Summary
- Implement minimal API endpoints for the Wildlife module
- Expose species, category, and conservation data via REST API

## Endpoints

**Species** (`/api/species`)
- `GET /` - List with filtering (search, fauna/flora, category, municipality) and cursor pagination
- `GET /count` - Total count with same filters
- `GET /{id}` - Detail by ID
- `GET /{id}/image` - Profile image (JPEG)
- `GET /by-municipality/{municipalityId}` - Species in a municipality
- `GET /by-category/{categoryId}` - Species in a category

**Species Categories** (`/api/species-categories`)
- `GET /` - List all categories
- `GET /{id}` - By ID
- `GET /by-code/{code}` - By code

**Conservation** 
- `GET /api/fws-actions` - List FWS actions
- `GET /api/nrcs-practices` - List NRCS practices
- `GET /api/conservation-links/species/{speciesId}` - Links for a species

## Test plan
- [ ] Build succeeds with `dotnet build`
- [ ] Endpoints registered in WildlifeApiExtensions