### PR TITLE
refactor: Use module-prefixed API routes

### DIFF
--- a/src/Features/Identity/EcoData.Identity.Api/Endpoints/UserAuthEndpoints.cs
+++ b/src/Features/Identity/EcoData.Identity.Api/Endpoints/UserAuthEndpoints.cs
@@ -16,7 +16,7 @@ public static class UserAuthEndpoints
 {
     public static IEndpointRouteBuilder MapUserAuthEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/auth").WithTags("User Auth");
+        var group = app.MapGroup("/identity/auth").WithTags("User Auth");
 
         group
             .MapPost(

--- a/src/Features/Locations/EcoData.Locations.Api/MunicipalityEndpoints.cs
+++ b/src/Features/Locations/EcoData.Locations.Api/MunicipalityEndpoints.cs
@@ -13,7 +13,7 @@ public static class MunicipalityEndpoints
 {
     public static IEndpointRouteBuilder MapMunicipalityEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/municipalities").WithTags("Municipalities");
+        var group = app.MapGroup("/locations/municipalities").WithTags("Municipalities");
 
         group
             .MapGet(

--- a/src/Features/Locations/EcoData.Locations.Api/StateEndpoints.cs
+++ b/src/Features/Locations/EcoData.Locations.Api/StateEndpoints.cs
@@ -12,7 +12,7 @@ public static class StateEndpoints
 {
     public static IEndpointRouteBuilder MapStateEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/states").WithTags("States");
+        var group = app.MapGroup("/locations/states").WithTags("States");
 
         group
             .MapGet(

--- a/src/Features/Organization/EcoData.Organization.Api/DataSourceEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/DataSourceEndpoints.cs
@@ -9,7 +9,7 @@ public static class DataSourceEndpoints
 {
     public static IEndpointRouteBuilder MapDataSourceEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/datasources").WithTags("DataSources");
+        var group = app.MapGroup("/organization/datasources").WithTags("DataSources");
 
         group
             .MapGet(

--- a/src/Features/Organization/EcoData.Organization.Api/MemberEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/MemberEndpoints.cs
@@ -16,7 +16,7 @@ public static class MemberEndpoints
 {
     public static IEndpointRouteBuilder MapMemberEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/organizations/{organizationId:guid}/members")
+        var group = app.MapGroup("/organization/organizations/{organizationId:guid}/members")
             .WithTags("Organization Members")
             .RequireAuthorization();
 

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationAccessRequestEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationAccessRequestEndpoints.cs
@@ -21,7 +21,7 @@ public static class OrganizationAccessRequestEndpoints
         this IEndpointRouteBuilder app
     )
     {
-        var orgGroup = app.MapGroup("/api/organizations/{organizationId:guid}/access-requests")
+        var orgGroup = app.MapGroup("/organization/organizations/{organizationId:guid}/access-requests")
             .WithTags("Organization Access Requests")
             .RequireAuthorization();
 
@@ -257,7 +257,7 @@ public static class OrganizationAccessRequestEndpoints
             )
             .WithName("UpdateOrganizationAccessRequestStatus");
 
-        var meGroup = app.MapGroup("/api/me/access-requests")
+        var meGroup = app.MapGroup("/organization/me/access-requests")
             .WithTags("My Access Requests")
             .RequireAuthorization();
 

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationBlockedUserEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationBlockedUserEndpoints.cs
@@ -17,7 +17,7 @@ public static class OrganizationBlockedUserEndpoints
         this IEndpointRouteBuilder app
     )
     {
-        var group = app.MapGroup("/api/organizations/{organizationId:guid}/blocked-users")
+        var group = app.MapGroup("/organization/organizations/{organizationId:guid}/blocked-users")
             .WithTags("Organization Blocked Users")
             .RequireAuthorization();
 

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationEndpoints.cs
@@ -18,7 +18,7 @@ public static class OrganizationEndpoints
 {
     public static IEndpointRouteBuilder MapOrganizationEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/organizations").WithTags("Organizations");
+        var group = app.MapGroup("/organization/organizations").WithTags("Organizations");
 
         group
             .MapGet(

--- a/src/Features/Organization/EcoData.Organization.Api/PermissionEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/PermissionEndpoints.cs
@@ -14,7 +14,7 @@ public static class PermissionEndpoints
 {
     public static IEndpointRouteBuilder MapPermissionEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/organizations/{organizationId:guid}/my-permissions")
+        var group = app.MapGroup("/organization/organizations/{organizationId:guid}/my-permissions")
             .WithTags("Permissions")
             .RequireAuthorization();
 

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/GeoTestEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/GeoTestEndpoints.cs
@@ -13,7 +13,7 @@ public static class GeoTestEndpoints
 {
     public static IEndpointRouteBuilder MapGeoTestEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/sensors/geo-test").WithTags("Geo Test");
+        var group = app.MapGroup("/sensors/geo-test").WithTags("Geo Test");
 
         // Test 1: Read a sensor's Location (Point geometry)
         group

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/ReferenceDataEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/ReferenceDataEndpoints.cs
@@ -11,7 +11,7 @@ public static class ReferenceDataEndpoints
 {
     public static IEndpointRouteBuilder MapReferenceDataEndpoints(this IEndpointRouteBuilder app)
     {
-        var sensorTypesGroup = app.MapGroup("/api/sensor-types").WithTags("Sensor Types");
+        var sensorTypesGroup = app.MapGroup("/sensors/types").WithTags("Sensor Types");
 
         sensorTypesGroup
             .MapGet(
@@ -38,7 +38,7 @@ public static class ReferenceDataEndpoints
             )
             .WithName("GetSensorTypeById");
 
-        var parametersGroup = app.MapGroup("/api/parameters").WithTags("Parameters");
+        var parametersGroup = app.MapGroup("/sensors/parameters").WithTags("Parameters");
 
         parametersGroup
             .MapGet(

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorAlertEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorAlertEndpoints.cs
@@ -15,7 +15,7 @@ public static class SensorAlertEndpoints
 {
     public static IEndpointRouteBuilder MapSensorAlertEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/sensors/alerts").WithTags("Sensor Alerts");
+        var group = app.MapGroup("/sensors/alerts").WithTags("Sensor Alerts");
 
         group
             .MapGet(
@@ -62,7 +62,7 @@ public static class SensorAlertEndpoints
             )
             .WithName("StreamAllSensorAlerts");
 
-        var sensorGroup = app.MapGroup("/api/sensors/{sensorId:guid}/alerts")
+        var sensorGroup = app.MapGroup("/sensors/{sensorId:guid}/alerts")
             .WithTags("Sensor Alerts");
 
         sensorGroup

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorEndpoints.cs
@@ -18,7 +18,7 @@ public static class SensorEndpoints
 {
     public static IEndpointRouteBuilder MapSensorEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/sensors").WithTags("Sensors");
+        var group = app.MapGroup("/sensors").WithTags("Sensors");
 
         group
             .MapGet(

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorHealthConfigEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorHealthConfigEndpoints.cs
@@ -11,7 +11,7 @@ public static class SensorHealthConfigEndpoints
 {
     public static IEndpointRouteBuilder MapSensorHealthConfigEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/sensors/{sensorId:guid}/health/config")
+        var group = app.MapGroup("/sensors/{sensorId:guid}/health/config")
             .WithTags("Sensor Health Config");
 
         group

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorHealthEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorHealthEndpoints.cs
@@ -14,7 +14,7 @@ public static class SensorHealthEndpoints
 
     public static IEndpointRouteBuilder MapSensorHealthEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/health/sensors").WithTags("Sensor Health");
+        var group = app.MapGroup("/sensors/health").WithTags("Sensor Health");
 
         group
             .MapGet(
@@ -35,7 +35,7 @@ public static class SensorHealthEndpoints
             )
             .WithName("GetSensorHealthSummary");
 
-        var sensorGroup = app.MapGroup("/api/sensors/{sensorId:guid}/health")
+        var sensorGroup = app.MapGroup("/sensors/{sensorId:guid}/health")
             .WithTags("Sensor Health");
 
         sensorGroup

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorReadingEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/SensorReadingEndpoints.cs
@@ -18,7 +18,7 @@ public static class SensorReadingEndpoints
 
     public static IEndpointRouteBuilder MapSensorReadingEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/sensors/{sensorId:guid}/readings")
+        var group = app.MapGroup("/sensors/{sensorId:guid}/readings")
             .WithTags("Sensor Readings");
 
         group

--- a/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/ConservationEndpoints.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/ConservationEndpoints.cs
@@ -11,7 +11,7 @@ public static class ConservationEndpoints
 {
     public static IEndpointRouteBuilder MapConservationEndpoints(this IEndpointRouteBuilder app)
     {
-        var fwsGroup = app.MapGroup("/api/fws-actions").WithTags("FWS Actions");
+        var fwsGroup = app.MapGroup("/wildlife/fws-actions").WithTags("FWS Actions");
 
         fwsGroup
             .MapGet(
@@ -27,7 +27,7 @@ public static class ConservationEndpoints
             )
             .WithName("GetFwsActions");
 
-        var nrcsGroup = app.MapGroup("/api/nrcs-practices").WithTags("NRCS Practices");
+        var nrcsGroup = app.MapGroup("/wildlife/nrcs-practices").WithTags("NRCS Practices");
 
         nrcsGroup
             .MapGet(
@@ -43,7 +43,7 @@ public static class ConservationEndpoints
             )
             .WithName("GetNrcsPractices");
 
-        var linksGroup = app.MapGroup("/api/conservation-links").WithTags("Conservation Links");
+        var linksGroup = app.MapGroup("/wildlife/conservation-links").WithTags("Conservation Links");
 
         linksGroup
             .MapGet(

--- a/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesCategoryEndpoints.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesCategoryEndpoints.cs
@@ -11,7 +11,7 @@ public static class SpeciesCategoryEndpoints
 {
     public static IEndpointRouteBuilder MapSpeciesCategoryEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/species-categories").WithTags("Species Categories");
+        var group = app.MapGroup("/wildlife/species-categories").WithTags("Species Categories");
 
         group
             .MapGet(

--- a/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesEndpoints.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesEndpoints.cs
@@ -12,7 +12,7 @@ public static class SpeciesEndpoints
 {
     public static IEndpointRouteBuilder MapSpeciesEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/species").WithTags("Species");
+        var group = app.MapGroup("/wildlife/species").WithTags("Species");
 
         group
             .MapGet(


### PR DESCRIPTION
## Summary
- Replace `/api` prefix with module-specific prefixes for microservices readiness
- Enables seamless migration to microservices without client path changes

## Route Changes

| Module | Old Prefix | New Prefix |
|--------|-----------|------------|
| Identity | `/api/auth` | `/identity/auth` |
| Locations | `/api/states`, `/api/municipalities` | `/locations/states`, `/locations/municipalities` |
| Organization | `/api/organizations`, `/api/datasources` | `/organization/organizations`, `/organization/datasources` |
| Sensors | `/api/sensors`, `/api/sensor-types` | `/sensors`, `/sensors/types` |
| Wildlife | `/api/species`, `/api/species-categories` | `/wildlife/species`, `/wildlife/species-categories` |

## Benefits
- Clients can route by module prefix to different hosts when migrating to microservices
- No path changes needed on client side during migration
- Clear module boundaries in URL structure

## Test plan
- [ ] Build succeeds with `dotnet build`
- [ ] Verify endpoints are accessible with new routes