### PR TITLE
fix: Update client HTTP routes to match module-prefixed API

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/DataSourceHttpClient.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/DataSourceHttpClient.cs
@@ -10,7 +10,7 @@ public sealed class DataSourceHttpClient(HttpClient httpClient) : IDataSourceHtt
     )
     {
         var result = await httpClient.GetFromJsonAsync<IReadOnlyList<DataSourceDtoForList>>(
-            "api/datasources",
+            "organization/datasources",
             cancellationToken
         );
         return result ?? [];

--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/LocationHttpClient.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/LocationHttpClient.cs
@@ -22,7 +22,7 @@ public sealed class LocationHttpClient(HttpClient httpClient) : ILocationHttpCli
                 .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<StateDtoForList>(
-            $"api/states{queryString}",
+            $"locations/states{queryString}",
             cancellationToken
         )!;
     }
@@ -43,7 +43,7 @@ public sealed class LocationHttpClient(HttpClient httpClient) : ILocationHttpCli
                 .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<MunicipalityDtoForList>(
-            $"api/municipalities{queryString}",
+            $"locations/municipalities{queryString}",
             cancellationToken
         )!;
     }
@@ -53,7 +53,7 @@ public sealed class LocationHttpClient(HttpClient httpClient) : ILocationHttpCli
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.GetAsync($"api/municipalities/{id}", cancellationToken);
+        var response = await httpClient.GetAsync($"locations/municipalities/{id}", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -74,7 +74,7 @@ public sealed class LocationHttpClient(HttpClient httpClient) : ILocationHttpCli
             .Add("longitude", longitude)
             .Build();
 
-        var response = await httpClient.GetAsync($"api/municipalities/by-point{queryString}", cancellationToken);
+        var response = await httpClient.GetAsync($"locations/municipalities/by-point{queryString}", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -90,7 +90,7 @@ public sealed class LocationHttpClient(HttpClient httpClient) : ILocationHttpCli
     )
     {
         var response = await httpClient.GetAsync(
-            $"api/municipalities/geojson/state/{stateCode}",
+            $"locations/municipalities/geojson/state/{stateCode}",
             cancellationToken
         );
 

--- a/src/Features/Identity/EcoData.Identity.Application.Client/HttpClients/AuthHttpClient.cs
+++ b/src/Features/Identity/EcoData.Identity.Application.Client/HttpClients/AuthHttpClient.cs
@@ -10,7 +10,7 @@ public sealed class AuthHttpClient(HttpClient httpClient) : IAuthHttpClient
 {
     public async Task<OneOf<UserInfo, ProblemDetail>> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync("/api/auth/login", request, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("/identity/auth/login", request, cancellationToken);
 
         if (response.IsSuccessStatusCode)
         {
@@ -23,7 +23,7 @@ public sealed class AuthHttpClient(HttpClient httpClient) : IAuthHttpClient
 
     public async Task<OneOf<UserInfo, ProblemDetail>> RegisterAsync(RegisterRequest request, CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync("/api/auth/register", request, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("/identity/auth/register", request, cancellationToken);
 
         if (response.IsSuccessStatusCode)
         {
@@ -36,14 +36,14 @@ public sealed class AuthHttpClient(HttpClient httpClient) : IAuthHttpClient
 
     public async Task LogoutAsync(CancellationToken cancellationToken = default)
     {
-        await httpClient.PostAsync("/api/auth/logout", null, cancellationToken);
+        await httpClient.PostAsync("/identity/auth/logout", null, cancellationToken);
     }
 
     public async Task<UserInfo?> GetCurrentUserAsync(CancellationToken cancellationToken = default)
     {
         try
         {
-            return await httpClient.GetFromJsonAsync<UserInfo?>("/api/auth/me", cancellationToken);
+            return await httpClient.GetFromJsonAsync<UserInfo?>("/identity/auth/me", cancellationToken);
         }
         catch
         {

--- a/src/Features/Locations/EcoData.Locations.Application.Client/MunicipalityHttpClient.cs
+++ b/src/Features/Locations/EcoData.Locations.Application.Client/MunicipalityHttpClient.cs
@@ -22,13 +22,13 @@ public sealed class MunicipalityHttpClient(HttpClient httpClient) : IMunicipalit
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<MunicipalityDtoForList>(
-            $"api/municipalities{queryString}",
+            $"locations/municipalities{queryString}",
             ct)!;
     }
 
     public async Task<MunicipalityDtoForDetail?> GetByIdAsync(Guid id, CancellationToken ct = default)
     {
-        var response = await httpClient.GetAsync($"api/municipalities/{id}", ct);
+        var response = await httpClient.GetAsync($"locations/municipalities/{id}", ct);
 
         if (!response.IsSuccessStatusCode)
             return null;

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationAccessRequestEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationAccessRequestEndpoints.cs
@@ -93,7 +93,7 @@ public static class OrganizationAccessRequestEndpoints
                     );
 
                     return TypedResults.Created(
-                        $"/api/organizations/{organizationId}/access-requests/{accessRequest.Id}",
+                        $"/organization/organizations/{organizationId}/access-requests/{accessRequest.Id}",
                         accessRequest
                     );
                 }

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationBlockedUserEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationBlockedUserEndpoints.cs
@@ -105,7 +105,7 @@ public static class OrganizationBlockedUserEndpoints
                     );
 
                     return TypedResults.Created(
-                        $"/api/organizations/{organizationId}/blocked-users/{request.UserId}",
+                        $"/organization/organizations/{organizationId}/blocked-users/{request.UserId}",
                         blocked
                     );
                 }

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationEndpoints.cs
@@ -87,7 +87,7 @@ public static class OrganizationEndpoints
                     }
 
                     var created = await repository.CreateAsync(dto, ct);
-                    return TypedResults.Created($"/api/organizations/{created.Id}", created);
+                    return TypedResults.Created($"/organization/organizations/{created.Id}", created);
                 }
             )
             .WithName("CreateOrganization")

--- a/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationAccessRequestHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationAccessRequestHttpClient.cs
@@ -24,7 +24,7 @@ public sealed class OrganizationAccessRequestHttpClient(HttpClient httpClient)
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<OrganizationAccessRequestDto>(
-            $"api/organizations/{organizationId}/access-requests{query}",
+            $"organization/organizations/{organizationId}/access-requests{query}",
             cancellationToken
         )!;
     }
@@ -36,7 +36,7 @@ public sealed class OrganizationAccessRequestHttpClient(HttpClient httpClient)
     )
     {
         var response = await httpClient.GetAsync(
-            $"api/organizations/{organizationId}/access-requests/{id}",
+            $"organization/organizations/{organizationId}/access-requests/{id}",
             cancellationToken
         );
 
@@ -58,7 +58,7 @@ public sealed class OrganizationAccessRequestHttpClient(HttpClient httpClient)
     )
     {
         var response = await httpClient.PostAsJsonAsync(
-            $"api/organizations/{organizationId}/access-requests",
+            $"organization/organizations/{organizationId}/access-requests",
             request,
             cancellationToken
         );
@@ -82,7 +82,7 @@ public sealed class OrganizationAccessRequestHttpClient(HttpClient httpClient)
     )
     {
         var response = await httpClient.PutAsJsonAsync(
-            $"api/organizations/{organizationId}/access-requests/{id}/status",
+            $"organization/organizations/{organizationId}/access-requests/{id}/status",
             request,
             cancellationToken
         );
@@ -110,7 +110,7 @@ public sealed class OrganizationAccessRequestHttpClient(HttpClient httpClient)
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<OrganizationAccessRequestDto>(
-            $"api/me/access-requests{query}",
+            $"organization/me/access-requests{query}",
             cancellationToken
         )!;
     }
@@ -121,7 +121,7 @@ public sealed class OrganizationAccessRequestHttpClient(HttpClient httpClient)
     )
     {
         var response = await httpClient.PostAsync(
-            $"api/me/access-requests/{id}/cancel",
+            $"organization/me/access-requests/{id}/cancel",
             null,
             cancellationToken
         );

--- a/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationBlockedUserHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationBlockedUserHttpClient.cs
@@ -15,7 +15,7 @@ public sealed class OrganizationBlockedUserHttpClient(HttpClient httpClient)
     )
     {
         return httpClient.GetFromJsonAsAsyncEnumerable<OrganizationBlockedUserDto>(
-            $"api/organizations/{organizationId}/blocked-users",
+            $"organization/organizations/{organizationId}/blocked-users",
             cancellationToken
         )!;
     }
@@ -29,7 +29,7 @@ public sealed class OrganizationBlockedUserHttpClient(HttpClient httpClient)
     {
         var request = new BlockUserRequest(userId, reason);
         var response = await httpClient.PostAsJsonAsync(
-            $"api/organizations/{organizationId}/blocked-users",
+            $"organization/organizations/{organizationId}/blocked-users",
             request,
             cancellationToken
         );
@@ -52,7 +52,7 @@ public sealed class OrganizationBlockedUserHttpClient(HttpClient httpClient)
     )
     {
         var response = await httpClient.DeleteAsync(
-            $"api/organizations/{organizationId}/blocked-users/{userId}",
+            $"organization/organizations/{organizationId}/blocked-users/{userId}",
             cancellationToken
         );
 

--- a/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationHttpClient.cs
@@ -22,7 +22,7 @@ public sealed class OrganizationHttpClient(HttpClient httpClient) : IOrganizatio
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<OrganizationDtoForList>(
-            $"api/organizations{queryString}",
+            $"organization/organizations{queryString}",
             cancellationToken
         )!;
     }
@@ -32,7 +32,7 @@ public sealed class OrganizationHttpClient(HttpClient httpClient) : IOrganizatio
     )
     {
         return httpClient.GetFromJsonAsAsyncEnumerable<MyOrganizationDto>(
-            "api/organizations/my",
+            "organization/organizations/my",
             cancellationToken
         )!;
     }
@@ -42,7 +42,7 @@ public sealed class OrganizationHttpClient(HttpClient httpClient) : IOrganizatio
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.GetAsync($"api/organizations/{id}", cancellationToken);
+        var response = await httpClient.GetAsync($"organization/organizations/{id}", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -61,7 +61,7 @@ public sealed class OrganizationHttpClient(HttpClient httpClient) : IOrganizatio
     )
     {
         var response = await httpClient.PostAsJsonAsync(
-            "api/organizations",
+            "organization/organizations",
             dto,
             cancellationToken
         );
@@ -84,7 +84,7 @@ public sealed class OrganizationHttpClient(HttpClient httpClient) : IOrganizatio
     )
     {
         var response = await httpClient.PutAsJsonAsync(
-            $"api/organizations/{id}",
+            $"organization/organizations/{id}",
             dto,
             cancellationToken
         );
@@ -105,7 +105,7 @@ public sealed class OrganizationHttpClient(HttpClient httpClient) : IOrganizatio
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.DeleteAsync($"api/organizations/{id}", cancellationToken);
+        var response = await httpClient.DeleteAsync($"organization/organizations/{id}", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationMemberHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationMemberHttpClient.cs
@@ -24,7 +24,7 @@ public sealed class OrganizationMemberHttpClient(HttpClient httpClient)
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<OrganizationMemberDto>(
-            $"api/organizations/{organizationId}/members{query}",
+            $"organization/organizations/{organizationId}/members{query}",
             cancellationToken
         )!;
     }
@@ -36,7 +36,7 @@ public sealed class OrganizationMemberHttpClient(HttpClient httpClient)
     )
     {
         var response = await httpClient.GetAsync(
-            $"api/organizations/{organizationId}/members/{userId}",
+            $"organization/organizations/{organizationId}/members/{userId}",
             cancellationToken
         );
 
@@ -59,7 +59,7 @@ public sealed class OrganizationMemberHttpClient(HttpClient httpClient)
     )
     {
         var response = await httpClient.PutAsJsonAsync(
-            $"api/organizations/{organizationId}/members/{userId}",
+            $"organization/organizations/{organizationId}/members/{userId}",
             request,
             cancellationToken
         );
@@ -82,7 +82,7 @@ public sealed class OrganizationMemberHttpClient(HttpClient httpClient)
     )
     {
         var response = await httpClient.DeleteAsync(
-            $"api/organizations/{organizationId}/members/{userId}",
+            $"organization/organizations/{organizationId}/members/{userId}",
             cancellationToken
         );
 

--- a/src/Features/Organization/EcoData.Organization.Application.Client/PermissionHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/PermissionHttpClient.cs
@@ -11,7 +11,7 @@ public sealed class PermissionHttpClient(HttpClient httpClient) : IPermissionHtt
     )
     {
         var result = await httpClient.GetFromJsonAsync<UserPermissionsDto>(
-            $"api/organizations/{organizationId}/my-permissions",
+            $"organization/organizations/{organizationId}/my-permissions",
             cancellationToken
         );
 

--- a/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorAlertHttpClient.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorAlertHttpClient.cs
@@ -30,7 +30,7 @@ public sealed class SensorAlertHttpClient(HttpClient httpClient) : ISensorAlertH
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<SensorHealthAlertDtoForList>(
-            $"api/sensors/alerts{queryString}",
+            $"sensors/alerts{queryString}",
             cancellationToken
         )!;
     }
@@ -41,7 +41,7 @@ public sealed class SensorAlertHttpClient(HttpClient httpClient) : ISensorAlertH
     )
     {
         var response = await httpClient.GetAsync(
-            $"/api/sensors/alerts/{alertId}",
+            $"/sensors/alerts/{alertId}",
             cancellationToken
         );
 
@@ -59,7 +59,7 @@ public sealed class SensorAlertHttpClient(HttpClient httpClient) : ISensorAlertH
     )
     {
         using var response = await httpClient.GetAsync(
-            "api/sensors/alerts/stream",
+            "sensors/alerts/stream",
             HttpCompletionOption.ResponseHeadersRead,
             cancellationToken
         );
@@ -89,7 +89,7 @@ public sealed class SensorAlertHttpClient(HttpClient httpClient) : ISensorAlertH
     )
     {
         using var response = await httpClient.GetAsync(
-            $"api/sensors/{sensorId}/alerts/stream",
+            $"sensors/{sensorId}/alerts/stream",
             HttpCompletionOption.ResponseHeadersRead,
             cancellationToken
         );

--- a/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorHealthHttpClient.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorHealthHttpClient.cs
@@ -13,7 +13,7 @@ public sealed class SensorHealthHttpClient(HttpClient httpClient) : ISensorHealt
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.GetAsync("/api/health/sensors/summary", cancellationToken);
+        var response = await httpClient.GetAsync("/sensors/health/summary", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
             return await response.ReadProblemAsync(cancellationToken);
@@ -35,7 +35,7 @@ public sealed class SensorHealthHttpClient(HttpClient httpClient) : ISensorHealt
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<SensorHealthStatusDtoForList>(
-            $"api/health/sensors{queryString}",
+            $"sensors/health{queryString}",
             cancellationToken
         )!;
     }
@@ -45,7 +45,7 @@ public sealed class SensorHealthHttpClient(HttpClient httpClient) : ISensorHealt
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.GetAsync($"/api/sensors/{sensorId}/health", cancellationToken);
+        var response = await httpClient.GetAsync($"/sensors/{sensorId}/health", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
             return await response.ReadProblemAsync(cancellationToken);
@@ -59,7 +59,7 @@ public sealed class SensorHealthHttpClient(HttpClient httpClient) : ISensorHealt
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.GetAsync($"/api/sensors/{sensorId}/health/config", cancellationToken);
+        var response = await httpClient.GetAsync($"/sensors/{sensorId}/health/config", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
             return await response.ReadProblemAsync(cancellationToken);
@@ -74,7 +74,7 @@ public sealed class SensorHealthHttpClient(HttpClient httpClient) : ISensorHealt
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.PutAsJsonAsync($"/api/sensors/{sensorId}/health/config", config, cancellationToken);
+        var response = await httpClient.PutAsJsonAsync($"/sensors/{sensorId}/health/config", config, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
             return await response.ReadProblemAsync(cancellationToken);

--- a/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorHttpClient.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorHttpClient.cs
@@ -16,7 +16,7 @@ public sealed class SensorHttpClient(HttpClient httpClient) : ISensorHttpClient
     )
     {
         var response = await httpClient.PostAsJsonAsync(
-            "api/sensors/register",
+            "sensors/register",
             request,
             cancellationToken
         );
@@ -48,7 +48,7 @@ public sealed class SensorHttpClient(HttpClient httpClient) : ISensorHttpClient
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<SensorDtoForList>(
-            $"api/sensors{queryString}",
+            $"sensors{queryString}",
             cancellationToken
         )!;
     }
@@ -69,7 +69,7 @@ public sealed class SensorHttpClient(HttpClient httpClient) : ISensorHttpClient
             .Build();
 
         return httpClient.GetFromJsonAsync<int>(
-            $"api/sensors/count{queryString}",
+            $"sensors/count{queryString}",
             cancellationToken
         )!;
     }
@@ -79,7 +79,7 @@ public sealed class SensorHttpClient(HttpClient httpClient) : ISensorHttpClient
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.GetAsync($"api/sensors/{sensorId}", cancellationToken);
+        var response = await httpClient.GetAsync($"sensors/{sensorId}", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -96,7 +96,7 @@ public sealed class SensorHttpClient(HttpClient httpClient) : ISensorHttpClient
     )
     {
         var response = await httpClient.PutAsJsonAsync(
-            $"api/sensors/{sensorId}",
+            $"sensors/{sensorId}",
             request,
             cancellationToken
         );
@@ -117,7 +117,7 @@ public sealed class SensorHttpClient(HttpClient httpClient) : ISensorHttpClient
         CancellationToken cancellationToken = default
     )
     {
-        var response = await httpClient.DeleteAsync($"api/sensors/{sensorId}", cancellationToken);
+        var response = await httpClient.DeleteAsync($"sensors/{sensorId}", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorReadingHttpClient.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Application.Client/SensorReadingHttpClient.cs
@@ -30,7 +30,7 @@ public sealed class SensorReadingHttpClient(HttpClient httpClient) : ISensorRead
             .Build();
 
         return httpClient.GetFromJsonAsAsyncEnumerable<ReadingDtoForDetail>(
-            $"api/sensors/{sensorId}/readings{queryString}",
+            $"sensors/{sensorId}/readings{queryString}",
             cancellationToken
         )!;
     }
@@ -41,7 +41,7 @@ public sealed class SensorReadingHttpClient(HttpClient httpClient) : ISensorRead
     )
     {
         var response = await httpClient.GetAsync(
-            $"api/sensors/{sensorId}/readings/parameters",
+            $"sensors/{sensorId}/readings/parameters",
             cancellationToken
         );
 
@@ -66,7 +66,7 @@ public sealed class SensorReadingHttpClient(HttpClient httpClient) : ISensorRead
             .Build();
 
         var response = await httpClient.GetAsync(
-            $"api/sensors/{sensorId}/readings/stats{queryString}",
+            $"sensors/{sensorId}/readings/stats{queryString}",
             cancellationToken
         );
 
@@ -105,7 +105,7 @@ public sealed class SensorReadingHttpClient(HttpClient httpClient) : ISensorRead
         var batch = new ReadingBatchDtoForCreate(sensorId, readingItems);
 
         var response = await httpClient.PostAsJsonAsync(
-            $"api/sensors/{sensorId}/readings",
+            $"sensors/{sensorId}/readings",
             batch,
             cancellationToken
         );
@@ -125,7 +125,7 @@ public sealed class SensorReadingHttpClient(HttpClient httpClient) : ISensorRead
     )
     {
         using var response = await httpClient.GetAsync(
-            $"api/sensors/{sensorId}/readings/stream",
+            $"sensors/{sensorId}/readings/stream",
             HttpCompletionOption.ResponseHeadersRead,
             cancellationToken
         );


### PR DESCRIPTION
## Summary
- Update all HTTP client code to use the new module-prefixed routes
- Fixes client-server communication after PR #176 changed API route prefixes

## Files Updated

**Identity**
- `AuthHttpClient.cs` - `/api/auth` → `/identity/auth`

**Locations**
- `MunicipalityHttpClient.cs` - `/api/municipalities` → `/locations/municipalities`
- `LocationHttpClient.cs` (EcoPortal) - states and municipalities routes

**Organization**
- `OrganizationHttpClient.cs` - `/api/organizations` → `/organization/organizations`
- `OrganizationMemberHttpClient.cs`
- `OrganizationAccessRequestHttpClient.cs` - includes `/api/me/` → `/organization/me/`
- `OrganizationBlockedUserHttpClient.cs`
- `PermissionHttpClient.cs`
- `DataSourceHttpClient.cs` (EcoPortal) - `/api/datasources` → `/organization/datasources`
- API return URLs (Created responses)

**Sensors**
- `SensorHttpClient.cs` - `/api/sensors` → `/sensors`
- `SensorHealthHttpClient.cs` - `/api/health/sensors` → `/sensors/health`
- `SensorAlertHttpClient.cs`
- `SensorReadingHttpClient.cs`

## Test plan
- [ ] Build succeeds with `dotnet build`
- [ ] Client can communicate with API using new routes