### PR TITLE
feat: Add FaunaFinder Blazor Web App for Wildlife features

### DIFF
--- a/src/Apps/FaunaFinder/FaunaFinder.Client/FaunaFinder.Client.csproj
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/FaunaFinder.Client.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
+    <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
+    <PackageReference Include="MudBlazor" Version="9.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.Contracts\EcoData.Wildlife.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Contracts\EcoData.Locations.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -6,12 +6,12 @@
 <MudSnackbarProvider />
 
 <MudLayout>
-    <MudAppBar Elevation="1">
+    <MudAppBar Elevation="1" Fixed="true">
         <MudText Typo="Typo.h5" Class="ml-3">FaunaFinder</MudText>
         <MudSpacer />
         <MudIconButton Icon="@Icons.Material.Filled.Search" Color="Color.Inherit" />
     </MudAppBar>
-    <MudMainContent Class="pa-4">
+    <MudMainContent Class="pt-16 pa-4">
         @Body
     </MudMainContent>
 </MudLayout>

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -1,0 +1,17 @@
+@inherits LayoutComponentBase
+
+<MudThemeProvider />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
+<MudLayout>
+    <MudAppBar Elevation="1">
+        <MudText Typo="Typo.h5" Class="ml-3">FaunaFinder</MudText>
+        <MudSpacer />
+        <MudIconButton Icon="@Icons.Material.Filled.Search" Color="Color.Inherit" />
+    </MudAppBar>
+    <MudMainContent Class="pa-4">
+        @Body
+    </MudMainContent>
+</MudLayout>

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor
@@ -1,0 +1,47 @@
+@page "/"
+
+<PageTitle>FaunaFinder - Puerto Rico Wildlife</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="mt-4">
+    <MudText Typo="Typo.h3" GutterBottom="true">Welcome to FaunaFinder</MudText>
+    <MudText Typo="Typo.body1" Class="mb-4">
+        Discover the wildlife of Puerto Rico. Browse species, explore conservation efforts,
+        and learn about the diverse fauna and flora of the island.
+    </MudText>
+
+    <MudGrid>
+        <MudItem xs="12" sm="6" md="4">
+            <MudCard>
+                <MudCardContent>
+                    <MudText Typo="Typo.h6">Species</MudText>
+                    <MudText Typo="Typo.body2">Browse all species in our database</MudText>
+                </MudCardContent>
+                <MudCardActions>
+                    <MudButton Color="Color.Primary" Href="/species">Explore</MudButton>
+                </MudCardActions>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4">
+            <MudCard>
+                <MudCardContent>
+                    <MudText Typo="Typo.h6">Categories</MudText>
+                    <MudText Typo="Typo.body2">View species by category</MudText>
+                </MudCardContent>
+                <MudCardActions>
+                    <MudButton Color="Color.Primary" Href="/categories">Browse</MudButton>
+                </MudCardActions>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4">
+            <MudCard>
+                <MudCardContent>
+                    <MudText Typo="Typo.h6">Conservation</MudText>
+                    <MudText Typo="Typo.body2">FWS actions and NRCS practices</MudText>
+                </MudCardContent>
+                <MudCardActions>
+                    <MudButton Color="Color.Primary" Href="/conservation">Learn More</MudButton>
+                </MudCardActions>
+            </MudCard>
+        </MudItem>
+    </MudGrid>
+</MudContainer>

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Program.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using MudBlazor.Services;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.Services.AddMudServices();
+
+await builder.Build().RunAsync();

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Routes.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Routes.razor
@@ -1,0 +1,13 @@
+@using FaunaFinder.Client.Layout
+
+<Router AppAssembly="typeof(Routes).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(MainLayout)">
+            <MudText Typo="Typo.h4">Page not found</MudText>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/_Imports.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/_Imports.razor
@@ -1,0 +1,11 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using MudBlazor
+@using FaunaFinder.Client
+@using FaunaFinder.Client.Layout

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/wwwroot/app.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/wwwroot/app.css
@@ -1,0 +1,3 @@
+html, body {
+    font-family: 'Inter', sans-serif;
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Components/App.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Components/App.razor
@@ -1,0 +1,28 @@
+@using Microsoft.AspNetCore.Components.Web
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <title>FaunaFinder - Puerto Rico Wildlife</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="@Assets["app.css"]" />
+    <link rel="stylesheet" href="@Assets["FaunaFinder.Server.styles.css"]" />
+    <HeadOutlet @rendermode="renderMode" />
+</head>
+
+<body>
+    <FaunaFinder.Client.Routes @rendermode="renderMode" />
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_framework/blazor.web.js"></script>
+</body>
+
+</html>
+
+@code {
+    IComponentRenderMode renderMode = new InteractiveWebAssemblyRenderMode(prerender: false);
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/FaunaFinder.Server.csproj
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/FaunaFinder.Server.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MudBlazor" Version="9.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FaunaFinder.Client\FaunaFinder.Client.csproj" />
+    <ProjectReference Include="..\..\..\Host\EcoData.ServiceDefaults\EcoData.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.Api\EcoData.Wildlife.Api.csproj" />
+    <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.DataAccess\EcoData.Wildlife.DataAccess.csproj" />
+    <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.Database\EcoData.Wildlife.Database.csproj" />
+    <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Api\EcoData.Locations.Api.csproj" />
+    <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.DataAccess\EcoData.Locations.DataAccess.csproj" />
+    <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Database\EcoData.Locations.Database.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
@@ -1,0 +1,46 @@
+using EcoData.Locations.Api;
+using EcoData.Locations.DataAccess.Extensions;
+using EcoData.Locations.Database.Extensions;
+using EcoData.Wildlife.Api;
+using EcoData.Wildlife.DataAccess;
+using EcoData.Wildlife.Database.Extensions;
+using FaunaFinder.Server.Components;
+using MudBlazor.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+builder.AddLocationsDatabase();
+builder.AddWildlifeDatabase();
+
+builder.Services.AddRazorComponents().AddInteractiveWebAssemblyComponents();
+builder.Services.AddMudServices();
+builder.Services.AddLocationsDataAccess();
+builder.Services.AddWildlifeDataAccess();
+
+var app = builder.Build();
+
+app.MapDefaultEndpoints();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseWebAssemblyDebugging();
+}
+else
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    app.UseHsts();
+}
+
+app.UseAntiforgery();
+
+app.MapStaticAssets();
+app.MapRazorComponents<App>()
+    .AddInteractiveWebAssemblyRenderMode()
+    .AddAdditionalAssemblies(typeof(FaunaFinder.Client._Imports).Assembly);
+
+app.MapStateEndpoints();
+app.MapMunicipalityEndpoints();
+app.MapWildlifeApiEndpoints();
+
+app.Run();

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Properties/launchSettings.json
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5300",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Host/EcoData.AppHost/AppHost.cs
+++ b/src/Host/EcoData.AppHost/AppHost.cs
@@ -72,6 +72,14 @@ var ecoportal = builder
         }
     );
 
+// FaunaFinder app (local development only)
+var faunafinder = builder
+    .AddProject<Projects.FaunaFinder_Server>("faunafinder")
+    .WithReference(locationsDb)
+    .WithReference(wildlifeDb)
+    .WaitFor(seeder)
+    .ExcludeFromManifest();
+
 var sensorsIngestion = builder
     .AddProject<Projects.EcoData_Sensors_Ingestion>("sensors-ingestion")
     .WithReference(organizationDb)

--- a/src/Host/EcoData.AppHost/EcoData.AppHost.csproj
+++ b/src/Host/EcoData.AppHost/EcoData.AppHost.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Apps\EcoPortal\EcoPortal.Server\EcoPortal.Server.csproj" />
+    <ProjectReference Include="..\..\Apps\FaunaFinder\FaunaFinder.Server\FaunaFinder.Server.csproj" />
     <ProjectReference Include="..\..\Features\Sensors\EcoData.Sensors.Ingestion\EcoData.Sensors.Ingestion.csproj" />
     <ProjectReference Include="..\EcoData.Seeder\EcoData.Seeder.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Zig\Aspire.Hosting.Zig.csproj" IsAspireProjectResource="false" />


### PR DESCRIPTION
## Summary
- Add FaunaFinder Blazor Web App (WASM + Server) for Wildlife features
- Configure with MudBlazor UI components and Wildlife/Locations API endpoints
- Excluded from manifest for local development only

## Test plan
- [ ] Run AppHost and verify FaunaFinder appears in dashboard
- [ ] Navigate to FaunaFinder and confirm home page loads
- [ ] Verify MudBlazor components render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)