### PR TITLE
fix: Resolve Blazor page route conflicts with API endpoints

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/Components/PublicGuide.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/GettingStarted/Components/PublicGuide.razor
@@ -36,7 +36,7 @@
                     <MudText Typo="Typo.body2">
                         Search and filter sensors by location or name. View detailed information about each monitoring station.
                     </MudText>
-                    <MudButton Href="/sensors" Variant="Variant.Text" Color="Color.Primary" EndIcon="@Icons.Material.Filled.ArrowForward">
+                    <MudButton Href="/sensor-dashboard" Variant="Variant.Text" Color="Color.Primary" EndIcon="@Icons.Material.Filled.ArrowForward">
                         View Sensors
                     </MudButton>
                 </MudStack>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/HealthAlerts/Pages/AlertDetailPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/HealthAlerts/Pages/AlertDetailPage.razor
@@ -44,7 +44,7 @@
                             <tr>
                                 <td><strong>Sensor</strong></td>
                                 <td>
-                                    <MudLink Href="@($"/sensors/{_alert.SensorId}")">
+                                    <MudLink Href="@($"/sensor/{_alert.SensorId}")">
                                         @_alert.SensorName
                                     </MudLink>
                                 </td>
@@ -122,7 +122,7 @@
     {
         if (_alert is not null)
         {
-            Navigation.NavigateTo($"/sensors/{_alert.SensorId}");
+            Navigation.NavigateTo($"/sensor/{_alert.SensorId}");
         }
     }
 

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationSensors/Pages/OrganizationSensorsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationSensors/Pages/OrganizationSensorsPage.razor
@@ -49,6 +49,6 @@
 
     private void NavigateToDetail(SensorDtoForList sensor)
     {
-        Navigation.NavigateTo($"/sensors/{sensor.Id}");
+        Navigation.NavigateTo($"/sensor/{sensor.Id}");
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
@@ -515,7 +515,7 @@
     private void NavigateToSensors() => Navigation.NavigateTo($"/organizations/{Id}/sensors");
     private void NavigateToTeam() => Navigation.NavigateTo($"/organizations/{Id}/team");
     private void NavigateToMap() => Navigation.NavigateTo($"/organizations/{Id}/map");
-    private void NavigateToSensor(SensorDtoForList sensor) => Navigation.NavigateTo($"/sensors/{sensor.Id}");
+    private void NavigateToSensor(SensorDtoForList sensor) => Navigation.NavigateTo($"/sensor/{sensor.Id}");
     private void NavigateToCreateSensor() => Navigation.NavigateTo($"/organizations/{Id}/sensors/create");
 
     private async Task ConfirmDelete()

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationMapPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationMapPage.razor
@@ -149,7 +149,7 @@
 
     private void NavigateToSensor(Guid sensorId)
     {
-        Navigation.NavigateTo($"/sensors/{sensorId}");
+        Navigation.NavigateTo($"/sensor/{sensorId}");
     }
 
     private void NavigateBack()

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorConfigurePage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorConfigurePage.razor
@@ -1,4 +1,4 @@
-@page "/sensors/{SensorId:guid}/configure"
+@page "/sensor/{SensorId:guid}/configure"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
 @using EcoData.Sensors.Application.Client
@@ -19,7 +19,7 @@
 
 <PageTitle>Configure Sensor - EcoData</PageTitle>
 
-<NuiPageLayout Title="Configure Sensor" ParentPath="@($"/sensors/{SensorId}")">
+<NuiPageLayout Title="Configure Sensor" ParentPath="@($"/sensor/{SensorId}")">
         @if (LoadCommand.IsLoading)
         {
             <MudStack Spacing="4">
@@ -345,7 +345,7 @@
         );
     }
 
-    private void NavigateToEdit() => Navigation.NavigateTo($"/sensors/{SensorId}/edit");
+    private void NavigateToEdit() => Navigation.NavigateTo($"/sensor/{SensorId}/edit");
 
     private Color GetHealthStatusColor() => _healthStatus?.Status switch
     {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/Components/SensorReadingsPreview.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/Components/SensorReadingsPreview.razor
@@ -95,6 +95,6 @@ else
 
     private void NavigateToReadings()
     {
-        Navigation.NavigateTo($"/sensors/{SensorId}/readings");
+        Navigation.NavigateTo($"/sensor/{SensorId}/readings");
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailAuthenticated.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailAuthenticated.razor
@@ -320,9 +320,9 @@
         _ = _statsFetch.FetchAsync();
     }
 
-    private void NavigateToConfigure() => Navigation.NavigateTo($"/sensors/{Sensor.Id}/configure");
+    private void NavigateToConfigure() => Navigation.NavigateTo($"/sensor/{Sensor.Id}/configure");
 
-    private void NavigateToEdit() => Navigation.NavigateTo($"/sensors/{Sensor.Id}/edit");
+    private void NavigateToEdit() => Navigation.NavigateTo($"/sensor/{Sensor.Id}/edit");
 
     private async Task ConfirmDelete()
     {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorDetailPages/SensorDetailPage.razor
@@ -1,4 +1,4 @@
-@page "/sensors/{SensorId:guid}"
+@page "/sensor/{SensorId:guid}"
 @using EcoData.Sensors.Contracts.Dtos
 @using EcoData.Sensors.Application.Client
 @using EcoPortal.Client.Components
@@ -8,7 +8,7 @@
 
 <PageTitle>Sensor Details - EcoData</PageTitle>
 
-<NuiPageLayout Title="Sensor Details" ParentPath="/sensors">
+<NuiPageLayout Title="Sensor Details" ParentPath="/sensor-dashboard">
         @if (_loading)
         {
             <SensorDetailSkeleton />

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorEditPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorEditPage.razor
@@ -1,4 +1,4 @@
-@page "/sensors/{SensorId:guid}/edit"
+@page "/sensor/{SensorId:guid}/edit"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
 @using EcoData.Sensors.Application.Client
@@ -17,7 +17,7 @@
 
 <PageTitle>Edit Sensor - EcoData</PageTitle>
 
-<NuiPageLayout Title="Edit Sensor" ParentPath="@($"/sensors/{SensorId}")">
+<NuiPageLayout Title="Edit Sensor" ParentPath="@($"/sensor/{SensorId}")">
         @if (LoadCommand.IsLoading)
         {
             <MudPaper Elevation="1" Class="pa-6">
@@ -126,7 +126,7 @@
             _ =>
             {
                 Snackbar.Add("Sensor updated successfully", Severity.Success);
-                Navigation.NavigateTo($"/sensors/{SensorId}", replace: true);
+                Navigation.NavigateTo($"/sensor/{SensorId}", replace: true);
             },
             problem => _errorMessage = problem.Detail ?? "Failed to update sensor"
         );

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorReadingsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorReadingsPage.razor
@@ -1,4 +1,4 @@
-@page "/sensors/{SensorId:guid}/readings"
+@page "/sensor/{SensorId:guid}/readings"
 @using EcoData.Sensors.Contracts.Dtos
 @using EcoData.Sensors.Application.Client
 @using EcoPortal.Client.Features.Sensors.Dialogs
@@ -11,7 +11,7 @@
 
 <PageTitle>Sensor Readings - EcoData</PageTitle>
 
-<NuiPageLayout Title="Readings" ParentPath="@($"/sensors/{SensorId}")">
+<NuiPageLayout Title="Readings" ParentPath="@($"/sensor/{SensorId}")">
         @if (_loading)
         {
             <MudPaper Elevation="0" Class="pa-4 rounded-lg" Style="border: 1px solid var(--mud-palette-lines-default);">

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorsPage.razor
@@ -1,4 +1,4 @@
-@page "/sensors"
+@page "/sensor-dashboard"
 @using EcoData.Sensors.Contracts.Dtos
 @using EcoPortal.Client.Features.Sensors.Components
 @inject INativeNavigationManager Navigation
@@ -20,6 +20,6 @@
 
     private void NavigateToDetail(SensorDtoForList sensor)
     {
-        Navigation.NavigateTo($"/sensors/{sensor.Id}");
+        Navigation.NavigateTo($"/sensor/{sensor.Id}");
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Pages/GettingStartedPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Pages/GettingStartedPage.razor
@@ -83,7 +83,7 @@
                 <MudText Typo="Typo.h6">Quick Links</MudText>
                 <MudGrid Spacing="2">
                     <MudItem xs="12" sm="6" md="3">
-                        <MudButton Href="/sensors" Variant="Variant.Outlined" FullWidth="true"
+                        <MudButton Href="/sensor-dashboard" Variant="Variant.Outlined" FullWidth="true"
                                    StartIcon="@Icons.Material.Outlined.Sensors" Color="Color.Primary">
                             Browse Sensors
                         </MudButton>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Pages/MonitorPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Pages/MonitorPage.razor
@@ -9,7 +9,7 @@
         <QuickActionCard Icon="@Icons.Material.Filled.Water"
                          Title="Sensors"
                          Description="View sensor data"
-                         OnClick="@(() => Navigation.NavigateTo("/sensors"))" />
+                         OnClick="@(() => Navigation.NavigateTo("/sensor-dashboard"))" />
 
         <QuickActionCard Icon="@Icons.Material.Filled.Notifications"
                          Title="Alerts"

--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/TabNavigationService.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/TabNavigationService.cs
@@ -54,7 +54,7 @@ public sealed class TabNavigationService : ITabNavigationService
     private static NavigationTab GetTabFromPath(string path) => path switch
     {
         "/" or "" => NavigationTab.Home,
-        _ when path.StartsWith("/monitor") || path.StartsWith("/sensors") || path.StartsWith("/alerts")
+        _ when path.StartsWith("/monitor") || path.StartsWith("/sensor") || path.StartsWith("/alerts")
             => NavigationTab.Monitor,
         _ when path.StartsWith("/orgs") || path.StartsWith("/organizations") || path.StartsWith("/access-requests")
             => NavigationTab.Orgs,

--- a/src/Apps/EcoPortal/EcoPortal.Server/wwwroot/sitemap.xml
+++ b/src/Apps/EcoPortal/EcoPortal.Server/wwwroot/sitemap.xml
@@ -11,7 +11,7 @@
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://portal.ecodatapr.com/sensors</loc>
+    <loc>https://portal.ecodatapr.com/sensor-dashboard</loc>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary
- Fix `AmbiguousMatchException` in production caused by Blazor page routes conflicting with module-prefixed API routes
- Change `/sensors` to `/sensor-dashboard` for sensors list page
- Change `/sensors/{id}` to `/sensor/{id}` for sensor detail pages (singular form)
- Update all navigation links and sitemap

## Root Cause
After PR #176 changed API routes to use module prefixes (`/sensors` instead of `/api/sensors`), the Blazor page routes started conflicting with API endpoints:
- Blazor: `@page "/sensors"` vs API: `GET /sensors`
- Blazor: `@page "/sensors/{id:guid}"` vs API: `GET /sensors/{id:guid}`

## Test plan
- [ ] Deploy to production
- [ ] Verify no more AmbiguousMatchException errors
- [ ] Verify sensor pages load correctly at new URLs
- [ ] Verify navigation works throughout the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)