### PR TITLE
fix: Sync auth state after login without page refresh

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Program.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Program.cs
@@ -8,7 +8,6 @@ using EcoPortal.Client.Features.Organizations.Services;
 using EcoPortal.Client.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 
@@ -38,8 +37,8 @@ builder.Services.AddScoped<ILeafletMapService, LeafletMapService>();
 builder.Services.AddNativeUi();
 builder.Services.AddScoped<ITabNavigationService, TabNavigationService>();
 
-builder.Services.AddAuthenticationStateDeserialization();
 builder.Services.AddScoped<AuthStateService>();
+builder.Services.AddScoped<AuthenticationStateProvider, EcoPortalAuthStateProvider>();
 builder.Services.AddScoped<PermissionContextService>();
 
 // Register custom policy provider BEFORE AddAuthorizationCore (uses TryAddSingleton)

--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/EcoPortalAuthStateProvider.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/EcoPortalAuthStateProvider.cs
@@ -1,0 +1,36 @@
+using EcoData.Identity.Contracts.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace EcoPortal.Client.Services;
+
+public sealed class EcoPortalAuthStateProvider : AuthenticationStateProvider, IDisposable
+{
+    private readonly AuthStateService _authStateService;
+
+    public EcoPortalAuthStateProvider(AuthStateService authStateService)
+    {
+        _authStateService = authStateService;
+        _authStateService.OnAuthStateChanged += HandleAuthStateChanged;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        if (!_authStateService.IsInitialized)
+        {
+            await _authStateService.InitializeAsync();
+        }
+
+        var principal = _authStateService.CurrentUser.ToClaimsPrincipal();
+        return new AuthenticationState(principal);
+    }
+
+    private void HandleAuthStateChanged()
+    {
+        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+    }
+
+    public void Dispose()
+    {
+        _authStateService.OnAuthStateChanged -= HandleAuthStateChanged;
+    }
+}

--- a/src/Features/Identity/EcoData.Identity.Contracts/Claims/UserClaimsExtensions.cs
+++ b/src/Features/Identity/EcoData.Identity.Contracts/Claims/UserClaimsExtensions.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+using EcoData.Identity.Contracts.Responses;
+
+namespace EcoData.Identity.Contracts.Claims;
+
+public static class UserClaimsExtensions
+{
+    public static IEnumerable<Claim> ToClaims(this UserInfo user)
+    {
+        yield return new Claim(ClaimTypes.NameIdentifier, user.Id.ToString());
+        yield return new Claim(ClaimTypes.Email, user.Email);
+        yield return new Claim(ClaimTypes.Name, user.DisplayName);
+
+        if (user.GlobalRole.HasValue)
+        {
+            yield return new Claim(ClaimTypes.Role, user.GlobalRole.Value.ToString());
+        }
+    }
+
+    public static ClaimsPrincipal ToClaimsPrincipal(this UserInfo? user, string authenticationType = "EcoPortal")
+    {
+        if (user is null)
+        {
+            return new ClaimsPrincipal(new ClaimsIdentity());
+        }
+
+        var identity = new ClaimsIdentity(user.ToClaims(), authenticationType);
+        return new ClaimsPrincipal(identity);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix bug where `AuthorizeView` components showed unauthenticated content until page refresh after login
- Add `UserClaimsExtensions` for unified claims creation from `UserInfo`
- Add `EcoPortalAuthStateProvider` that bridges `AuthStateService` to `AuthenticationStateProvider`

## Root Cause
Two independent auth systems weren't communicating:
1. `AuthStateService` - Updated immediately on login
2. `AuthenticationStateProvider` - Used by `AuthorizeView`, NOT notified on login

## Solution
Custom `EcoPortalAuthStateProvider` subscribes to `AuthStateService.OnAuthStateChanged` and calls `NotifyAuthenticationStateChanged()` to sync framework state.

## Test plan
- [ ] Login and navigate to `/sensors/{id}` - should show authenticated view immediately
- [ ] Logout - `AuthorizeView` should show unauthenticated content
- [ ] Page refresh - auth state should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)