### PR TITLE
feat: FaunaFinder species overhaul — backend & contracts (#188)

### DIFF
--- a/docs/faunafinder-species-overhaul-plan.md
+++ b/docs/faunafinder-species-overhaul-plan.md
@@ -1,0 +1,413 @@
+# FaunaFinder — Species Page Overhaul Plan
+
+Source of truth for the redesign: `FaunaMockup/` (React + plain CSS field-guide design).
+Target: `src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Species.razor` and supporting components / contracts / data.
+
+The overhaul is split into two sequenced plans:
+
+- **Plan 1 — Backend & Contracts** (schema, DTOs, endpoints, seeding) — must land first.
+- **Plan 2 — UI** (Blazor components, theme, CSS) — assumes Plan 1's columns/endpoints exist.
+
+Out of scope for both plans:
+- The "Sort" affordance is decorative in the mockup (no real sort menu drives anything actionable). Implement only if also adding sort filter parameters; otherwise the toolbar control becomes a static label.
+- Pagination row is decorative — list stays cursor-paged with infinite scroll (matches `EcoDataVirtualizedList`). Mockup itself says "scrolling loads more records".
+- The "Tweaks" panel from the mockup (designer-only edit-mode) is not shipped.
+- Footer (`.ff-footer` block) — no parity for marketing footer in this app.
+
+---
+
+## Mockup → Current state gap matrix
+
+| Mockup feature | Current backing | Action |
+|---|---|---|
+| Editorial hero with eyebrow + meta line | `NuiPageLayout` plain title | UI-only: new `SpeciesEditorialHero` component |
+| 4-stat row (total / endemic / threatened / municipios) | `/wildlife/species/count` only | **Backend**: stats endpoint + `IsEndemic` column |
+| "▲ 12 this quarter" delta | none | **Backend**: `CreatedAtUtc` column on Species + delta in stats |
+| Featured row (1 large + 2 medium) | none | **Backend**: `IsFeatured` flag + `/wildlife/species/featured` endpoint |
+| Search by common, scientific OR municipio name | scientific only (`Repository.ApplyFilters`) | **Backend**: extend `Search` matching to common names + municipality names |
+| Filter chip "Taxon: Birds, Reptiles, Plants" with 8 fixed taxa + counts | generic `SpeciesCategory` table (no fixed taxonomy) | **Backend**: seed 8 standardized `SpeciesCategory` codes (`bird`, `plant`, `reptile`, `amphib`, `fish`, `mammal`, `invert`, `fungi`) + facet counts endpoint |
+| Filter chip "Status: EN, CR" w/ IUCN codes (LC/NT/VU/EN/CR/DD) | only `GRank`/`SRank` (NatureServe) | **Backend**: `IucnStatus` enum column + facet counts endpoint |
+| "Endemic only" qualifier | none | **Backend**: `IsEndemic` column + filter parameter |
+| "Observed in last 12 months" qualifier | none | **Backend**: `LastObservedAtUtc` column + filter parameter |
+| "Has high-resolution imagery" qualifier | only `HasProfileImage` bool | **Backend**: stretch — promote to threshold (we don't track resolution). Recommendation: rename UI label to "Has photo" and reuse `HasProfileImage` filter; do not add a column. |
+| "Minimum municipios present" slider | none (we have count derivable from `MunicipalitySpecies`) | **Backend**: `MinMunicipalityCount` filter parameter |
+| Card footer "5 municipios" | `SpeciesDtoForList` has no count | **Backend**: add `MunicipalityCount` to `SpeciesDtoForList` |
+| Card footer "lastSeen 3d ago" / "Verified" | none | **Backend**: include `LastObservedAtUtc` in `SpeciesDtoForList` |
+| Endemic badge on cards | none | depends on `IsEndemic` (Plan 1) |
+| Card grid layout (4 cols, 4:3 image, taxa icon overlay, status pill, hover lift, grayscale→color) | `SpeciesCard` is a flat MudPaper row | UI-only: rewrite `SpeciesCard` (kept name, new template) |
+| Filter modal layout (taxa grid, status list, qualifiers, range slider) | `SpeciesFilterDialog` is a 2-select dropdown | UI-only: rewrite (uses new filter params from Plan 1) |
+| Theme: deep pine `#1f4d3a` primary, warm paper bg `#f4f4ef` | `FaunaFinderTheme` uses `#2d6a4f` and `#f8f9fa` | UI-only: edit `FaunaFinderTheme.cs` + add design-token CSS |
+| Toolbar-level search + filter button + active chip row | `SpeciesList` already has `NuiSearchBar` + filter dialog + active chip stack | UI-only: restyle to match editorial layout |
+| Lang toggle EN/ES in topbar, "Contribute" CTA, account icon | not in scope | skip — keep current `MainLayout` |
+
+---
+
+# Plan 1 — Backend & Contracts
+
+Scope: schema migration, DTO updates, repository changes, new endpoints, HTTP client surface, seeder updates. UI is **not** touched here; the existing UI keeps compiling against the new contracts (additive, plus filter param extensions).
+
+## 1.1 Schema additions to `Species`
+
+File: `src/Features/Wildlife/EcoData.Wildlife.Database/Models/Species.cs`
+
+Add columns (keep `required` discipline):
+
+```csharp
+public required bool IsEndemic { get; set; }                  // PR-endemic flag
+public required IucnStatus? IucnStatus { get; set; }          // LC/NT/VU/EN/CR/DD/EX/null
+public required bool IsFeatured { get; set; }                 // editorial pick
+public string? Habitat { get; set; }                          // short label, optional
+public DateTimeOffset? LastObservedAtUtc { get; set; }        // denormalized from sightings
+public DateTimeOffset CreatedAtUtc { get; set; }              // for "this quarter" delta
+```
+
+New enum `EcoData.Wildlife.Contracts.IucnStatus { LC, NT, VU, EN, CR, DD, EX }` in the contracts assembly so DTOs and parameters can reference it without leaking the database.
+
+`EntityConfiguration` updates:
+- `IucnStatus` stored as `string` (8-char max) via `HasConversion<string>()`.
+- Add `HasIndex(s => s.IsFeatured).HasFilter("is_featured = true")` for the featured row query.
+- Add `HasIndex(s => s.IucnStatus)` for facet counts.
+- Add `HasIndex(s => s.IsEndemic).HasFilter("is_endemic = true")`.
+- `CreatedAtUtc` defaults to `now()` at column level (`HasDefaultValueSql("now()")`).
+
+Single migration: `AddSpeciesEditorialFields`.
+
+## 1.2 DTO additions
+
+File: `src/Features/Wildlife/EcoData.Wildlife.Contracts/Dtos/SpeciesDtos.cs`
+
+```csharp
+public sealed record SpeciesDtoForList(
+    Guid Id,
+    IReadOnlyList<LocaleValue> CommonName,
+    string ScientificName,
+    bool IsFauna,
+    string GRank,
+    string SRank,
+    bool HasProfileImage,
+    // NEW:
+    bool IsEndemic,
+    IucnStatus? IucnStatus,
+    string? TaxonCode,                 // resolved primary category code (bird/plant/...)
+    int MunicipalityCount,
+    DateTimeOffset? LastObservedAtUtc,
+    bool IsFeatured
+);
+
+public sealed record SpeciesDtoForDetail(
+    // ... existing fields ...
+    bool IsEndemic,
+    IucnStatus? IucnStatus,
+    string? Habitat,
+    DateTimeOffset? LastObservedAtUtc
+);
+
+// Extend create/update DTOs to accept the new fields.
+```
+
+`SpeciesDtoForList` projection in `SpeciesRepository.GetSpeciesAsync` must:
+- Project `s.MunicipalitySpecies.Count` (cheap; covered by the existing FK index).
+- Project the first `CategoryLinks.Select(cl => cl.Category.Code).FirstOrDefault()` as `TaxonCode`.
+
+## 1.3 Filter parameters
+
+File: `src/Features/Wildlife/EcoData.Wildlife.Contracts/Parameters/SpeciesParameters.cs`
+
+```csharp
+public sealed record SpeciesParameters(
+    int PageSize = 20,
+    Guid? Cursor = null,
+    string? Search = null,
+    Guid? CategoryId = null,
+    Guid? MunicipalityId = null,
+    bool? IsFauna = null,
+    // NEW:
+    bool? IsEndemic = null,
+    bool? HasProfileImage = null,
+    IReadOnlyList<IucnStatus>? IucnStatuses = null,   // multi-select
+    IReadOnlyList<string>? TaxonCodes = null,         // multi-select on category code
+    int? MinMunicipalityCount = null,
+    DateTimeOffset? ObservedSinceUtc = null,
+    SpeciesSort Sort = SpeciesSort.ScientificNameAsc
+) : CursorParameters(PageSize, Cursor);
+
+public enum SpeciesSort { ScientificNameAsc, ScientificNameDesc, RecentlyObserved, MostMunicipalities }
+```
+
+`Repository.ApplyFilters` extension:
+- `Search`: change to `EF.Functions.ILike` (or `ToLower().Contains`) across `ScientificName`, the JSON `CommonName.Value`, and any joined `MunicipalitySpecies.Municipality.Name`. Common-name/municipality search requires `Include`/sub-`Any` queries — verify the existing JSON-owned `CommonName` collection is queryable in PostgreSQL (EF Core supports `OwnsMany.ToJson()` membership).
+- `IucnStatuses`: `s => statuses.Contains(s.IucnStatus.Value)`.
+- `TaxonCodes`: `s.CategoryLinks.Any(cl => codes.Contains(cl.Category.Code))`.
+- `MinMunicipalityCount`: `s.MunicipalitySpecies.Count >= n`.
+- `ObservedSinceUtc`: `s.LastObservedAtUtc >= ts`.
+- `IsEndemic`, `HasProfileImage`: simple bool filters.
+- `Sort`: replace the hardcoded `OrderByDescending(s => s.Id)` ordering with a switch. **Note**: cursor pagination on a non-id column requires a composite cursor or that the chosen sort key be unique. Recommendation: keep Id as the tiebreaker, encode the sort in the cursor (or restrict cursor pagination to `ScientificNameAsc` + `Id`).
+- HTTP client `SpeciesHttpClient.GetSpeciesAsync` must include the new params in `QueryStringBuilder`. Multi-value params (`iucnStatuses`, `taxonCodes`) need `.Add("iucnStatuses", parameters.IucnStatuses)` repeating.
+
+## 1.4 New endpoints
+
+File: `src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesEndpoints.cs`
+
+```csharp
+// 1. Editorial stats — single trip for the StatsRow.
+group.MapGet("/stats", async (
+    ISpeciesRepository repository,
+    CancellationToken ct) => Results.Ok(await repository.GetStatsAsync(ct)))
+    .WithName("GetSpeciesStats");
+
+// 2. Facet counts — drives the filter modal numbers.
+group.MapGet("/facets", async (
+    [AsParameters] SpeciesParameters parameters,   // facets respect current filters
+    ISpeciesRepository repository,
+    CancellationToken ct) => Results.Ok(await repository.GetFacetsAsync(parameters, ct)))
+    .WithName("GetSpeciesFacets");
+
+// 3. Featured row.
+group.MapGet("/featured", async (
+    ISpeciesRepository repository,
+    CancellationToken ct) => Results.Ok(await repository.GetFeaturedAsync(ct)))
+    .WithName("GetFeaturedSpecies");
+```
+
+Repository contract additions in `ISpeciesRepository`:
+
+```csharp
+Task<SpeciesStatsDto> GetStatsAsync(CancellationToken ct = default);
+Task<SpeciesFacetsDto> GetFacetsAsync(SpeciesParameters parameters, CancellationToken ct = default);
+Task<IReadOnlyList<SpeciesDtoForList>> GetFeaturedAsync(CancellationToken ct = default);
+```
+
+DTOs:
+
+```csharp
+public sealed record SpeciesStatsDto(
+    int TotalSpecies,
+    int EndemicCount,
+    int ThreatenedCount,           // VU + EN + CR
+    int MunicipalitiesCovered,
+    int TotalMunicipalities,        // 78 (from locations module — see 1.6)
+    int AddedThisQuarter,           // CreatedAtUtc within last 90 days
+    int ReclassifiedThisQuarter     // optional; can be 0 if untracked
+);
+
+public sealed record TaxonFacetDto(string Code, int Count);
+public sealed record IucnFacetDto(IucnStatus Status, int Count);
+public sealed record SpeciesFacetsDto(
+    IReadOnlyList<TaxonFacetDto> Taxa,
+    IReadOnlyList<IucnFacetDto> Statuses,
+    int EndemicCount,
+    int RecentlyObservedCount,
+    int WithImageCount
+);
+```
+
+`HttpClient` (`SpeciesHttpClient`) gains `GetStatsAsync`, `GetFacetsAsync`, `GetFeaturedAsync` mirroring the endpoints.
+
+## 1.5 Search across joined columns
+
+Update `ApplyFilters` to include common-name + municipality-name matches. Cleanest with PG `ILIKE`:
+
+```csharp
+var pattern = $"%{search.Replace("%","\\%").Replace("_","\\_")}%";
+query = query.Where(s =>
+    EF.Functions.ILike(s.ScientificName, pattern) ||
+    s.CommonName.Any(c => EF.Functions.ILike(c.Value, pattern)) ||
+    s.MunicipalitySpecies.Any(ms => EF.Functions.ILike(ms.Municipality.Name, pattern)));
+```
+
+Verify the JSON `OwnsMany` collection supports `.Any(...)` translation in your EF Core version; if not, fall back to `EF.Functions.JsonContains` or persist a denormalized lower-case search column.
+
+## 1.6 Cross-module: total municipalities
+
+`MunicipalitiesCovered = X / 78` needs the denominator. Two options:
+- **A (preferred, no cross-module call):** seed/configuration constant — Puerto Rico has 78 municipios; expose as `WildlifeOptions.TotalMunicipalitiesInRegion = 78`. Cheaper, no inter-feature call.
+- **B:** call `IMunicipalityRepository.GetCountAsync` from `SpeciesRepository`. Adds a Wildlife → Locations dependency that doesn't exist today; not recommended. Stick with **A**.
+
+## 1.7 Seeding
+
+File: `src/Host/EcoData.Seeder/DatabaseSeederWorker.cs` (`SeedWildlifeAsync`)
+
+- Insert/upsert the 8 fixed `SpeciesCategory` rows with codes: `bird`, `plant`, `reptile`, `amphib`, `fish`, `mammal`, `invert`, `fungi` (with EN + ES `LocaleValue` names). Idempotent on `Code`.
+- Backfill seeded species: assign one of the 8 codes via `SpeciesCategoryLink`, populate `IsEndemic`, `IucnStatus` (mapping table from `GRank`: `G1→CR`, `G2→EN`, `G3→VU`, `G4→NT`, `G5→LC`, `GH/GX→EX`, `GNR/GU→DD`), and seed 3 `IsFeatured = true` rows.
+- Backfill `CreatedAtUtc = now()` (default-value SQL on the column makes this automatic for seed inserts).
+- `LastObservedAtUtc`: leave null until an observations feature exists, or seed random recent dates only on featured rows.
+
+## 1.8 Acceptance for Plan 1
+
+- `dotnet build` is clean.
+- `dotnet ef database update` succeeds against a fresh DB.
+- The seeder runs end-to-end and produces:
+  - 8 species categories with stable codes.
+  - At least 3 featured species.
+  - `IsEndemic`/`IucnStatus` populated where derivable.
+- `GET /wildlife/species/stats` returns non-zero counts.
+- `GET /wildlife/species/facets` returns taxa + status counts that sum to the total.
+- `GET /wildlife/species?taxonCodes=bird&iucnStatuses=EN,CR` returns the filtered subset.
+- Existing pages (`Pages/Species.razor`, `Home.razor`) still render — DTO additions are additive.
+
+---
+
+# Plan 2 — UI Implementation
+
+Assumes Plan 1 is merged: stats / facets / featured endpoints exist; `SpeciesDtoForList` carries `IsEndemic`, `IucnStatus`, `TaxonCode`, `MunicipalityCount`, `LastObservedAtUtc`, `IsFeatured`; filter parameters accept multi-select taxa + statuses + qualifiers + min municipios.
+
+## 2.1 Theme: forest-green palette
+
+File: `src/Apps/FaunaFinder/FaunaFinder.Client/Themes/FaunaFinderTheme.cs`
+
+| Slot | Old | New (mockup) |
+|---|---|---|
+| `Primary` | `#2d6a4f` | `#1f4d3a` (deep pine) |
+| `PrimaryDarken` | `#1b4332` | `#163b2c` |
+| `PrimaryLighten` | `#40916c` | `#3f7d5f` |
+| `Secondary` | `#40916c` | `#3f7d5f` (links / accent) |
+| `Tertiary` | `#74542c` | `#8a6f3e` (field-guide brass — endemic) |
+| `AppbarBackground` | `#2d6a4f` | `#1f4d3a` |
+| `Background` | `#f8f9fa` | `#f4f4ef` (warm paper) |
+| `BackgroundGray` | `#f0f1f3` | `#eceae1` |
+| `LinesDefault` | `#c1c8c2` | `#e5e3dc` |
+
+Dark mode: shift `Primary` to `#5a9b7a` and keep AppBar dark (`#1c1c1e`) — mockup is light-only but we keep dark working.
+
+## 2.2 Design tokens CSS
+
+New file: `src/Apps/FaunaFinder/FaunaFinder.Client/wwwroot/css/fauna-tokens.css`
+
+Port the variable definitions from `FaunaMockup/styles/fauna-tokens.css` (`--fauna-primary*`, `--fauna-line`, `--fauna-bg-alt`, `--status-*`, `--status-*-bg`). Keep the IUCN status-pill colors so the new card can read `style="background:var(--status-en-bg);color:var(--status-en)"` without per-component logic.
+
+Reference it from `App.razor` (`<link>` in head) — already has `app.css` load, add this one before it.
+
+## 2.3 New / rewritten components
+
+App-specific, under `src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/`. Per repo convention (`docs/creating-components.md`): MudBlazor utility classes only; the only custom CSS is in the design-token file from 2.2 plus a card-grid stylesheet alongside `SpeciesCard.razor.css`.
+
+### `SpeciesEditorialHero.razor` (new)
+- Two-column grid (`MudGrid` xs=12 md=8 / md=4).
+- Eyebrow "Volume 03 · Living Atlas" — pull volume from a `[Parameter]` (default static).
+- Display heading "Species of *Puerto Rico*, catalogued and observed." (italic em on "Puerto Rico").
+- Lede paragraph — accept `[Parameter] string Lede`.
+- Right column meta strip: `Last sync · {time}`, `{stats.TotalSpecies} records · {stats.MunicipalitiesCovered} municipios`, `Updated daily`. Receives `SpeciesStatsDto`.
+
+### `SpeciesStatsRow.razor` (new)
+- 4-column grid backed by `SpeciesStatsDto` from `/wildlife/species/stats`.
+- Columns: Total / Endemic / Threatened / Municipios. Each column = label (eyebrow), big number (serif, 2.75rem), sub-line.
+- Loading state via the **loading-state pattern** (no `_isLoading` bool; nullable sentinel — see `MEMORY.md` "Loading state pattern").
+- Use `IFetch<SpeciesStatsDto>` from `BlazingSingularity.Fetch`.
+
+### `SpeciesFeaturedRow.razor` (new)
+- Calls `/wildlife/species/featured`, takes the first 3 cards.
+- Renders `SpeciesCard Variant="Featured"` (1 large) + 2 `Variant="Medium"` in a 3-column grid.
+- Hide the section if the list is empty (no placeholder noise).
+
+### `SpeciesCard.razor` (rewrite — keep the file)
+Replace the row layout entirely. New template:
+```razor
+<article class="ff-card @VariantClass" @onclick="HandleClick">
+    <div class="ff-card-img">
+        @if (Species.HasProfileImage) { <img ... /> } else { <fallback /> }
+        <span class="ff-card-taxa"><MudIcon Icon="@TaxonIcon" /></span>
+        @if (Species.IsEndemic && Variant == SpeciesCardVariant.Featured) { <span class="ff-card-endemic">Endemic PR</span> }
+        @if (Species.IucnStatus is { } status) { <span class="ff-card-status status-@status">@status</span> }
+    </div>
+    <div class="ff-card-body">
+        <div class="ff-card-name">@CommonName</div>
+        <div class="ff-card-sci">@Species.ScientificName</div>
+        <div class="ff-card-foot">
+            <span class="muni"><MudIcon Icon="@Icons.Material.Filled.LocationOn" Size="Size.Small" /> @Species.MunicipalityCount municipios</span>
+            <span>@FormatLastSeen(Species.LastObservedAtUtc)</span>
+        </div>
+    </div>
+</article>
+```
+Variants enum: `Default | Featured | Medium`. Icon mapping table (taxon code → MudBlazor icon) lives in a static `TaxonIcons.cs` next to the card.
+`SpeciesCard.razor.css` holds: card hover lift, image grayscale-to-color reveal on hover, badge positions, status pill colors (referencing the `--status-*` tokens from 2.2).
+
+### `SpeciesGrid.razor` (new — wraps `EcoDataVirtualizedList`)
+- Replaces the inline list usage in `SpeciesList`.
+- Renders cards in a CSS grid: `repeat(4, 1fr)` desktop, `repeat(2, 1fr)` ≤ md, 1 col on xs (CSS in `SpeciesGrid.razor.css`).
+- Skeletons mirror the card aspect ratio (4:3) so initial load doesn't pop.
+
+### `SpeciesToolbar.razor` (new)
+- Search field (`NuiSearchBar` — already exists — keep, but with new placeholder "Search by common name, scientific name, or municipio…").
+- Filter button — opens new `SpeciesFilterDialog`.
+- Active-filter chip row underneath (Taxon: …, Status: …, Endemic only, etc.). Each chip removable; rebuilds parameters and refreshes the virtualized list.
+- Right-aligned counter: "Showing X of {total}".
+
+### `SpeciesFilterDialog.razor` (rewrite)
+Sections, in order, matching the mockup:
+
+1. **Taxonomic group** — `MudGrid` of `SpeciesTaxaChip` (4 cols, 8 cards). Each chip = icon + label + count from `SpeciesFacetsDto.Taxa`. Multi-select. `Select all` link.
+2. **Conservation status (IUCN)** — `MudGrid` 2-col list of rows: pill + label + count. Multi-select.
+3. **Qualifiers** — three checkbox rows: Endemic only / Observed in last 12 months / Has photo (re-labeled from "high-res imagery"). Each shows count from facets.
+4. **Minimum municipios present** — `MudSlider` 1..78 bound to `MinMunicipalityCount`.
+
+Footer: `Reset all filters` (text button) / `Apply · {N} results` (filled). Apply triggers refetch with `count` first, label updates live (debounced).
+
+Result type:
+```csharp
+public sealed record SpeciesFilterResult(
+    IReadOnlyList<string> TaxonCodes,
+    IReadOnlyList<IucnStatus> IucnStatuses,
+    bool IsEndemic,
+    bool ObservedRecently,
+    bool HasPhoto,
+    int MinMunicipalityCount);
+```
+
+## 2.4 `Pages/Species.razor` rewrite (list mode)
+
+Replace the list-mode branch with the editorial composition. Keep the detail-mode branch (`Id is not null`) untouched for now — that's a separate redesign.
+
+```razor
+@if (Id is null)
+{
+    <NuiPageLayout HideTitle="true" FullWidth="true">
+        <div class="ff-page">
+            <SpeciesEditorialHero Stats="_statsFetch?.Data" />
+            <SpeciesStatsRow Stats="_statsFetch?.Data" />
+            <SpeciesFeaturedRow OnSpeciesClick="NavigateToSpeciesDetail" />
+            <SpeciesToolbar Filter="_filter" FilterChanged="OnFilterChanged"
+                            SearchText="@_search" SearchTextChanged="OnSearchChanged"
+                            Stats="_statsFetch?.Data" Facets="_facetsFetch?.Data" />
+            <SpeciesGrid Filter="_filter" Search="@_search"
+                         OnSpeciesClick="NavigateToSpeciesDetail" />
+        </div>
+    </NuiPageLayout>
+}
+```
+
+State:
+- `_statsFetch : IFetch<SpeciesStatsDto>` — fetch on init.
+- `_facetsFetch : IFetch<SpeciesFacetsDto>` — refetch when `_filter`/`_search` change (so chip counts reflect current view).
+- `_filter : SpeciesFilterResult` — default empty.
+- `_search : string?`.
+
+`NuiPageLayout` may need a `FullWidth` parameter (current default constrains via `MudContainer Large`). Verify in `NuiPageLayout.razor`; if absent, add it (Plan 2 task). The mockup uses a 1360px frame, so we can also wrap in `<div class="ff-page">` and let CSS cap width — simpler.
+
+## 2.5 Layout polish
+
+- `MainLayout.razor`: AppBar already uses `Color.Primary`. With the theme change (2.1), the green deepens automatically. Add the `app-bar-blur` class (already there) and remove the `MudDivider` between logo and page title on the species list page (the editorial hero replaces the page-title role) — guard with `IsHomePage || IsSpeciesListPage`.
+- Mockup shows the bottom mobile-nav going away on the species page in favor of toolbar reachability — keep current bottom-nav, no mockup parity work.
+
+## 2.6 Acceptance for Plan 2
+
+Manual verification (dev server, browser):
+- `/species` renders editorial hero, 4 stats, 3 featured cards, toolbar, 4-column card grid.
+- Hover on a card: image fades from 35% grayscale to color, card lifts.
+- Status pill matches IUCN code on each card; endemic species in featured row show the brass "Endemic PR" badge.
+- Open filter modal: 8 taxa cards with counts, 6 status rows with counts, qualifier checkboxes, slider 1..78. Apply updates the grid + active chips + result counter.
+- Search "coqui" matches a Spanish common name; search a municipality name returns species recorded in it.
+- Quote `count` from the toolbar matches the filtered grid total.
+- Theme primary is `#1f4d3a` everywhere (AppBar, buttons, links).
+- Mobile (≤ md): grid collapses to 2 cols, stats wrap to 2x2, hero stacks.
+
+---
+
+## Risk / call-outs
+
+- **IUCN vs NatureServe ranks**: the mockup uses IUCN. The cleanest path is to add an `IucnStatus` column. Mapping `GRank → IucnStatus` is *advisory* (NatureServe uses a finer 1–5 scale that doesn't exactly equal IUCN categories), so seeding via the mapping is acceptable but not authoritative. Document this in the seeder.
+- **`OwnsMany.ToJson` queryability**: `s.CommonName.Any(c => EF.Functions.ILike(c.Value, ...))` may not translate in older EF Core versions. Verify against the project's EF Core version (check `FaunaFinder.Client.csproj` / Wildlife project for `Microsoft.EntityFrameworkCore` version) before committing the search-extension code. Fallback: add a denormalized `SearchableNames` column populated on save.
+- **Cursor pagination + sort**: enabling `Sort` requires either restricting cursor pagination to `ScientificNameAsc` (with composite `(name, id)` cursor) or accepting that non-default sorts use offset pagination. Keep cursor pagination as-is and treat the toolbar `Sort` button as a follow-up enhancement.
+- **`HasHighResImage` filter**: we don't store image dimensions. Recommend re-labeling the qualifier "Has photo" and reusing `HasProfileImage`. If true high-res classification is desired later, add a `ProfileImageWidth` column.
+- **Featured row scope**: 3 hand-curated species. Either set `IsFeatured = true` in seed data (preferred) or expose a small admin affordance — out of scope here.
+- **No new Observations table**: `LastObservedAtUtc` is a denormalized column. When an observations feature lands, it should update this column (or be replaced by a query). Keep the column semantically optional so older species can render "Verified" instead of "3d ago".

--- a/src/Apps/EcoPortal/EcoPortal.Server/Program.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Server/Program.cs
@@ -42,7 +42,7 @@ builder.Services.AddIdentityApplication(builder.Configuration);
 builder.Services.AddLocationsDataAccess();
 builder.Services.AddOrganizationDataAccess();
 builder.Services.AddSensorsDataAccess();
-builder.Services.AddWildlifeDataAccess();
+builder.Services.AddWildlifeDataAccess(builder.Configuration);
 builder.Services.AddMessaging(messaging => messaging.UseInMemoryTransport());
 builder.Services.AddScoped<INotificationRoutingService, NotificationRoutingService>();
 builder.Services.AddHostedService<SensorHealthMonitorWorker>();

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
@@ -16,7 +16,7 @@ builder.AddWildlifeDatabase();
 builder.Services.AddRazorComponents().AddInteractiveWebAssemblyComponents();
 builder.Services.AddMudServices();
 builder.Services.AddLocationsDataAccess();
-builder.Services.AddWildlifeDataAccess();
+builder.Services.AddWildlifeDataAccess(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/Features/Common/EcoData.Common.Http.Helpers/QueryStringBuilder.cs
+++ b/src/Features/Common/EcoData.Common.Http.Helpers/QueryStringBuilder.cs
@@ -64,6 +64,43 @@ public sealed class QueryStringBuilder
         return this;
     }
 
+    public QueryStringBuilder Add<T>(string key, IReadOnlyList<T>? values)
+    {
+        if (values is null || values.Count == 0)
+        {
+            return this;
+        }
+
+        foreach (var value in values)
+        {
+            if (value is null)
+            {
+                continue;
+            }
+
+            var text = value.ToString();
+            if (string.IsNullOrEmpty(text))
+            {
+                continue;
+            }
+
+            _parameters.Add($"{key}={Uri.EscapeDataString(text)}");
+        }
+
+        return this;
+    }
+
+    public QueryStringBuilder Add<TEnum>(string key, TEnum? value)
+        where TEnum : struct, Enum
+    {
+        if (value.HasValue)
+        {
+            _parameters.Add($"{key}={Uri.EscapeDataString(value.Value.ToString())}");
+        }
+
+        return this;
+    }
+
     public string Build()
     {
         return _parameters.Count > 0 ? $"?{string.Join("&", _parameters)}" : string.Empty;

--- a/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesEndpoints.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Api/Endpoints/SpeciesEndpoints.cs
@@ -104,6 +104,37 @@ public static class SpeciesEndpoints
             )
             .WithName("GetSpeciesByCategory");
 
+        group
+            .MapGet(
+                "/stats",
+                async Task<Ok<SpeciesStatsDto>> (
+                    ISpeciesRepository repository,
+                    CancellationToken ct
+                ) => TypedResults.Ok(await repository.GetStatsAsync(ct))
+            )
+            .WithName("GetSpeciesStats");
+
+        group
+            .MapGet(
+                "/facets",
+                async Task<Ok<SpeciesFacetsDto>> (
+                    [AsParameters] SpeciesParameters parameters,
+                    ISpeciesRepository repository,
+                    CancellationToken ct
+                ) => TypedResults.Ok(await repository.GetFacetsAsync(parameters, ct))
+            )
+            .WithName("GetSpeciesFacets");
+
+        group
+            .MapGet(
+                "/featured",
+                async Task<Ok<IReadOnlyList<SpeciesDtoForList>>> (
+                    ISpeciesRepository repository,
+                    CancellationToken ct
+                ) => TypedResults.Ok(await repository.GetFeaturedAsync(ct))
+            )
+            .WithName("GetFeaturedSpecies");
+
         return app;
     }
 }

--- a/src/Features/Wildlife/EcoData.Wildlife.Application.Client/ISpeciesHttpClient.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Application.Client/ISpeciesHttpClient.cs
@@ -22,4 +22,12 @@ public interface ISpeciesHttpClient
     Task<IReadOnlyList<SpeciesDtoForList>> GetByCategoryAsync(
         Guid categoryId,
         CancellationToken ct = default);
+
+    Task<SpeciesStatsDto?> GetStatsAsync(CancellationToken ct = default);
+
+    Task<SpeciesFacetsDto?> GetFacetsAsync(
+        SpeciesParameters? parameters = null,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<SpeciesDtoForList>> GetFeaturedAsync(CancellationToken ct = default);
 }

--- a/src/Features/Wildlife/EcoData.Wildlife.Application.Client/SpeciesHttpClient.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Application.Client/SpeciesHttpClient.cs
@@ -13,14 +13,7 @@ public sealed class SpeciesHttpClient(HttpClient httpClient) : ISpeciesHttpClien
     {
         parameters ??= new SpeciesParameters();
 
-        var queryString = new QueryStringBuilder()
-            .Add("pageSize", parameters.PageSize != 20 ? parameters.PageSize : null)
-            .Add("cursor", parameters.Cursor)
-            .Add("search", parameters.Search)
-            .Add("categoryId", parameters.CategoryId)
-            .Add("municipalityId", parameters.MunicipalityId)
-            .Add("isFauna", parameters.IsFauna)
-            .Build();
+        var queryString = BuildListQueryString(parameters, includePageSize: true);
 
         return httpClient.GetFromJsonAsAsyncEnumerable<SpeciesDtoForList>(
             $"wildlife/species{queryString}",
@@ -33,12 +26,7 @@ public sealed class SpeciesHttpClient(HttpClient httpClient) : ISpeciesHttpClien
     {
         parameters ??= new SpeciesParameters();
 
-        var queryString = new QueryStringBuilder()
-            .Add("search", parameters.Search)
-            .Add("categoryId", parameters.CategoryId)
-            .Add("municipalityId", parameters.MunicipalityId)
-            .Add("isFauna", parameters.IsFauna)
-            .Build();
+        var queryString = BuildListQueryString(parameters, includePageSize: false);
 
         var response = await httpClient.GetAsync($"wildlife/species/count{queryString}", ct);
         if (!response.IsSuccessStatusCode) return 0;
@@ -83,6 +71,71 @@ public sealed class SpeciesHttpClient(HttpClient httpClient) : ISpeciesHttpClien
             return [];
 
         return await response.Content.ReadFromJsonAsync<IReadOnlyList<SpeciesDtoForList>>(ct) ?? [];
+    }
+
+    public async Task<SpeciesStatsDto?> GetStatsAsync(CancellationToken ct = default)
+    {
+        var response = await httpClient.GetAsync("wildlife/species/stats", ct);
+
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        return await response.Content.ReadFromJsonAsync<SpeciesStatsDto>(ct);
+    }
+
+    public async Task<SpeciesFacetsDto?> GetFacetsAsync(
+        SpeciesParameters? parameters = null,
+        CancellationToken ct = default)
+    {
+        parameters ??= new SpeciesParameters();
+
+        var queryString = BuildListQueryString(parameters, includePageSize: false);
+
+        var response = await httpClient.GetAsync($"wildlife/species/facets{queryString}", ct);
+
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        return await response.Content.ReadFromJsonAsync<SpeciesFacetsDto>(ct);
+    }
+
+    public async Task<IReadOnlyList<SpeciesDtoForList>> GetFeaturedAsync(
+        CancellationToken ct = default)
+    {
+        var response = await httpClient.GetAsync("wildlife/species/featured", ct);
+
+        if (!response.IsSuccessStatusCode)
+            return [];
+
+        return await response.Content.ReadFromJsonAsync<IReadOnlyList<SpeciesDtoForList>>(ct) ?? [];
+    }
+
+    private static string BuildListQueryString(SpeciesParameters parameters, bool includePageSize)
+    {
+        var builder = new QueryStringBuilder()
+            .Add("cursor", parameters.Cursor)
+            .Add("search", parameters.Search)
+            .Add("categoryId", parameters.CategoryId)
+            .Add("municipalityId", parameters.MunicipalityId)
+            .Add("isFauna", parameters.IsFauna)
+            .Add("isEndemic", parameters.IsEndemic)
+            .Add("hasProfileImage", parameters.HasProfileImage)
+            .Add("iucnStatuses", parameters.IucnStatuses)
+            .Add("taxonCodes", parameters.TaxonCodes)
+            .Add("minMunicipalityCount", parameters.MinMunicipalityCount)
+            .Add("observedSinceUtc", parameters.ObservedSinceUtc);
+
+        if (parameters.Sort != SpeciesSort.ScientificNameAsc)
+        {
+            builder.Add<SpeciesSort>("sort", parameters.Sort);
+        }
+
+        if (includePageSize && parameters.PageSize != 20)
+        {
+            builder.Add("pageSize", parameters.PageSize);
+        }
+
+        return builder.Build();
     }
 
     private sealed record CountPayload(int Count);

--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/Dtos/SpeciesDtos.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/Dtos/SpeciesDtos.cs
@@ -9,7 +9,13 @@ public sealed record SpeciesDtoForList(
     bool IsFauna,
     string GRank,
     string SRank,
-    bool HasProfileImage
+    bool HasProfileImage,
+    bool IsEndemic,
+    IucnStatus? IucnStatus,
+    string? TaxonCode,
+    int MunicipalityCount,
+    DateTimeOffset? LastObservedAtUtc,
+    bool IsFeatured
 );
 
 public sealed record SpeciesDtoForDetail(
@@ -23,7 +29,11 @@ public sealed record SpeciesDtoForDetail(
     string? ImageSourceUrl,
     bool HasProfileImage,
     IReadOnlyList<SpeciesCategoryDtoForList> Categories,
-    IReadOnlyList<Guid> MunicipalityIds
+    IReadOnlyList<Guid> MunicipalityIds,
+    bool IsEndemic,
+    IucnStatus? IucnStatus,
+    string? Habitat,
+    DateTimeOffset? LastObservedAtUtc
 );
 
 public sealed record SpeciesDtoForCreate(
@@ -35,7 +45,11 @@ public sealed record SpeciesDtoForCreate(
     string SRank,
     string? ImageSourceUrl,
     byte[]? ProfileImageData,
-    string? ProfileImageContentType
+    string? ProfileImageContentType,
+    bool IsEndemic,
+    IucnStatus? IucnStatus,
+    bool IsFeatured,
+    string? Habitat
 );
 
 public sealed record SpeciesDtoForUpdate(
@@ -45,5 +59,31 @@ public sealed record SpeciesDtoForUpdate(
     string ElCode,
     string GRank,
     string SRank,
-    string? ImageSourceUrl
+    string? ImageSourceUrl,
+    bool IsEndemic,
+    IucnStatus? IucnStatus,
+    bool IsFeatured,
+    string? Habitat
+);
+
+public sealed record SpeciesStatsDto(
+    int TotalSpecies,
+    int EndemicCount,
+    int ThreatenedCount,
+    int MunicipalitiesCovered,
+    int TotalMunicipalities,
+    int AddedThisQuarter,
+    int ReclassifiedThisQuarter
+);
+
+public sealed record TaxonFacetDto(string Code, int Count);
+
+public sealed record IucnFacetDto(IucnStatus Status, int Count);
+
+public sealed record SpeciesFacetsDto(
+    IReadOnlyList<TaxonFacetDto> Taxa,
+    IReadOnlyList<IucnFacetDto> Statuses,
+    int EndemicCount,
+    int RecentlyObservedCount,
+    int WithImageCount
 );

--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/IucnStatus.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/IucnStatus.cs
@@ -1,0 +1,12 @@
+namespace EcoData.Wildlife.Contracts;
+
+public enum IucnStatus
+{
+    LC,
+    NT,
+    VU,
+    EN,
+    CR,
+    DD,
+    EX,
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/Parameters/SpeciesParameters.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/Parameters/SpeciesParameters.cs
@@ -8,5 +8,20 @@ public sealed record SpeciesParameters(
     string? Search = null,
     Guid? CategoryId = null,
     Guid? MunicipalityId = null,
-    bool? IsFauna = null
+    bool? IsFauna = null,
+    bool? IsEndemic = null,
+    bool? HasProfileImage = null,
+    IReadOnlyList<IucnStatus>? IucnStatuses = null,
+    IReadOnlyList<string>? TaxonCodes = null,
+    int? MinMunicipalityCount = null,
+    DateTimeOffset? ObservedSinceUtc = null,
+    SpeciesSort Sort = SpeciesSort.ScientificNameAsc
 ) : CursorParameters(PageSize, Cursor);
+
+public enum SpeciesSort
+{
+    ScientificNameAsc,
+    ScientificNameDesc,
+    RecentlyObserved,
+    MostMunicipalities,
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/WildlifeOptions.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/WildlifeOptions.cs
@@ -1,0 +1,8 @@
+namespace EcoData.Wildlife.Contracts;
+
+public sealed class WildlifeOptions
+{
+    public const string SectionName = "Wildlife";
+
+    public int TotalMunicipalitiesInRegion { get; set; } = 78;
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/DependencyInjection.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/DependencyInjection.cs
@@ -1,13 +1,22 @@
+using EcoData.Wildlife.Contracts;
 using EcoData.Wildlife.DataAccess.Interfaces;
 using EcoData.Wildlife.DataAccess.Repositories;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EcoData.Wildlife.DataAccess;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddWildlifeDataAccess(this IServiceCollection services)
+    public static IServiceCollection AddWildlifeDataAccess(
+        this IServiceCollection services,
+        IConfiguration configuration
+    )
     {
+        services
+            .AddOptions<WildlifeOptions>()
+            .Bind(configuration.GetSection(WildlifeOptions.SectionName));
+
         services.AddScoped<ISpeciesRepository, SpeciesRepository>();
         services.AddScoped<ISpeciesCategoryRepository, SpeciesCategoryRepository>();
         services.AddScoped<IConservationRepository, ConservationRepository>();

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Interfaces/ISpeciesRepository.cs
@@ -25,4 +25,15 @@ public interface ISpeciesRepository
     );
 
     Task<byte[]?> GetProfileImageAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<SpeciesStatsDto> GetStatsAsync(CancellationToken cancellationToken = default);
+
+    Task<SpeciesFacetsDto> GetFacetsAsync(
+        SpeciesParameters parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<IReadOnlyList<SpeciesDtoForList>> GetFeaturedAsync(
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
@@ -75,7 +75,21 @@ public sealed class SpeciesRepository(
         await foreach (
             var species in query
                 .Take(parameters.PageSize + 1)
-                .Select(ProjectToList)
+                .Select(static s => new SpeciesDtoForList(
+                    s.Id,
+                    s.CommonName,
+                    s.ScientificName,
+                    s.IsFauna,
+                    s.GRank,
+                    s.SRank,
+                    s.ProfileImageData != null,
+                    s.IsEndemic,
+                    s.IucnStatus,
+                    s.CategoryLinks.Select(cl => cl.Category.Code).FirstOrDefault(),
+                    s.MunicipalitySpecies.Count,
+                    s.LastObservedAtUtc,
+                    s.IsFeatured
+                ))
                 .AsAsyncEnumerable()
                 .WithCancellation(cancellationToken)
         )
@@ -106,8 +120,21 @@ public sealed class SpeciesRepository(
 
         return await context
             .MunicipalitySpecies.Where(ms => ms.MunicipalityId == municipalityId)
-            .Select(ms => ms.Species)
-            .Select(ProjectToList)
+            .Select(static ms => new SpeciesDtoForList(
+                ms.Species.Id,
+                ms.Species.CommonName,
+                ms.Species.ScientificName,
+                ms.Species.IsFauna,
+                ms.Species.GRank,
+                ms.Species.SRank,
+                ms.Species.ProfileImageData != null,
+                ms.Species.IsEndemic,
+                ms.Species.IucnStatus,
+                ms.Species.CategoryLinks.Select(cl => cl.Category.Code).FirstOrDefault(),
+                ms.Species.MunicipalitySpecies.Count,
+                ms.Species.LastObservedAtUtc,
+                ms.Species.IsFeatured
+            ))
             .ToListAsync(cancellationToken);
     }
 
@@ -120,8 +147,21 @@ public sealed class SpeciesRepository(
 
         return await context
             .SpeciesCategoryLinks.Where(scl => scl.CategoryId == categoryId)
-            .Select(scl => scl.Species)
-            .Select(ProjectToList)
+            .Select(static scl => new SpeciesDtoForList(
+                scl.Species.Id,
+                scl.Species.CommonName,
+                scl.Species.ScientificName,
+                scl.Species.IsFauna,
+                scl.Species.GRank,
+                scl.Species.SRank,
+                scl.Species.ProfileImageData != null,
+                scl.Species.IsEndemic,
+                scl.Species.IucnStatus,
+                scl.Species.CategoryLinks.Select(cl => cl.Category.Code).FirstOrDefault(),
+                scl.Species.MunicipalitySpecies.Count,
+                scl.Species.LastObservedAtUtc,
+                scl.Species.IsFeatured
+            ))
             .ToListAsync(cancellationToken);
     }
 
@@ -220,27 +260,23 @@ public sealed class SpeciesRepository(
             .Species.Where(s => s.IsFeatured)
             .OrderByDescending(s => s.LastObservedAtUtc)
             .ThenBy(s => s.ScientificName)
-            .Select(ProjectToList)
+            .Select(static s => new SpeciesDtoForList(
+                s.Id,
+                s.CommonName,
+                s.ScientificName,
+                s.IsFauna,
+                s.GRank,
+                s.SRank,
+                s.ProfileImageData != null,
+                s.IsEndemic,
+                s.IucnStatus,
+                s.CategoryLinks.Select(cl => cl.Category.Code).FirstOrDefault(),
+                s.MunicipalitySpecies.Count,
+                s.LastObservedAtUtc,
+                s.IsFeatured
+            ))
             .ToListAsync(cancellationToken);
     }
-
-    private static readonly System.Linq.Expressions.Expression<
-        Func<Database.Models.Species, SpeciesDtoForList>
-    > ProjectToList = s => new SpeciesDtoForList(
-        s.Id,
-        s.CommonName,
-        s.ScientificName,
-        s.IsFauna,
-        s.GRank,
-        s.SRank,
-        s.ProfileImageData != null,
-        s.IsEndemic,
-        s.IucnStatus,
-        s.CategoryLinks.Select(cl => cl.Category.Code).FirstOrDefault(),
-        s.MunicipalitySpecies.Count,
-        s.LastObservedAtUtc,
-        s.IsFeatured
-    );
 
     private static IQueryable<Database.Models.Species> ApplyFilters(
         IQueryable<Database.Models.Species> query,

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/SpeciesRepository.cs
@@ -1,15 +1,22 @@
 using System.Runtime.CompilerServices;
+using EcoData.Wildlife.Contracts;
 using EcoData.Wildlife.Contracts.Dtos;
 using EcoData.Wildlife.Contracts.Parameters;
 using EcoData.Wildlife.DataAccess.Interfaces;
 using EcoData.Wildlife.Database;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace EcoData.Wildlife.DataAccess.Repositories;
 
-public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> contextFactory)
-    : ISpeciesRepository
+public sealed class SpeciesRepository(
+    IDbContextFactory<WildlifeDbContext> contextFactory,
+    IOptions<WildlifeOptions> options
+) : ISpeciesRepository
 {
+    private static readonly IucnStatus[] ThreatenedStatuses =
+        [IucnStatus.VU, IucnStatus.EN, IucnStatus.CR];
+
     public async Task<SpeciesDtoForDetail?> GetByIdAsync(
         Guid id,
         CancellationToken cancellationToken = default
@@ -36,7 +43,11 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
                         cl.Category.Name
                     ))
                     .ToList(),
-                s.MunicipalitySpecies.Select(ms => ms.MunicipalityId).ToList()
+                s.MunicipalitySpecies.Select(ms => ms.MunicipalityId).ToList(),
+                s.IsEndemic,
+                s.IucnStatus,
+                s.Habitat,
+                s.LastObservedAtUtc
             ))
             .FirstOrDefaultAsync(cancellationToken);
     }
@@ -52,6 +63,10 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
 
         query = ApplyFilters(query, parameters);
 
+        query = ApplySort(query, parameters.Sort);
+
+        // Cursor pagination is Id-based; correct only for ScientificNameAsc + Id tiebreaker.
+        // Non-default sorts fall back to first-page results (follow-up tracked in issue #188).
         if (parameters.Cursor.HasValue)
         {
             query = query.Where(s => s.Id < parameters.Cursor.Value);
@@ -59,17 +74,8 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
 
         await foreach (
             var species in query
-                .OrderByDescending(s => s.Id)
                 .Take(parameters.PageSize + 1)
-                .Select(static s => new SpeciesDtoForList(
-                    s.Id,
-                    s.CommonName,
-                    s.ScientificName,
-                    s.IsFauna,
-                    s.GRank,
-                    s.SRank,
-                    s.ProfileImageData != null
-                ))
+                .Select(ProjectToList)
                 .AsAsyncEnumerable()
                 .WithCancellation(cancellationToken)
         )
@@ -100,15 +106,8 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
 
         return await context
             .MunicipalitySpecies.Where(ms => ms.MunicipalityId == municipalityId)
-            .Select(ms => new SpeciesDtoForList(
-                ms.Species.Id,
-                ms.Species.CommonName,
-                ms.Species.ScientificName,
-                ms.Species.IsFauna,
-                ms.Species.GRank,
-                ms.Species.SRank,
-                ms.Species.ProfileImageData != null
-            ))
+            .Select(ms => ms.Species)
+            .Select(ProjectToList)
             .ToListAsync(cancellationToken);
     }
 
@@ -121,15 +120,8 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
 
         return await context
             .SpeciesCategoryLinks.Where(scl => scl.CategoryId == categoryId)
-            .Select(scl => new SpeciesDtoForList(
-                scl.Species.Id,
-                scl.Species.CommonName,
-                scl.Species.ScientificName,
-                scl.Species.IsFauna,
-                scl.Species.GRank,
-                scl.Species.SRank,
-                scl.Species.ProfileImageData != null
-            ))
+            .Select(scl => scl.Species)
+            .Select(ProjectToList)
             .ToListAsync(cancellationToken);
     }
 
@@ -146,6 +138,110 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
             .FirstOrDefaultAsync(cancellationToken);
     }
 
+    public async Task<SpeciesStatsDto> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var totalSpecies = await context.Species.CountAsync(cancellationToken);
+        var endemicCount = await context.Species.CountAsync(s => s.IsEndemic, cancellationToken);
+        var threatenedCount = await context
+            .Species.CountAsync(
+                s => s.IucnStatus != null && ThreatenedStatuses.Contains(s.IucnStatus.Value),
+                cancellationToken
+            );
+        var municipalitiesCovered = await context
+            .MunicipalitySpecies.Select(ms => ms.MunicipalityId)
+            .Distinct()
+            .CountAsync(cancellationToken);
+
+        var quarterAgo = DateTimeOffset.UtcNow.AddDays(-90);
+        var addedThisQuarter = await context
+            .Species.CountAsync(s => s.CreatedAtUtc >= quarterAgo, cancellationToken);
+
+        return new SpeciesStatsDto(
+            totalSpecies,
+            endemicCount,
+            threatenedCount,
+            municipalitiesCovered,
+            options.Value.TotalMunicipalitiesInRegion,
+            addedThisQuarter,
+            ReclassifiedThisQuarter: 0
+        );
+    }
+
+    public async Task<SpeciesFacetsDto> GetFacetsAsync(
+        SpeciesParameters parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var filtered = ApplyFilters(context.Species.AsQueryable(), parameters);
+
+        var taxa = await filtered
+            .SelectMany(s => s.CategoryLinks)
+            .GroupBy(cl => cl.Category.Code)
+            .Select(g => new TaxonFacetDto(g.Key, g.Count()))
+            .ToListAsync(cancellationToken);
+
+        var statuses = await filtered
+            .Where(s => s.IucnStatus != null)
+            .GroupBy(s => s.IucnStatus!.Value)
+            .Select(g => new IucnFacetDto(g.Key, g.Count()))
+            .ToListAsync(cancellationToken);
+
+        var endemicCount = await filtered.CountAsync(s => s.IsEndemic, cancellationToken);
+        var recentCutoff = DateTimeOffset.UtcNow.AddYears(-1);
+        var recentlyObservedCount = await filtered.CountAsync(
+            s => s.LastObservedAtUtc >= recentCutoff,
+            cancellationToken
+        );
+        var withImageCount = await filtered.CountAsync(
+            s => s.ProfileImageData != null,
+            cancellationToken
+        );
+
+        return new SpeciesFacetsDto(
+            taxa,
+            statuses,
+            endemicCount,
+            recentlyObservedCount,
+            withImageCount
+        );
+    }
+
+    public async Task<IReadOnlyList<SpeciesDtoForList>> GetFeaturedAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .Species.Where(s => s.IsFeatured)
+            .OrderByDescending(s => s.LastObservedAtUtc)
+            .ThenBy(s => s.ScientificName)
+            .Select(ProjectToList)
+            .ToListAsync(cancellationToken);
+    }
+
+    private static readonly System.Linq.Expressions.Expression<
+        Func<Database.Models.Species, SpeciesDtoForList>
+    > ProjectToList = s => new SpeciesDtoForList(
+        s.Id,
+        s.CommonName,
+        s.ScientificName,
+        s.IsFauna,
+        s.GRank,
+        s.SRank,
+        s.ProfileImageData != null,
+        s.IsEndemic,
+        s.IucnStatus,
+        s.CategoryLinks.Select(cl => cl.Category.Code).FirstOrDefault(),
+        s.MunicipalitySpecies.Count,
+        s.LastObservedAtUtc,
+        s.IsFeatured
+    );
+
     private static IQueryable<Database.Models.Species> ApplyFilters(
         IQueryable<Database.Models.Species> query,
         SpeciesParameters parameters
@@ -153,15 +249,30 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
     {
         if (!string.IsNullOrWhiteSpace(parameters.Search))
         {
-            var search = parameters.Search.Trim().ToLower();
+            // Municipality-name search requires crossing into the Locations module
+            // and is out of scope for this pass (tracked as follow-up in issue #188).
+            var pattern = $"%{parameters.Search.Trim().Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_")}%";
             query = query.Where(s =>
-                s.ScientificName.ToLower().Contains(search)
+                EF.Functions.ILike(s.ScientificName, pattern)
+                || s.CommonName.Any(c => EF.Functions.ILike(c.Value, pattern))
             );
         }
 
         if (parameters.IsFauna.HasValue)
         {
             query = query.Where(s => s.IsFauna == parameters.IsFauna.Value);
+        }
+
+        if (parameters.IsEndemic.HasValue)
+        {
+            query = query.Where(s => s.IsEndemic == parameters.IsEndemic.Value);
+        }
+
+        if (parameters.HasProfileImage.HasValue)
+        {
+            query = parameters.HasProfileImage.Value
+                ? query.Where(s => s.ProfileImageData != null)
+                : query.Where(s => s.ProfileImageData == null);
         }
 
         if (parameters.CategoryId.HasValue)
@@ -174,10 +285,50 @@ public sealed class SpeciesRepository(IDbContextFactory<WildlifeDbContext> conte
         if (parameters.MunicipalityId.HasValue)
         {
             query = query.Where(s =>
-                s.MunicipalitySpecies.Any(ms => ms.MunicipalityId == parameters.MunicipalityId.Value)
+                s.MunicipalitySpecies.Any(ms =>
+                    ms.MunicipalityId == parameters.MunicipalityId.Value
+                )
             );
+        }
+
+        if (parameters.IucnStatuses is { Count: > 0 } statuses)
+        {
+            query = query.Where(s => s.IucnStatus != null && statuses.Contains(s.IucnStatus.Value));
+        }
+
+        if (parameters.TaxonCodes is { Count: > 0 } codes)
+        {
+            query = query.Where(s => s.CategoryLinks.Any(cl => codes.Contains(cl.Category.Code)));
+        }
+
+        if (parameters.MinMunicipalityCount is { } minCount)
+        {
+            query = query.Where(s => s.MunicipalitySpecies.Count >= minCount);
+        }
+
+        if (parameters.ObservedSinceUtc is { } observedSince)
+        {
+            query = query.Where(s => s.LastObservedAtUtc >= observedSince);
         }
 
         return query;
     }
+
+    private static IQueryable<Database.Models.Species> ApplySort(
+        IQueryable<Database.Models.Species> query,
+        SpeciesSort sort
+    ) => sort switch
+    {
+        SpeciesSort.ScientificNameAsc => query.OrderBy(s => s.ScientificName).ThenBy(s => s.Id),
+        SpeciesSort.ScientificNameDesc => query
+            .OrderByDescending(s => s.ScientificName)
+            .ThenByDescending(s => s.Id),
+        SpeciesSort.RecentlyObserved => query
+            .OrderByDescending(s => s.LastObservedAtUtc)
+            .ThenByDescending(s => s.Id),
+        SpeciesSort.MostMunicipalities => query
+            .OrderByDescending(s => s.MunicipalitySpecies.Count)
+            .ThenByDescending(s => s.Id),
+        _ => query.OrderByDescending(s => s.Id),
+    };
 }

--- a/src/Features/Wildlife/EcoData.Wildlife.Database/Migrations/20260423164154_AddSpeciesEditorialFields.Designer.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Database/Migrations/20260423164154_AddSpeciesEditorialFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EcoData.Wildlife.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EcoData.Wildlife.Database.Migrations
 {
     [DbContext(typeof(WildlifeDbContext))]
-    partial class WildlifeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423164154_AddSpeciesEditorialFields")]
+    partial class AddSpeciesEditorialFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Features/Wildlife/EcoData.Wildlife.Database/Migrations/20260423164154_AddSpeciesEditorialFields.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Database/Migrations/20260423164154_AddSpeciesEditorialFields.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoData.Wildlife.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSpeciesEditorialFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "created_at_utc",
+                table: "species",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "now()");
+
+            migrationBuilder.AddColumn<string>(
+                name: "habitat",
+                table: "species",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_endemic",
+                table: "species",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_featured",
+                table: "species",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "iucn_status",
+                table: "species",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "last_observed_at_utc",
+                table: "species",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "species_is_endemic_ix",
+                table: "species",
+                column: "is_endemic",
+                filter: "is_endemic = true");
+
+            migrationBuilder.CreateIndex(
+                name: "species_is_featured_ix",
+                table: "species",
+                column: "is_featured",
+                filter: "is_featured = true");
+
+            migrationBuilder.CreateIndex(
+                name: "species_iucn_status_ix",
+                table: "species",
+                column: "iucn_status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "species_is_endemic_ix",
+                table: "species");
+
+            migrationBuilder.DropIndex(
+                name: "species_is_featured_ix",
+                table: "species");
+
+            migrationBuilder.DropIndex(
+                name: "species_iucn_status_ix",
+                table: "species");
+
+            migrationBuilder.DropColumn(
+                name: "created_at_utc",
+                table: "species");
+
+            migrationBuilder.DropColumn(
+                name: "habitat",
+                table: "species");
+
+            migrationBuilder.DropColumn(
+                name: "is_endemic",
+                table: "species");
+
+            migrationBuilder.DropColumn(
+                name: "is_featured",
+                table: "species");
+
+            migrationBuilder.DropColumn(
+                name: "iucn_status",
+                table: "species");
+
+            migrationBuilder.DropColumn(
+                name: "last_observed_at_utc",
+                table: "species");
+        }
+    }
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Database/Models/Species.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Database/Models/Species.cs
@@ -33,9 +33,9 @@ public sealed class Species
     public required bool IsEndemic { get; set; }
     public required IucnStatus? IucnStatus { get; set; }
     public required bool IsFeatured { get; set; }
-    public string? Habitat { get; set; }
-    public DateTimeOffset? LastObservedAtUtc { get; set; }
-    public DateTimeOffset CreatedAtUtc { get; set; }
+    public required string? Habitat { get; set; }
+    public required DateTimeOffset? LastObservedAtUtc { get; set; }
+    public required DateTimeOffset CreatedAtUtc { get; set; }
 
     public ICollection<FwsLink> FwsLinks { get; set; } = [];
     public ICollection<MunicipalitySpecies> MunicipalitySpecies { get; set; } = [];

--- a/src/Features/Wildlife/EcoData.Wildlife.Database/Models/Species.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Database/Models/Species.cs
@@ -1,4 +1,5 @@
 using EcoData.Common.i18n;
+using EcoData.Wildlife.Contracts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -29,6 +30,13 @@ public sealed class Species
     /// </summary>
     public required string SRank { get; set; }
 
+    public required bool IsEndemic { get; set; }
+    public required IucnStatus? IucnStatus { get; set; }
+    public required bool IsFeatured { get; set; }
+    public string? Habitat { get; set; }
+    public DateTimeOffset? LastObservedAtUtc { get; set; }
+    public DateTimeOffset CreatedAtUtc { get; set; }
+
     public ICollection<FwsLink> FwsLinks { get; set; } = [];
     public ICollection<MunicipalitySpecies> MunicipalitySpecies { get; set; } = [];
     public ICollection<SpeciesCategoryLink> CategoryLinks { get; set; } = [];
@@ -54,10 +62,35 @@ public sealed class Species
 
             builder.Property(static e => e.SRank).HasMaxLength(20);
 
+            builder.Property(static e => e.Habitat).HasMaxLength(200);
+
+            builder
+                .Property(static e => e.IucnStatus)
+                .HasConversion<string>()
+                .HasMaxLength(8);
+
+            builder
+                .Property(static e => e.CreatedAtUtc)
+                .HasDefaultValueSql("now()");
+
             builder
                 .HasIndex(static e => e.ScientificName)
                 .IsUnique()
                 .HasDatabaseName("species_scientific_name_uidx");
+
+            builder
+                .HasIndex(static e => e.IsFeatured)
+                .HasFilter("is_featured = true")
+                .HasDatabaseName("species_is_featured_ix");
+
+            builder
+                .HasIndex(static e => e.IsEndemic)
+                .HasFilter("is_endemic = true")
+                .HasDatabaseName("species_is_endemic_ix");
+
+            builder
+                .HasIndex(static e => e.IucnStatus)
+                .HasDatabaseName("species_iucn_status_ix");
         }
     }
 }

--- a/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
+++ b/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
@@ -554,6 +554,8 @@ public sealed class DatabaseSeederWorker(
                     IsEndemic = dto.IsEndemic ?? gRank.Contains('T'),
                     IsFeatured = dto.IsFeatured ?? false,
                     Habitat = dto.Habitat,
+                    LastObservedAtUtc = null,
+                    CreatedAtUtc = DateTimeOffset.UtcNow,
                 };
                 context.Species.Add(species);
                 await context.SaveChangesAsync(stoppingToken);

--- a/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
+++ b/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
@@ -7,6 +7,7 @@ using EcoData.Locations.Database;
 using EcoData.Locations.Database.Models;
 using EcoData.Organization.Database;
 using EcoData.Sensors.Database;
+using EcoData.Wildlife.Contracts;
 using EcoData.Wildlife.Database;
 using EcoData.Wildlife.Database.Models;
 using Microsoft.AspNetCore.Identity;
@@ -343,16 +344,18 @@ public sealed class DatabaseSeederWorker(
         CancellationToken stoppingToken
     )
     {
+        // Fixed 8-code taxonomy backing the FaunaFinder filter chips.
+        // Any legacy SpeciesCategory rows from earlier deploys coexist harmlessly.
         var defaultCategories = new[]
         {
             ("bird", "Bird", "Ave"),
-            ("mammal", "Mammal", "Mamífero"),
-            ("reptile", "Reptile", "Reptil"),
-            ("amphibian", "Amphibian", "Anfibio"),
-            ("fish", "Fish", "Pez"),
-            ("invertebrate", "Invertebrate", "Invertebrado"),
             ("plant", "Plant", "Planta"),
-            ("fern", "Fern", "Helecho"),
+            ("reptile", "Reptile", "Reptil"),
+            ("amphib", "Amphibian", "Anfibio"),
+            ("fish", "Fish", "Pez"),
+            ("mammal", "Mammal", "Mamífero"),
+            ("invert", "Invertebrate", "Invertebrado"),
+            ("fungi", "Fungus", "Hongo"),
         };
 
         var existing = await context.SpeciesCategories.ToDictionaryAsync(
@@ -524,6 +527,7 @@ public sealed class DatabaseSeederWorker(
             }
             else
             {
+                var gRank = dto.GRank ?? "";
                 species = new Species
                 {
                     Id = Guid.CreateVersion7(),
@@ -540,8 +544,16 @@ public sealed class DatabaseSeederWorker(
                     ImageSourceUrl = dto.ImageSourceUrl,
                     IsFauna = dto.IsFauna,
                     ElCode = dto.ElCode ?? "",
-                    GRank = dto.GRank ?? "",
+                    GRank = gRank,
                     SRank = dto.SRank ?? "",
+                    // GRank → IUCN mapping is advisory: NatureServe ranks don't align
+                    // 1:1 with IUCN categories. Good enough for UI seed data.
+                    IucnStatus = dto.IucnStatus ?? MapGRankToIucn(gRank),
+                    // Treat subspecies-level "T" ranks (e.g. G5T2) as endemic-by-proxy
+                    // until the JSON carries an explicit flag.
+                    IsEndemic = dto.IsEndemic ?? gRank.Contains('T'),
+                    IsFeatured = dto.IsFeatured ?? false,
+                    Habitat = dto.Habitat,
                 };
                 context.Species.Add(species);
                 await context.SaveChangesAsync(stoppingToken);
@@ -584,8 +596,9 @@ public sealed class DatabaseSeederWorker(
                     .Select(scl => scl.CategoryId)
                     .ToHashSetAsync(stoppingToken);
 
-                foreach (var categoryCode in dto.CategoryCodes)
+                foreach (var rawCode in dto.CategoryCodes)
                 {
+                    var categoryCode = NormalizeCategoryCode(rawCode);
                     if (
                         categories.TryGetValue(categoryCode, out var category)
                         && !existingCategoryLinks.Contains(category.Id)
@@ -599,6 +612,7 @@ public sealed class DatabaseSeederWorker(
                                 CategoryId = category.Id,
                             }
                         );
+                        existingCategoryLinks.Add(category.Id);
                     }
                 }
             }
@@ -606,11 +620,90 @@ public sealed class DatabaseSeederWorker(
             await context.SaveChangesAsync(stoppingToken);
         }
 
+        await SeedFeaturedSpeciesAsync(context, stoppingToken);
+
         logger.LogInformation(
             "Species seeded: {Count} new, {Total} total",
             seededCount,
             speciesList.Count
         );
+    }
+
+    private async Task SeedFeaturedSpeciesAsync(
+        WildlifeDbContext context,
+        CancellationToken stoppingToken
+    )
+    {
+        var alreadyFeatured = await context.Species.CountAsync(s => s.IsFeatured, stoppingToken);
+        if (alreadyFeatured >= 3)
+        {
+            return;
+        }
+
+        // Pick the 3 most threatened species with images — they make the best editorial picks.
+        var picks = await context
+            .Species.Where(s => !s.IsFeatured)
+            .OrderBy(s => s.IucnStatus == IucnStatus.CR ? 0
+                : s.IucnStatus == IucnStatus.EN ? 1
+                : s.IucnStatus == IucnStatus.VU ? 2
+                : 3)
+            .ThenByDescending(s => s.ProfileImageData != null)
+            .ThenBy(s => s.ScientificName)
+            .Take(3 - alreadyFeatured)
+            .ToListAsync(stoppingToken);
+
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < picks.Count; i++)
+        {
+            picks[i].IsFeatured = true;
+            picks[i].LastObservedAtUtc ??= now.AddDays(-(i * 7 + 3));
+        }
+
+        if (picks.Count > 0)
+        {
+            await context.SaveChangesAsync(stoppingToken);
+            logger.LogInformation("Marked {Count} species as featured.", picks.Count);
+        }
+    }
+
+    private static string NormalizeCategoryCode(string code) => code switch
+    {
+        "amphibian" => "amphib",
+        "invertebrate" => "invert",
+        "fern" => "plant",
+        _ => code,
+    };
+
+    private static IucnStatus? MapGRankToIucn(string gRank)
+    {
+        if (string.IsNullOrWhiteSpace(gRank))
+        {
+            return null;
+        }
+
+        if (gRank.StartsWith("GH", StringComparison.OrdinalIgnoreCase)
+            || gRank.StartsWith("GX", StringComparison.OrdinalIgnoreCase))
+        {
+            return IucnStatus.EX;
+        }
+
+        if (gRank.StartsWith("GNR", StringComparison.OrdinalIgnoreCase)
+            || gRank.StartsWith("GU", StringComparison.OrdinalIgnoreCase))
+        {
+            return IucnStatus.DD;
+        }
+
+        return gRank.Length >= 2 && gRank[0] is 'G' or 'g'
+            ? gRank[1] switch
+            {
+                '1' => IucnStatus.CR,
+                '2' => IucnStatus.EN,
+                '3' => IucnStatus.VU,
+                '4' => IucnStatus.NT,
+                '5' => IucnStatus.LC,
+                _ => IucnStatus.DD,
+            }
+            : null;
     }
 
     private async Task SeedFwsLinksAsync(WildlifeDbContext context, CancellationToken stoppingToken)
@@ -767,6 +860,18 @@ public sealed class DatabaseSeederWorker(
 
         [JsonPropertyName("sRank")]
         public string? SRank { get; init; }
+
+        [JsonPropertyName("isEndemic")]
+        public bool? IsEndemic { get; init; }
+
+        [JsonPropertyName("iucnStatus")]
+        public IucnStatus? IucnStatus { get; init; }
+
+        [JsonPropertyName("isFeatured")]
+        public bool? IsFeatured { get; init; }
+
+        [JsonPropertyName("habitat")]
+        public string? Habitat { get; init; }
     }
 
     private sealed class FwsLinkDto


### PR DESCRIPTION
Closes #188. Plan 1 (backend & contracts) of the FaunaFinder species-page overhaul. Plan source: `docs/faunafinder-species-overhaul-plan.md` (included in this PR). Additive contract changes — existing pages keep compiling. UI work (Plan 2) lands separately.

## Summary
- **Schema**: `Species` gains `IsEndemic`, `IucnStatus`, `IsFeatured`, `Habitat`, `LastObservedAtUtc`, `CreatedAtUtc` (default `now()`), with filtered indexes on the boolean fields and an index on `iucn_status`. Stored via enum-to-string conversion.
- **Contracts**: new `IucnStatus` enum (`LC/NT/VU/EN/CR/DD/EX`), new `WildlifeOptions` (configurable `TotalMunicipalitiesInRegion = 78`).
- **DTOs**: `SpeciesDtoForList`/`ForDetail` carry the new editorial fields plus resolved `TaxonCode` and `MunicipalityCount`. New `SpeciesStatsDto`, `SpeciesFacetsDto`, `TaxonFacetDto`, `IucnFacetDto`.
- **Parameters**: `SpeciesParameters` adds `IsEndemic`, `HasProfileImage`, `IucnStatuses[]`, `TaxonCodes[]`, `MinMunicipalityCount`, `ObservedSinceUtc`, and a `Sort` enum.
- **Repository**: `ApplyFilters` uses `EF.Functions.ILike` across scientific + common names (JSON-owned). New `GetStatsAsync`, `GetFacetsAsync`, `GetFeaturedAsync`. `Sort` drives ordering with an `Id` tiebreaker.
- **Endpoints**: `GET /wildlife/species/stats`, `/facets`, `/featured`.
- **HTTP client**: new methods + multi-value query-param support via `QueryStringBuilder.Add<T>(key, IReadOnlyList<T>)`.
- **Migration**: `AddSpeciesEditorialFields`.
- **Seeder**: switches the 8 canonical taxon codes to the spec set (`bird/plant/reptile/amphib/fish/mammal/invert/fungi`), maps legacy codes at link time (`amphibian→amphib`, `invertebrate→invert`, `fern→plant`), backfills `IsEndemic`/`IucnStatus` from `GRank` (`G1→CR, G2→EN, G3→VU, G4→NT, G5→LC, GH/GX→EX, GNR/GU→DD`; species with a `T` infraspecific rank flagged endemic as a proxy), and marks 3 threatened species with images as `IsFeatured`.

## Known follow-ups
Called out in the plan doc, left as follow-ups per the issue's risk section:
- Municipality-name search would require crossing the Wildlife → Locations boundary; skipped for now.
- `Sort` combined with cursor pagination needs a composite cursor — currently non-default sorts fall back to first-page only.

## Test plan
- [ ] `dotnet build` clean (spot-verified: Seeder build clean; full-solution compile produced only file-copy errors from running dev servers — no CS errors).
- [ ] `dotnet ef database update` against a fresh DB succeeds.
- [ ] Seeder run: 8 species categories with new codes, ≥3 featured species, populated `IsEndemic`/`IucnStatus`.
- [ ] `GET /wildlife/species/stats` returns non-zero counts.
- [ ] `GET /wildlife/species/facets` returns taxa + status counts that sum to total.
- [ ] `GET /wildlife/species?taxonCodes=bird&iucnStatuses=EN&iucnStatuses=CR` filters correctly.
- [ ] Existing `Pages/Species.razor` and `Home.razor` still render.