### PR TITLE
fix: shrink species stat numbers on mobile

### DIFF
--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesStatsRow.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesStatsRow.razor.css
@@ -70,4 +70,12 @@
     .ff-stat:nth-child(-n+2) {
         border-top: 0;
     }
+
+    .ff-stat-value {
+        font-size: 1.75rem;
+    }
+
+    .ff-stat-value .unit {
+        font-size: 0.75rem;
+    }
 }


### PR DESCRIPTION
## Summary
- The `.ff-stat-value` numbers on the Species page render at 2.75rem, which is oversized on phone widths.
- Inside the existing `@media (max-width: 900px)` block, drop the value to 1.75rem and the inline `/total` unit to 0.75rem.
- Labels and sub-text are unchanged.

## Test plan
- [ ] Open `/species` on a mobile viewport (<= 900px) and confirm the four stat numbers fit comfortably without overlapping the borders.
- [ ] Confirm the desktop layout (>900px) is unchanged.