### PR TITLE
feat: add Municipalities link to desktop top nav

### DIFF
--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -43,6 +43,7 @@
                 <nav class="ff-nav ml-6">
                     <a href="/" class="@GetNavLinkClass("/", exact: true)">Map</a>
                     <a href="/species" class="@GetNavLinkClass("/species")">Species</a>
+                    <a href="/municipalities" class="@GetNavLinkClass("/municipalities")">Municipalities</a>
                     <a href="/categories" class="@GetNavLinkClass("/categories")">Categories</a>
                 </nav>
             </MudHidden>


### PR DESCRIPTION
## Summary
- Adds a `Municipalities` link to the desktop top-nav in `MainLayout.razor`, between `Species` and `Categories`.
- Routes to `/municipalities` (the existing `Pages/Municipalities.razor`).
- Reuses `GetNavLinkClass("/municipalities")` so the active-state styling works automatically (it matches any path starting with `/municipalities`, including `/municipalities/{id}`).

## Not in this PR
- Mobile bottom nav still shows Map/Species/Categories. The user asked specifically for the *top* navbar; happy to add Municipalities to the bottom nav in a follow-up if wanted.

## Test plan
- [ ] On a desktop viewport, confirm the four links render in order: Map, Species, Municipalities, Categories.
- [ ] Click Municipalities and verify navigation to `/municipalities`.
- [ ] Confirm the link shows the active style on `/municipalities` and on `/municipalities/{id}`.
- [ ] Mobile viewport unchanged — top bar still shows logo/title only.