### PR TITLE
feat(map): theme the click-municipality species panel

### DIFF
--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Map/MapSpeciesPanel.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Map/MapSpeciesPanel.razor
@@ -1,0 +1,80 @@
+@namespace FaunaFinder.Client.Components.Map
+@using EcoData.Wildlife.Contracts
+@using EcoData.Wildlife.Contracts.Dtos
+@using FaunaFinder.Client.Components.Species
+
+<header class="msp-head">
+    <div class="msp-head-meta">
+        <div class="msp-eyebrow">Municipio</div>
+        <div class="msp-title">@(Title ?? "—")</div>
+    </div>
+    <button type="button" class="msp-close" @onclick="HandleClose" aria-label="Close">
+        <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Small" />
+    </button>
+</header>
+
+@if (IsLoading)
+{
+    <div class="msp-list">
+        @for (var i = 0; i < 6; i++)
+        {
+            <div class="msp-row msp-row-skeleton">
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="80%" Height="20px" />
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="55%" Height="14px" />
+            </div>
+        }
+    </div>
+}
+else if (Species is null || Species.Count == 0)
+{
+    <div class="msp-empty">
+        <MudIcon Icon="@Icons.Material.Outlined.Pets" Size="Size.Medium" />
+        <div class="msp-empty-title">No species recorded</div>
+        <div class="msp-empty-sub">No species have been observed in this municipio yet.</div>
+    </div>
+}
+else
+{
+    <div class="msp-meta">@Species.Count @(Species.Count == 1 ? "species" : "species") observed</div>
+    <div class="msp-list">
+        @{
+            var idx = 0;
+        }
+        @foreach (var s in Species)
+        {
+            var position = ++idx;
+            var current = s;
+            <div class="msp-row" @onclick="@(() => HandleClick(current))">
+                <div class="msp-row-idx">@position.ToString("00")</div>
+                <div class="msp-row-icon" title="@TaxonIcons.GetLabel(current.TaxonCode)">
+                    <i class="@TaxonIcons.GetIcon(current.TaxonCode)"></i>
+                </div>
+                <div class="msp-row-body">
+                    <div class="msp-row-name">@Locale.Resolve(current.CommonName, fallback: current.ScientificName)</div>
+                    <div class="msp-row-sci">@current.ScientificName</div>
+                </div>
+                @if (current.IucnStatus is { } status)
+                {
+                    <span class="ff-status-pill @($"status-{status}")">@status</span>
+                }
+                else
+                {
+                    <span class="ff-status-pill status-DD">DD</span>
+                }
+            </div>
+        }
+    </div>
+}
+
+@code {
+    [Parameter] public string? Title { get; set; }
+    [Parameter] public IReadOnlyList<SpeciesDtoForList>? Species { get; set; }
+    [Parameter] public bool IsLoading { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    [Parameter] public EventCallback<SpeciesDtoForList> OnSpeciesClick { get; set; }
+
+    [CascadingParameter] public LocaleContext Locale { get; set; } = LocaleContext.English;
+
+    private Task HandleClose() => OnClose.InvokeAsync();
+    private Task HandleClick(SpeciesDtoForList s) => OnSpeciesClick.InvokeAsync(s);
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Map/MapSpeciesPanel.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Map/MapSpeciesPanel.razor.css
@@ -1,0 +1,156 @@
+.msp-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 18px 20px 14px;
+    border-bottom: 1px solid var(--fauna-line);
+    gap: 12px;
+    background: var(--fauna-surface);
+}
+
+.msp-head-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.msp-eyebrow {
+    font: var(--fauna-eyebrow);
+    text-transform: uppercase;
+    letter-spacing: var(--fauna-tracking-eyebrow);
+    color: var(--fauna-fg-4);
+}
+
+.msp-title {
+    font: 600 1.5rem/1.15 var(--fauna-font-serif);
+    color: var(--fauna-primary);
+    letter-spacing: var(--fauna-tracking-tight);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.msp-close {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    border: 1px solid var(--fauna-line);
+    background: var(--fauna-surface);
+    color: var(--fauna-fg-3);
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    transition: background-color var(--fauna-t-base) var(--fauna-ease),
+                border-color var(--fauna-t-base) var(--fauna-ease),
+                color var(--fauna-t-base) var(--fauna-ease);
+}
+
+.msp-close:hover {
+    background: var(--fauna-bg-alt);
+    color: var(--fauna-fg);
+}
+
+.msp-close ::deep .mud-icon-root {
+    font-size: 18px !important;
+    color: inherit;
+}
+
+.msp-meta {
+    padding: 10px 20px 6px;
+    font: var(--fauna-mono);
+    font-size: 11px;
+    color: var(--fauna-fg-4);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.msp-list {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.msp-row {
+    padding: 12px 16px 12px 20px;
+    display: grid;
+    grid-template-columns: 28px 22px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    cursor: pointer;
+    border-bottom: 1px solid var(--fauna-line);
+    transition: background-color var(--fauna-t-base) var(--fauna-ease);
+}
+
+.msp-row:hover {
+    background: var(--fauna-primary-50);
+}
+
+.msp-row-idx {
+    font: var(--fauna-mono);
+    font-size: 11px;
+    color: var(--fauna-fg-5);
+    letter-spacing: 0.05em;
+    text-align: right;
+}
+
+.msp-row-icon {
+    color: var(--fauna-primary-500);
+    font-size: 14px;
+    display: grid;
+    place-items: center;
+}
+
+.msp-row-body {
+    min-width: 0;
+}
+
+.msp-row-name {
+    font: 500 14px/1.2 var(--fauna-font-sans);
+    color: var(--fauna-fg);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.msp-row-sci {
+    font: italic 400 12px/1.3 var(--fauna-font-serif);
+    color: var(--fauna-fg-3);
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.msp-row-skeleton {
+    grid-template-columns: 1fr;
+    padding: 14px 20px;
+    gap: 4px;
+}
+
+.msp-empty {
+    padding: 48px 24px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    color: var(--fauna-fg-3);
+}
+
+.msp-empty ::deep .mud-icon-root {
+    color: var(--fauna-fg-5);
+    margin-bottom: 8px;
+}
+
+.msp-empty-title {
+    font: 500 14px/1.2 var(--fauna-font-sans);
+    color: var(--fauna-fg-2);
+}
+
+.msp-empty-sub {
+    font: var(--fauna-body-sm);
+    color: var(--fauna-fg-4);
+    max-width: 240px;
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityEditorialHero.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityEditorialHero.razor
@@ -7,6 +7,7 @@
         <h1 class="mm-hero-heading">
             Municipios of <em>Puerto Rico</em>,<br /> mapped and observed.
         </h1>
+        <p class="mm-hero-lede">@Lede</p>
     </div>
     <div class="mm-hero-meta">
         <span>Last sync · @LastSync</span>
@@ -19,6 +20,9 @@
     [Parameter] public SpeciesStatsDto? Stats { get; set; }
 
     [Parameter] public string Eyebrow { get; set; } = "Volume 03 · Living Atlas";
+
+    [Parameter] public string Lede { get; set; } =
+        "A geographic index to Puerto Rico's 78 municipios — each annotated with the species recorded inside its boundaries. Search by name, sort by biodiversity, or tap any pin to pull up a municipio's full roster and its notable residents.";
 
     private string LastSync => DateTime.Now.ToString("HH:mm") + " local";
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityEditorialHero.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityEditorialHero.razor.css
@@ -38,6 +38,13 @@
     color: var(--fauna-accent);
 }
 
+.mm-hero-lede {
+    font: 400 1.0625rem/1.55 var(--fauna-font-sans);
+    color: var(--fauna-fg-3);
+    max-width: 520px;
+    margin: 16px 0 0;
+}
+
 .mm-hero-meta {
     font: var(--fauna-mono);
     color: var(--fauna-fg-4);

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityEditorialHero.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityEditorialHero.razor.css
@@ -1,8 +1,8 @@
 .mm-hero {
-    padding: 40px 0 24px;
+    padding: 56px 0 32px;
     display: grid;
     grid-template-columns: 1fr auto;
-    gap: 32px;
+    gap: 48px;
     align-items: end;
     border-bottom: 1px solid var(--fauna-line);
 }
@@ -15,7 +15,7 @@
     text-transform: uppercase;
     letter-spacing: var(--fauna-tracking-eyebrow);
     color: var(--fauna-accent);
-    margin-bottom: 14px;
+    margin-bottom: 20px;
 }
 
 .mm-hero-eyebrow::before {
@@ -26,8 +26,8 @@
 }
 
 .mm-hero-heading {
-    font: 700 clamp(1.875rem, 4vw, 3.25rem)/1.05 var(--fauna-font-serif);
-    letter-spacing: -0.03em;
+    font: 700 clamp(2.25rem, 5vw, 4.25rem)/1.02 var(--fauna-font-serif);
+    letter-spacing: -0.035em;
     color: var(--fauna-primary);
     margin: 0;
 }
@@ -55,8 +55,8 @@
 @media (max-width: 900px) {
     .mm-hero {
         grid-template-columns: 1fr;
-        gap: 12px;
-        padding: 24px 0 16px;
+        gap: 20px;
+        padding: 32px 0 24px;
     }
 
     .mm-hero-meta {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityStatsRow.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityStatsRow.razor.css
@@ -47,21 +47,34 @@
 @media (max-width: 900px) {
     .mm-stats {
         grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
         padding: 20px 0 24px;
+        border-bottom: 0;
     }
 
-    .mm-stat {
-        padding: 16px;
-        border-left: 0;
-        border-top: 1px solid var(--fauna-line);
+    /* Mobile renders each stat as its own tile instead of a bordered strip.
+       The :first-child rule on desktop strips padding + border-left, so we
+       re-declare both here to ensure every card matches. */
+    .mm-stat,
+    .mm-stat:first-child {
+        padding: 14px 16px;
+        background: var(--fauna-surface);
+        border: 1px solid var(--fauna-line);
+        border-radius: 12px;
     }
 
-    .mm-stat:nth-child(-n+2) {
-        border-top: 0;
+    .mm-stat-label {
+        font-size: 10px;
     }
 
     .mm-stat-value {
         font-size: 1.75rem;
+        margin-top: 6px;
+    }
+
+    .mm-stat-sub {
+        margin-top: 6px;
+        font-size: 10px;
     }
 
     .mm-stat-value .unit {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityStatsRow.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityStatsRow.razor.css
@@ -2,12 +2,12 @@
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 0;
-    padding: 20px 0 24px;
+    padding: 28px 0 36px;
     border-bottom: 1px solid var(--fauna-line);
 }
 
 .mm-stat {
-    padding: 0 28px;
+    padding: 0 32px;
     border-left: 1px solid var(--fauna-line);
 }
 
@@ -24,16 +24,16 @@
 }
 
 .mm-stat-value {
-    font: 600 2rem/1 var(--fauna-font-serif);
+    font: 600 2.75rem/1 var(--fauna-font-serif);
     color: var(--fauna-primary);
     letter-spacing: -0.025em;
-    margin-top: 6px;
+    margin-top: 10px;
 }
 
 .mm-stat-value .unit {
-    font: 500 0.75rem/1 var(--fauna-font-sans);
+    font: 500 0.875rem/1 var(--fauna-font-sans);
     color: var(--fauna-fg-4);
-    margin-left: 4px;
+    margin-left: 6px;
     letter-spacing: 0;
 }
 
@@ -41,17 +41,17 @@
     font: var(--fauna-mono);
     font-size: 11px;
     color: var(--fauna-fg-4);
-    margin-top: 6px;
+    margin-top: 8px;
 }
 
 @media (max-width: 900px) {
     .mm-stats {
         grid-template-columns: repeat(2, 1fr);
-        padding: 12px 0 0;
+        padding: 20px 0 24px;
     }
 
     .mm-stat {
-        padding: 12px;
+        padding: 16px;
         border-left: 0;
         border-top: 1px solid var(--fauna-line);
     }
@@ -60,11 +60,11 @@
         border-top: 0;
     }
 
-    .mm-stat:nth-child(odd) {
-        padding-left: 0;
+    .mm-stat-value {
+        font-size: 1.75rem;
     }
 
-    .mm-stat:nth-child(even) {
-        border-left: 1px solid var(--fauna-line);
+    .mm-stat-value .unit {
+        font-size: 0.75rem;
     }
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesFeaturedRow.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesFeaturedRow.razor.css
@@ -36,7 +36,10 @@
 }
 
 @media (max-width: 900px) {
-    .ff-featured-grid {
-        grid-template-columns: 1fr;
+    /* Featured row is an editorial luxury — on small viewports the three
+       cards would stack to a tall column that pushes the toolbar + grid
+       off-screen. Hide the whole section instead. */
+    .ff-featured {
+        display: none;
     }
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesStatsRow.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesStatsRow.razor.css
@@ -58,21 +58,34 @@
 @media (max-width: 900px) {
     .ff-stats {
         grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
         padding: 20px 0 24px;
+        border-bottom: 0;
     }
 
-    .ff-stat {
-        padding: 16px;
-        border-left: 0;
-        border-top: 1px solid var(--fauna-line);
+    /* Mobile renders each stat as its own tile instead of a bordered strip.
+       The :first-child rule on desktop strips padding + border-left, so we
+       re-declare both here to ensure every card matches. */
+    .ff-stat,
+    .ff-stat:first-child {
+        padding: 14px 16px;
+        background: var(--fauna-surface);
+        border: 1px solid var(--fauna-line);
+        border-radius: 12px;
     }
 
-    .ff-stat:nth-child(-n+2) {
-        border-top: 0;
+    .ff-stat-label {
+        font-size: 10px;
     }
 
     .ff-stat-value {
         font-size: 1.75rem;
+        margin-top: 6px;
+    }
+
+    .ff-stat-sub {
+        margin-top: 6px;
+        font-size: 10px;
     }
 
     .ff-stat-value .unit {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -134,9 +134,11 @@
 
     private bool IsEditorialListPage =>
         string.Equals(Navigation.State.Path, "/species", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(Navigation.State.Path, "/municipalities", StringComparison.OrdinalIgnoreCase);
+        string.Equals(Navigation.State.Path, "/municipalities", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(Navigation.State.Path, "/categories", StringComparison.OrdinalIgnoreCase);
 
-    // Hide the divider+title on pages with their own editorial hero (home, species list, muni list).
+    // Hide the divider+title on top-level list pages (home, species, muni, categories).
+    // Each either renders its own root heading or relies on the active nav pill for context.
     private bool ShowTitleDivider =>
         !IsHomePage && !IsEditorialListPage && Navbar.State.Title is not null;
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -74,7 +74,7 @@
         </MudAppBar>
 
         <MudMainContent Class="main-content">
-            @if (IsHomePage || IsSpeciesListPage)
+            @if (IsHomePage || IsEditorialListPage)
             {
                 @Body
             }
@@ -105,6 +105,13 @@
                         <MudText Typo="Typo.caption">Species</MudText>
                     </MudStack>
                 </MudButton>
+                <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Municipalities)" Class="bottom-nav-item"
+                           OnClick="@(() => NavigateToTab(NavigationTab.Municipalities))">
+                    <MudStack AlignItems="AlignItems.Center" Spacing="0">
+                        <MudIcon Icon="@Icons.Material.Filled.LocationCity" Size="Size.Medium" />
+                        <MudText Typo="Typo.caption">Municipios</MudText>
+                    </MudStack>
+                </MudButton>
                 <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Categories)" Class="bottom-nav-item"
                            OnClick="@(() => NavigateToTab(NavigationTab.Categories))">
                     <MudStack AlignItems="AlignItems.Center" Spacing="0">
@@ -118,19 +125,20 @@
 </CascadingValue>
 
 @code {
-    private enum NavigationTab { Map, Species, Categories }
+    private enum NavigationTab { Map, Species, Municipalities, Categories }
 
     private NavigationTab _currentTab = NavigationTab.Map;
     private LocaleContext _locale = LocaleContext.English;
 
     private bool IsHomePage => Navigation.State.Path == "/" || Navigation.State.Path == "";
 
-    private bool IsSpeciesListPage =>
-        string.Equals(Navigation.State.Path, "/species", StringComparison.OrdinalIgnoreCase);
+    private bool IsEditorialListPage =>
+        string.Equals(Navigation.State.Path, "/species", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(Navigation.State.Path, "/municipalities", StringComparison.OrdinalIgnoreCase);
 
-    // Hide the divider+title on pages with their own editorial hero (home, species list).
+    // Hide the divider+title on pages with their own editorial hero (home, species list, muni list).
     private bool ShowTitleDivider =>
-        !IsHomePage && !IsSpeciesListPage && Navbar.State.Title is not null;
+        !IsHomePage && !IsEditorialListPage && Navbar.State.Title is not null;
 
     protected override void OnInitialized()
     {
@@ -157,6 +165,7 @@
         {
             "/" or "" => NavigationTab.Map,
             var p when p.StartsWith("/species", StringComparison.OrdinalIgnoreCase) => NavigationTab.Species,
+            var p when p.StartsWith("/municipalities", StringComparison.OrdinalIgnoreCase) => NavigationTab.Municipalities,
             var p when p.StartsWith("/categories", StringComparison.OrdinalIgnoreCase) => NavigationTab.Categories,
             _ => NavigationTab.Map
         };
@@ -183,6 +192,7 @@
         {
             NavigationTab.Map => "/",
             NavigationTab.Species => "/species",
+            NavigationTab.Municipalities => "/municipalities",
             NavigationTab.Categories => "/categories",
             _ => "/"
         };

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor
@@ -2,7 +2,6 @@
 @using EcoData.Common.Maps
 @using EcoData.Common.Maps.Models
 @using EcoData.Locations.Application.Client
-@using EcoData.Locations.Contracts.Dtos
 @using EcoData.Wildlife.Application.Client
 @using EcoData.Wildlife.Contracts.Dtos
 @using BlazingSingularity.Fetch
@@ -64,8 +63,7 @@
     private MapController<MunicipalityMarker> _mapController = new();
     private bool _sidebarOpen;
     private bool _sheetOpen;
-    private MunicipalityDtoForList? _selectedMunicipality;
-    private Dictionary<string, MunicipalityDtoForList> _municipalitiesByGeoJsonId = new();
+    private SelectedMunicipality? _selectedMunicipality;
 
     private IFetch<bool> _mapInitFetch = default!;
     private IFetch<IReadOnlyList<SpeciesDtoForList>>? _speciesFetch;
@@ -86,11 +84,6 @@
 
     private async Task<bool> InitMapAsync(CancellationToken ct)
     {
-        await foreach (var municipality in MunicipalityHttpClient.GetMunicipalitiesAsync(ct: ct))
-        {
-            _municipalitiesByGeoJsonId[municipality.GeoJsonId] = municipality;
-        }
-
         var geoJson = await MunicipalityHttpClient.GetGeoJsonByStateCodeAsync("PR", ct);
         if (!string.IsNullOrEmpty(geoJson))
         {
@@ -114,23 +107,28 @@
 
         try
         {
-            var props = System.Text.Json.JsonDocument.Parse(properties);
-            if (props.RootElement.TryGetProperty("geoJsonId", out var geoJsonIdElement))
+            using var props = System.Text.Json.JsonDocument.Parse(properties);
+            var root = props.RootElement;
+
+            if (!root.TryGetProperty("id", out var idEl) ||
+                !root.TryGetProperty("name", out var nameEl))
             {
-                var geoJsonId = geoJsonIdElement.GetString();
-                if (geoJsonId is not null && _municipalitiesByGeoJsonId.TryGetValue(geoJsonId, out var municipality))
-                {
-                    await InvokeAsync(async () => await SelectMunicipalityAsync(municipality));
-                }
+                return;
             }
+
+            var id = idEl.GetGuid();
+            if (id == Guid.Empty) return;
+
+            var name = nameEl.GetString() ?? string.Empty;
+            await InvokeAsync(() => SelectMunicipalityAsync(new SelectedMunicipality(id, name)));
         }
-        catch
+        catch (Exception ex)
         {
-            // Ignore parse errors
+            Console.Error.WriteLine($"Failed to handle municipality click: {ex.Message}");
         }
     }
 
-    private async Task SelectMunicipalityAsync(MunicipalityDtoForList municipality)
+    private async Task SelectMunicipalityAsync(SelectedMunicipality municipality)
     {
         _selectedMunicipality = municipality;
         _sidebarOpen = true;
@@ -143,6 +141,8 @@
         );
         await _speciesFetch.FetchAsync();
     }
+
+    private sealed record SelectedMunicipality(Guid Id, string Name);
 
     private void CloseSidebar()
     {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor
@@ -34,52 +34,13 @@
     <MudHidden Breakpoint="Breakpoint.SmAndDown">
         @if (_selectedMunicipality is not null)
         {
-            <div class="desktop-sidebar @(_sidebarOpen ? "open" : "")">
-                <div class="sidebar-header">
-                    <MudText Typo="Typo.h6">@_selectedMunicipality.Name</MudText>
-                    <MudIconButton Icon="@Icons.Material.Filled.Close"
-                                   Size="Size.Small"
-                                   OnClick="CloseSidebar" />
-                </div>
-
-                @if (_speciesFetch?.IsLoading is not false)
-                {
-                    <div class="pa-3">
-                        @for (int i = 0; i < 5; i++)
-                        {
-                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded" />
-                        }
-                    </div>
-                }
-                else if ((_speciesFetch.Data?.Count ?? 0) == 0)
-                {
-                    <NuiEmptyState Icon="@Icons.Material.Outlined.Pets"
-                                   Title="No species found"
-                                   Description="No species have been recorded in this municipality yet." />
-                }
-                else
-                {
-                    <div class="sidebar-content">
-                        <NuiSectionHeader Title="@($"{_speciesFetch.Data!.Count} Species")" />
-                        <MudList T="SpeciesDtoForList" Dense="true">
-                            @foreach (var species in _speciesFetch.Data!)
-                            {
-                                <NuiListItem Title="@GetSpeciesName(species)"
-                                             Subtitle="@species.ScientificName"
-                                             Icon="@(species.IsFauna ? Icons.Material.Filled.Pets : Icons.Material.Filled.Park)"
-                                             ShowChevron="true"
-                                             OnClick="@(() => NavigateToSpecies(species.Id))">
-                                    <TrailingContent>
-                                        <NuiStatusBadge Status="@GetConservationStatus(species.GRank)"
-                                                        Text="@(species.GRank ?? "-")"
-                                                        Size="NuiStatusSize.Small" />
-                                    </TrailingContent>
-                                </NuiListItem>
-                            }
-                        </MudList>
-                    </div>
-                }
-            </div>
+            <aside class="desktop-sidebar @(_sidebarOpen ? "open" : "")">
+                <MapSpeciesPanel Title="@_selectedMunicipality.Name"
+                                 IsLoading="@(_speciesFetch?.IsLoading is not false)"
+                                 Species="@_speciesFetch?.Data"
+                                 OnClose="CloseSidebar"
+                                 OnSpeciesClick="OnSpeciesClicked" />
+            </aside>
         }
     </MudHidden>
 
@@ -89,53 +50,11 @@
         {
             <div class="mobile-sheet-backdrop @(_sheetOpen ? "open" : "")" @onclick="CloseSheet"></div>
             <div class="mobile-sheet @(_sheetOpen ? "open" : "")">
-                <div class="mobile-sheet-header">
-                    <MudText Typo="Typo.subtitle1">@_selectedMunicipality.Name</MudText>
-                    <MudSpacer />
-                    <MudIconButton Icon="@Icons.Material.Filled.Close"
-                                   Size="Size.Medium"
-                                   OnClick="CloseSheet" />
-                </div>
-
-                @if (_speciesFetch?.IsLoading is not false)
-                {
-                    <div class="pa-3">
-                        @for (int i = 0; i < 5; i++)
-                        {
-                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="60px" Class="mb-3 rounded" />
-                        }
-                    </div>
-                }
-                else if ((_speciesFetch.Data?.Count ?? 0) == 0)
-                {
-                    <NuiEmptyState Icon="@Icons.Material.Outlined.Pets"
-                                   Title="No species found"
-                                   Description="No species have been recorded in this municipality yet." />
-                }
-                else
-                {
-                    <div class="mobile-sheet-content">
-                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="px-3 mb-2">
-                            @_speciesFetch.Data!.Count species found
-                        </MudText>
-                        <MudList T="SpeciesDtoForList" Dense="true">
-                            @foreach (var species in _speciesFetch.Data!)
-                            {
-                                <NuiListItem Title="@GetSpeciesName(species)"
-                                             Subtitle="@species.ScientificName"
-                                             Icon="@(species.IsFauna ? Icons.Material.Filled.Pets : Icons.Material.Filled.Park)"
-                                             ShowChevron="true"
-                                             OnClick="@(() => NavigateToSpecies(species.Id))">
-                                    <TrailingContent>
-                                        <NuiStatusBadge Status="@GetConservationStatus(species.GRank)"
-                                                        Text="@(species.GRank ?? "-")"
-                                                        Size="NuiStatusSize.Small" />
-                                    </TrailingContent>
-                                </NuiListItem>
-                            }
-                        </MudList>
-                    </div>
-                }
+                <MapSpeciesPanel Title="@_selectedMunicipality.Name"
+                                 IsLoading="@(_speciesFetch?.IsLoading is not false)"
+                                 Species="@_speciesFetch?.Data"
+                                 OnClose="CloseSheet"
+                                 OnSpeciesClick="OnSpeciesClicked" />
             </div>
         }
     </MudHidden>
@@ -245,29 +164,8 @@
         StateHasChanged();
     }
 
-    private void NavigateToSpecies(Guid speciesId)
-    {
-        NavigationManager.NavigateTo($"/species/{speciesId}");
-    }
-
-    private static string GetSpeciesName(SpeciesDtoForList species)
-    {
-        var englishName = species.CommonName.FirstOrDefault(n => n.Code == "en");
-        return englishName?.Value ?? species.CommonName.FirstOrDefault()?.Value ?? species.ScientificName;
-    }
-
-    private static NuiStatusType GetConservationStatus(string? gRank)
-    {
-        if (string.IsNullOrEmpty(gRank)) return NuiStatusType.Inactive;
-
-        return gRank.ToUpperInvariant() switch
-        {
-            "G1" or "G2" => NuiStatusType.Error,
-            "G3" => NuiStatusType.Warning,
-            "G4" or "G5" => NuiStatusType.Success,
-            _ => NuiStatusType.Inactive
-        };
-    }
+    private void OnSpeciesClicked(SpeciesDtoForList species) =>
+        NavigationManager.NavigateTo($"/species/{species.Id}");
 
     public void Dispose()
     {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor.css
@@ -61,7 +61,10 @@
     transform: translateX(0);
 }
 
-/* Mobile bottom sheet shell */
+/* Mobile bottom sheet shell.
+   Bottom nav sits at z-index 9999 (MainLayout.razor.css). The sheet has to
+   stack above that so tapping a pin while the nav is visible doesn't send
+   the sheet behind the nav strip. */
 .mobile-sheet-backdrop {
     position: fixed;
     top: 0;
@@ -69,7 +72,7 @@
     right: 0;
     bottom: 0;
     background-color: rgba(17, 17, 17, 0.45);
-    z-index: 600;
+    z-index: 10000;
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--fauna-t-slow) var(--fauna-ease);
@@ -84,17 +87,23 @@
     position: fixed;
     left: 0;
     right: 0;
-    bottom: calc(64px + env(safe-area-inset-bottom, 0px));
-    max-height: 70vh;
+    bottom: 0;
+    /* Always fill from the bottom edge up to ~75% of the viewport so the
+       sheet's top edge is consistent regardless of how much content it
+       holds. Inner content scrolls inside. */
+    height: 75vh;
+    max-height: calc(100vh - 64px);
     background: var(--fauna-surface);
     border-top: 1px solid var(--fauna-line);
     border-radius: 16px 16px 0 0;
     box-shadow: 0 -4px 24px rgba(17, 17, 17, 0.18);
-    z-index: 700;
+    z-index: 10001;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
     transform: translateY(100%);
     transition: transform var(--fauna-t-slow) var(--fauna-ease);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .mobile-sheet.open {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor.css
@@ -37,55 +37,42 @@
 }
 
 .map-loading-overlay {
-    background-color: rgba(255, 255, 255, 0.8);
+    background-color: rgba(244, 244, 239, 0.85);
 }
 
-/* Desktop Sidebar */
+/* Desktop sidebar shell — inner chrome lives in MapSpeciesPanel */
 .desktop-sidebar {
     position: absolute;
     top: 0;
     right: 0;
-    width: 380px;
+    width: 400px;
     height: 100%;
-    background-color: var(--mud-palette-surface);
-    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
+    background: var(--fauna-surface);
+    border-left: 1px solid var(--fauna-line);
+    box-shadow: var(--fauna-shadow-4);
     z-index: 500;
     display: flex;
     flex-direction: column;
     transform: translateX(100%);
-    transition: transform 0.3s ease;
+    transition: transform var(--fauna-t-slow) var(--fauna-ease);
 }
 
 .desktop-sidebar.open {
     transform: translateX(0);
 }
 
-.sidebar-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 16px;
-    border-bottom: 1px solid var(--mud-palette-lines-default);
-}
-
-.sidebar-content {
-    flex: 1;
-    overflow-y: auto;
-    padding: 8px 0;
-}
-
-/* Mobile Bottom Sheet */
+/* Mobile bottom sheet shell */
 .mobile-sheet-backdrop {
     position: fixed;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: rgba(17, 17, 17, 0.45);
     z-index: 600;
     opacity: 0;
     pointer-events: none;
-    transition: opacity 0.3s ease;
+    transition: opacity var(--fauna-t-slow) var(--fauna-ease);
 }
 
 .mobile-sheet-backdrop.open {
@@ -98,30 +85,18 @@
     left: 0;
     right: 0;
     bottom: calc(64px + env(safe-area-inset-bottom, 0px));
-    max-height: 60vh;
-    background-color: var(--mud-palette-surface);
+    max-height: 70vh;
+    background: var(--fauna-surface);
+    border-top: 1px solid var(--fauna-line);
     border-radius: 16px 16px 0 0;
-    box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 -4px 24px rgba(17, 17, 17, 0.18);
     z-index: 700;
     display: flex;
     flex-direction: column;
     transform: translateY(100%);
-    transition: transform 0.3s ease;
+    transition: transform var(--fauna-t-slow) var(--fauna-ease);
 }
 
 .mobile-sheet.open {
     transform: translateY(0);
-}
-
-.mobile-sheet-header {
-    display: flex;
-    align-items: center;
-    padding: 12px 16px;
-    border-bottom: 1px solid var(--mud-palette-lines-default);
-}
-
-.mobile-sheet-content {
-    flex: 1;
-    overflow-y: auto;
-    padding-bottom: 16px;
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/_Imports.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/_Imports.razor
@@ -13,6 +13,7 @@
 @using FaunaFinder.Client.Components
 @using FaunaFinder.Client.Components.Species
 @using FaunaFinder.Client.Components.Municipalities
+@using FaunaFinder.Client.Components.Map
 @using FaunaFinder.Client.Components.Shared
 @using FaunaFinder.Client.Localization
 @using EcoData.NativeUi


### PR DESCRIPTION
Closes #195. First PR in the map parity series (#195–#202).

## What changed
- New `Components/Map/MapSpeciesPanel.razor` (+ scoped CSS) renders the species list shown when a municipality is clicked, in the new fauna editorial style:
  - Newsreader serif for the **Municipio** header
  - JetBrains Mono for the eyebrow, the row index (`01`, `02`, …), and the *N species observed* meta caption
  - Italic Newsreader for the scientific name
  - Shared `ff-status-pill` (driven by `SpeciesDtoForList.IucnStatus`, falls back to `DD` when null) for the conservation badge
  - Taxon icon (Font Awesome via `TaxonIcons`) in the row gutter
- `Pages/Home.razor` swaps the prior `MudText h6 / MudList / NuiListItem / NuiStatusBadge` for two `<MapSpeciesPanel ... />` instances (one in the desktop sidebar, one in the mobile bottom sheet).
- `Pages/Home.razor.css` re-skins the sidebar / sheet shells with `--fauna-surface`, `--fauna-line`, `--fauna-shadow-4`, and the shared motion tokens. Slide-in behavior unchanged.
- Localization is now handled by the cascading `LocaleContext` (consistent with the rest of the new pages), so the bespoke `GetSpeciesName` helper is gone.

## Out of scope (tracked separately)
- #196 sort, #197 NRCS/FWS filter, #198 PDF/CSV export, #199 Species Near Me, #200 polygon search, #201 species-locations browse, #202 Near-Me state restore.

## Test plan
- [ ] On desktop, click a municipality on the map — sidebar slides in from the right with the new editorial header, species rows, and IUCN pills.
- [ ] On mobile (<= 960px), click a municipality — bottom sheet slides up with the same content (header, meta caption, rows).
- [ ] Click a species row → navigates to `/species/{id}`.
- [ ] Click a municipality with no recorded species → empty state shows the centered Pets icon + "No species recorded" copy.
- [ ] While loading, six skeleton rows appear in the panel.
- [ ] EN/ES toggle in the top bar swaps the displayed common name on the next municipality click.