### PR TITLE
feat: full i18n in FaunaFinder — EN + ES via ILocalizer

### DIFF
--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Map/MapSpeciesPanel.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Map/MapSpeciesPanel.razor
@@ -1,14 +1,15 @@
 @namespace FaunaFinder.Client.Components.Map
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts
 @using EcoData.Wildlife.Contracts.Dtos
 @using FaunaFinder.Client.Components.Species
 
 <header class="msp-head">
     <div class="msp-head-meta">
-        <div class="msp-eyebrow">Municipio</div>
+        <div class="msp-eyebrow">@L["Map_Panel_Eyebrow"]</div>
         <div class="msp-title">@(Title ?? "—")</div>
     </div>
-    <button type="button" class="msp-close" @onclick="HandleClose" aria-label="Close">
+    <button type="button" class="msp-close" @onclick="HandleClose" aria-label="@CloseLabel">
         <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Small" />
     </button>
 </header>
@@ -29,13 +30,13 @@ else if (Species is null || Species.Count == 0)
 {
     <div class="msp-empty">
         <MudIcon Icon="@Icons.Material.Outlined.Pets" Size="Size.Medium" />
-        <div class="msp-empty-title">No species recorded</div>
-        <div class="msp-empty-sub">No species have been observed in this municipio yet.</div>
+        <div class="msp-empty-title">@L["Map_Panel_NoSpecies_Title"]</div>
+        <div class="msp-empty-sub">@L["Map_Panel_NoSpecies_Description"]</div>
     </div>
 }
 else
 {
-    <div class="msp-meta">@Species.Count @(Species.Count == 1 ? "species" : "species") observed</div>
+    <div class="msp-meta">@L["Map_Panel_SpeciesObserved", Species.Count]</div>
     <div class="msp-list">
         @{
             var idx = 0;
@@ -46,7 +47,7 @@ else
             var current = s;
             <div class="msp-row" @onclick="@(() => HandleClick(current))">
                 <div class="msp-row-idx">@position.ToString("00")</div>
-                <div class="msp-row-icon" title="@TaxonIcons.GetLabel(current.TaxonCode)">
+                <div class="msp-row-icon" title="@L[TaxonIcons.GetLabelKey(current.TaxonCode)]">
                     <i class="@TaxonIcons.GetIcon(current.TaxonCode)"></i>
                 </div>
                 <div class="msp-row-body">
@@ -74,6 +75,8 @@ else
     [Parameter] public EventCallback<SpeciesDtoForList> OnSpeciesClick { get; set; }
 
     [CascadingParameter] public LocaleContext Locale { get; set; } = LocaleContext.English;
+
+    private string CloseLabel => L["Common_Close"];
 
     private Task HandleClose() => OnClose.InvokeAsync();
     private Task HandleClick(SpeciesDtoForList s) => OnSpeciesClick.InvokeAsync(s);

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityCard.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityCard.razor
@@ -1,9 +1,9 @@
 @namespace FaunaFinder.Client.Components.Municipalities
+@inherits LocalizedComponentBase
 @using EcoData.Locations.Contracts.Dtos
 @using EcoData.Wildlife.Application.Client
 @using EcoData.Wildlife.Contracts.Parameters
 @using BlazingSingularity.Fetch
-@implements IDisposable
 @inject ISpeciesHttpClient SpeciesClient
 
 <MudPaper Elevation="0" Class="pa-3 rounded-lg border-solid border mud-border-lines-default municipality-card"
@@ -21,7 +21,7 @@
                 }
                 else
                 {
-                    <span>@_countFetch.Data species</span>
+                    <span>@L["Muni_Card_SpeciesCount", _countFetch.Data]</span>
                 }
             </MudText>
         </MudStack>
@@ -40,6 +40,7 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         _countFetch = new Fetch<int>(
             ct => SpeciesClient.GetCountAsync(
                 new SpeciesParameters(MunicipalityId: Municipality.Id),
@@ -50,8 +51,9 @@
 
     private Task HandleClick() => OnClick.InvokeAsync(Municipality);
 
-    public void Dispose()
+    public override void Dispose()
     {
+        base.Dispose();
         (_countFetch as IDisposable)?.Dispose();
     }
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityDetailCard.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityDetailCard.razor
@@ -1,4 +1,5 @@
 @namespace FaunaFinder.Client.Components.Municipalities
+@inherits LocalizedComponentBase
 @using EcoData.Locations.Contracts.Dtos
 
 <aside class="mm-detail">
@@ -7,26 +8,30 @@
             <div class="mm-detail-title">@Municipality.Name</div>
             <div class="mm-detail-sub">@CoordsLabel</div>
         </div>
-        <button type="button" class="mm-detail-close" title="Close" @onclick="HandleClose">
+        <button type="button" class="mm-detail-close" title="@CloseTitle" @onclick="HandleClose">
             <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Small" />
         </button>
     </div>
 
     <div class="mm-detail-stats">
         <div>
-            <div class="mm-detail-stat-label">Species</div>
+            <div class="mm-detail-stat-label">@L["Muni_DetailCard_Species_Label"]</div>
             <div class="mm-detail-stat-value">@(SpeciesCount?.ToString("N0") ?? "—")</div>
         </div>
         <div>
-            <div class="mm-detail-stat-label">FIPS</div>
+            <div class="mm-detail-stat-label">@L["Muni_DetailCard_Fips_Label"]</div>
             <div class="mm-detail-stat-value mm-detail-stat-mono">@Municipality.CountyFipsCode</div>
         </div>
     </div>
 
     <div class="mm-detail-cta">
-        <span class="count">@(SpeciesCount is { } c ? $"{c:N0} species recorded" : "Species count pending")</span>
+        <span class="count">
+            @(SpeciesCount is { } c
+                ? L["Muni_DetailCard_CountRecorded", c.ToString("N0")]
+                : L["Muni_DetailCard_CountPending"])
+        </span>
         <button type="button" class="mm-detail-link" @onclick="HandleViewDetails">
-            View details
+            @L["Common_ViewDetails"]
             <MudIcon Icon="@Icons.Material.Filled.ArrowForward" Size="Size.Small" />
         </button>
     </div>
@@ -44,6 +49,8 @@
 
     private string CoordsLabel =>
         $"{Municipality.CentroidLatitude:0.000}″N · {Math.Abs(Municipality.CentroidLongitude):0.000}″W";
+
+    private string CloseTitle => L["Common_Close"];
 
     private Task HandleClose() => OnClose.InvokeAsync();
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityEditorialHero.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityEditorialHero.razor
@@ -1,32 +1,35 @@
 @namespace FaunaFinder.Client.Components.Municipalities
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts.Dtos
 
 <section class="mm-hero">
     <div class="mm-hero-main">
-        <div class="mm-hero-eyebrow">@Eyebrow</div>
+        <div class="mm-hero-eyebrow">@EyebrowText</div>
         <h1 class="mm-hero-heading">
-            Municipios of <em>Puerto Rico</em>,<br /> mapped and observed.
+            @L["Muni_Hero_HeadingLead"] <em>Puerto Rico</em>@L["Muni_Hero_HeadingTail"]
         </h1>
-        <p class="mm-hero-lede">@Lede</p>
+        <p class="mm-hero-lede">@LedeText</p>
     </div>
     <div class="mm-hero-meta">
-        <span>Last sync · @LastSync</span>
+        <span>@L["Hero_LastSync", LastSync]</span>
         <span>@RecordsLine</span>
-        <span>Tap a pin or row to drill in</span>
+        <span>@L["Muni_Hero_Hint"]</span>
     </div>
 </section>
 
 @code {
     [Parameter] public SpeciesStatsDto? Stats { get; set; }
 
-    [Parameter] public string Eyebrow { get; set; } = "Volume 03 · Living Atlas";
+    [Parameter] public string? Eyebrow { get; set; }
 
-    [Parameter] public string Lede { get; set; } =
-        "A geographic index to Puerto Rico's 78 municipios — each annotated with the species recorded inside its boundaries. Search by name, sort by biodiversity, or tap any pin to pull up a municipio's full roster and its notable residents.";
+    [Parameter] public string? Lede { get; set; }
+
+    private string EyebrowText => Eyebrow ?? L["Hero_Eyebrow"];
+    private string LedeText => Lede ?? L["Muni_Hero_Lede"];
 
     private string LastSync => DateTime.Now.ToString("HH:mm") + " local";
 
     private string RecordsLine => Stats is null
-        ? "— municipios · — records"
-        : $"{Stats.TotalMunicipalities} municipios · {Stats.TotalSpecies:N0} records";
+        ? L["Muni_Hero_RecordsPending"]
+        : L["Muni_Hero_RecordsLine", Stats.TotalMunicipalities, Stats.TotalSpecies.ToString("N0")];
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityList.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityList.razor
@@ -1,11 +1,12 @@
 @namespace FaunaFinder.Client.Components.Municipalities
+@inherits LocalizedComponentBase
 @using EcoData.Locations.Contracts.Dtos
 
 <aside class="mm-rail">
     <div class="mm-rail-head">
         <div class="mm-search">
             <MudIcon Icon="@Icons.Material.Filled.Search" Size="Size.Small" />
-            <input placeholder="Search municipios by name…"
+            <input placeholder="@SearchPlaceholder"
                    value="@_search"
                    @oninput="OnSearchInput" />
         </div>
@@ -15,7 +16,7 @@
                 <ActivatorContent>
                     <button type="button" class="mm-sort">
                         <MudIcon Icon="@Icons.Material.Filled.Sort" Size="Size.Small" />
-                        Sort: @SortLabel
+                        @L["Muni_List_Sort_Prefix"] @SortLabel
                     </button>
                 </ActivatorContent>
                 <ChildContent>
@@ -30,7 +31,7 @@
                             {
                                 <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" Class="mr-2" Style="visibility:hidden" />
                             }
-                            @option.Label
+                            @L[option.LabelKey]
                         </MudMenuItem>
                     }
                 </ChildContent>
@@ -52,7 +53,7 @@
         {
             <div class="mm-row-empty">
                 <MudIcon Icon="@Icons.Material.Outlined.SearchOff" Size="Size.Medium" />
-                <span>No municipios match "@_search"</span>
+                <span>@L["Muni_List_Empty", _search]</span>
             </div>
         }
         else
@@ -74,7 +75,7 @@
                         @(count is { } c ? c.ToString() : "—")
                     </div>
                     <button type="button" class="mm-row-details"
-                            title="View details"
+                            title="@ViewDetailsTitle"
                             @onclick="@((MouseEventArgs _) => OnDetails.InvokeAsync(muni))"
                             @onclick:stopPropagation="true">
                         <MudIcon Icon="@Icons.Material.Filled.ArrowForward" Size="Size.Small" />
@@ -99,14 +100,23 @@
 
     private IReadOnlyList<MunicipalityDtoForList> _visible = [];
 
-    private static readonly (MunicipalitySort Value, string Label)[] SortOptions =
+    private string SearchPlaceholder => L["Muni_List_SearchPlaceholder"];
+    private string ViewDetailsTitle => L["Common_ViewDetails"];
+
+    private static readonly (MunicipalitySort Value, string LabelKey)[] SortOptions =
     [
-        (MunicipalitySort.SpeciesCountDesc, "species count ↓"),
-        (MunicipalitySort.NameAsc, "name A–Z"),
+        (MunicipalitySort.SpeciesCountDesc, "Muni_List_Sort_SpeciesCountDesc"),
+        (MunicipalitySort.NameAsc, "Muni_List_Sort_NameAsc"),
     ];
 
-    private string SortLabel => SortOptions.FirstOrDefault(o => o.Value == _sort).Label
-        ?? "species count ↓";
+    private string SortLabel
+    {
+        get
+        {
+            var entry = SortOptions.FirstOrDefault(o => o.Value == _sort);
+            return L[entry.LabelKey ?? "Muni_List_Sort_SpeciesCountDesc"];
+        }
+    }
 
     protected override void OnParametersSet() => RecomputeVisible();
 
@@ -152,17 +162,21 @@
     private static string CoordsLabel(MunicipalityDtoForList muni) =>
         $"{muni.CentroidLatitude:0.00}″N · {Math.Abs(muni.CentroidLongitude):0.00}″W";
 
-    private string VisibleLabel =>
-        Municipalities is null
-            ? "Loading…"
-            : _visible.Count == Municipalities.Count
-                ? $"{Municipalities.Count} municipios"
-                : $"{_visible.Count} of {Municipalities.Count}";
+    private string VisibleLabel
+    {
+        get
+        {
+            if (Municipalities is null) return L["Muni_List_Loading"];
+            if (_visible.Count == Municipalities.Count)
+                return L["Muni_List_VisibleAll", Municipalities.Count];
+            return L["Muni_List_VisibleFiltered", _visible.Count, Municipalities.Count];
+        }
+    }
 
     private string TotalLabel =>
         Municipalities is null
-            ? "loading municipios"
-            : $"{Municipalities.Count} municipios tracked";
+            ? L["Muni_List_Foot_Loading"]
+            : L["Muni_List_Foot_Total", Municipalities.Count];
 
     public enum MunicipalitySort
     {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityMap.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityMap.razor
@@ -1,11 +1,11 @@
 @namespace FaunaFinder.Client.Components.Municipalities
+@inherits LocalizedComponentBase
 @using System.Text.Json
 @using EcoData.Common.Maps
 @using EcoData.Common.Maps.Components
 @using EcoData.Common.Maps.Models
 @using EcoData.Locations.Application.Client
 @using EcoData.Locations.Contracts.Dtos
-@implements IDisposable
 @inject IMunicipalityHttpClient MunicipalityClient
 
 <div class="mm-map">
@@ -23,14 +23,14 @@
     }
 
     <div class="mm-legend">
-        <div class="mm-legend-title">Municipios</div>
+        <div class="mm-legend-title">@L["Muni_Map_Legend_Title"]</div>
         <div class="mm-legend-row">
             <span class="mm-legend-dot" style="background: var(--fauna-accent-warm);"></span>
-            <span>Selected</span>
+            <span>@L["Muni_Map_Legend_Selected"]</span>
         </div>
         <div class="mm-legend-row">
             <span class="mm-legend-dot" style="background: var(--fauna-primary);"></span>
-            <span>Boundary</span>
+            <span>@L["Muni_Map_Legend_Boundary"]</span>
         </div>
     </div>
 </div>
@@ -49,6 +49,7 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         _controller.OnGeoJsonClicked += HandleGeoJsonClicked;
         _ = LoadGeoJsonAsync();
     }
@@ -119,8 +120,9 @@
     private Task HandleViewDetails(MunicipalityDtoForList muni) =>
         OnViewDetails.InvokeAsync(muni);
 
-    public void Dispose()
+    public override void Dispose()
     {
+        base.Dispose();
         _controller.OnGeoJsonClicked -= HandleGeoJsonClicked;
     }
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityStatsRow.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Municipalities/MunicipalityStatsRow.razor
@@ -1,32 +1,33 @@
 @namespace FaunaFinder.Client.Components.Municipalities
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts.Dtos
 
 <section class="mm-stats">
     <div class="mm-stat">
-        <div class="mm-stat-label">Total municipios</div>
+        <div class="mm-stat-label">@L["Muni_Stats_Total_Label"]</div>
         <div class="mm-stat-value">
             @FormatNumber(Stats?.TotalMunicipalities)
-            <span class="unit">/ @(Stats?.TotalMunicipalities ?? 78) tracked</span>
+            <span class="unit">@L["Muni_Stats_Total_Unit", Stats?.TotalMunicipalities ?? 78]</span>
         </div>
-        <div class="mm-stat-sub">100% island coverage</div>
+        <div class="mm-stat-sub">@L["Muni_Stats_Total_Sub"]</div>
     </div>
 
     <div class="mm-stat">
-        <div class="mm-stat-label">Species catalogued</div>
+        <div class="mm-stat-label">@L["Muni_Stats_Species_Label"]</div>
         <div class="mm-stat-value">@FormatNumber(Stats?.TotalSpecies)</div>
-        <div class="mm-stat-sub">across the island</div>
+        <div class="mm-stat-sub">@L["Muni_Stats_Species_Sub"]</div>
     </div>
 
     <div class="mm-stat">
-        <div class="mm-stat-label">Avg · species / municipio</div>
+        <div class="mm-stat-label">@L["Muni_Stats_Avg_Label"]</div>
         <div class="mm-stat-value">@AverageLabel</div>
-        <div class="mm-stat-sub">@Stats?.MunicipalitiesCovered municipios contribute</div>
+        <div class="mm-stat-sub">@L["Muni_Stats_Avg_Sub", Stats?.MunicipalitiesCovered ?? 0]</div>
     </div>
 
     <div class="mm-stat">
-        <div class="mm-stat-label">Endemic hotspots</div>
+        <div class="mm-stat-label">@L["Muni_Stats_Hotspots_Label"]</div>
         <div class="mm-stat-value">@FormatNumber(Stats?.EndemicHotspotCount)</div>
-        <div class="mm-stat-sub">≥ 10 endemic species present</div>
+        <div class="mm-stat-sub">@L["Muni_Stats_Hotspots_Sub"]</div>
     </div>
 </section>
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesCard.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesCard.razor
@@ -1,4 +1,5 @@
 @namespace FaunaFinder.Client.Components.Species
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts
 @using EcoData.Wildlife.Contracts.Dtos
 
@@ -17,7 +18,7 @@
             </div>
         }
 
-        <span class="ff-card-taxa" title="@TaxonIcons.GetLabel(Species.TaxonCode)">
+        <span class="ff-card-taxa" title="@L[TaxonIcons.GetLabelKey(Species.TaxonCode)]">
             <i class="@TaxonIcons.GetIcon(Species.TaxonCode)"></i>
         </span>
 
@@ -25,7 +26,7 @@
         {
             <span class="ff-card-endemic">
                 <MudIcon Icon="@Icons.Material.Filled.Star" Size="Size.Small" />
-                Endemic PR
+                @L["Species_Card_EndemicBadge"]
             </span>
         }
 
@@ -41,7 +42,7 @@
         <div class="ff-card-foot">
             <span class="muni">
                 <MudIcon Icon="@Icons.Material.Filled.LocationOn" Size="Size.Small" />
-                @Species.MunicipalityCount municipios
+                @L["Species_Card_Municipios", Species.MunicipalityCount]
             </span>
             <span>@FormatLastSeen(Species.LastObservedAtUtc)</span>
         </div>
@@ -69,18 +70,18 @@
 
     private Task HandleClick() => OnClick.InvokeAsync(Species);
 
-    private static string FormatLastSeen(DateTimeOffset? lastSeen)
+    private string FormatLastSeen(DateTimeOffset? lastSeen)
     {
-        if (lastSeen is null) return "Verified";
+        if (lastSeen is null) return L["Common_Verified"];
 
         var delta = DateTimeOffset.UtcNow - lastSeen.Value;
         return delta switch
         {
-            { TotalMinutes: < 60 } => $"{Math.Max(1, (int)delta.TotalMinutes)}m ago",
-            { TotalHours: < 24 } => $"{(int)delta.TotalHours}h ago",
-            { TotalDays: < 30 } => $"{(int)delta.TotalDays}d ago",
-            { TotalDays: < 365 } => $"{(int)(delta.TotalDays / 30)}mo ago",
-            _ => $"{(int)(delta.TotalDays / 365)}y ago"
+            { TotalMinutes: < 60 } => L["Time_MinutesAgo", Math.Max(1, (int)delta.TotalMinutes)],
+            { TotalHours: < 24 } => L["Time_HoursAgo", (int)delta.TotalHours],
+            { TotalDays: < 30 } => L["Time_DaysAgo", (int)delta.TotalDays],
+            { TotalDays: < 365 } => L["Time_MonthsAgo", (int)(delta.TotalDays / 30)],
+            _ => L["Time_YearsAgo", (int)(delta.TotalDays / 365)]
         };
     }
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesEditorialHero.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesEditorialHero.razor
@@ -1,32 +1,32 @@
 @namespace FaunaFinder.Client.Components.Species
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts.Dtos
 
 <section class="ff-hero">
     <div class="ff-hero-main">
-        <div class="ff-hero-eyebrow">@Eyebrow</div>
+        <div class="ff-hero-eyebrow">@L["Hero_Eyebrow"]</div>
         <h1 class="ff-hero-heading">
-            Species of <em>Puerto Rico</em>,<br /> catalogued and observed.
+            @L["Species_Hero_HeadingLead"] <em>Puerto Rico</em>@L["Species_Hero_HeadingTail"]
         </h1>
-        <p class="ff-hero-lede">@Lede</p>
+        <p class="ff-hero-lede">@LedeText</p>
     </div>
     <div class="ff-hero-meta">
-        <span>Last sync · @LastSync</span>
+        <span>@L["Hero_LastSync", LastSync]</span>
         <span>@RecordsLine</span>
-        <span>Updated daily</span>
+        <span>@L["Species_Hero_UpdatedDaily"]</span>
     </div>
 </section>
 
 @code {
     [Parameter] public SpeciesStatsDto? Stats { get; set; }
 
-    [Parameter] public string Eyebrow { get; set; } = "Volume 03 · Living Atlas";
+    [Parameter] public string? Lede { get; set; }
 
-    [Parameter] public string Lede { get; set; } =
-        "A living field guide to the island's flora and fauna — drawn from verified sightings across 78 municipios. Browse by taxon, conservation status, or habitat; follow any record through to its distribution map and source observations.";
+    private string LedeText => Lede ?? L["Species_Hero_Lede"];
 
     private string LastSync => DateTime.Now.ToString("HH:mm") + " local";
 
     private string RecordsLine => Stats is null
-        ? "— records · — municipios"
-        : $"{Stats.TotalSpecies:N0} records · {Stats.MunicipalitiesCovered} municipios";
+        ? L["Species_Hero_RecordsPending"]
+        : L["Species_Hero_RecordsLine", Stats.TotalSpecies.ToString("N0"), Stats.MunicipalitiesCovered];
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesFeaturedRow.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesFeaturedRow.razor
@@ -1,16 +1,16 @@
 @namespace FaunaFinder.Client.Components.Species
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts.Dtos
 @using EcoData.Wildlife.Application.Client
 @using BlazingSingularity.Fetch
-@implements IDisposable
 @inject ISpeciesHttpClient SpeciesClient
 
 @if (_fetch is null || _fetch.IsLoading)
 {
     <section class="ff-featured">
         <div class="ff-featured-head">
-            <h2>Featured this week</h2>
-            <span class="meta">Curated · updated Mondays</span>
+            <h2>@L["Species_Featured_Heading"]</h2>
+            <span class="meta">@L["Species_Featured_Meta"]</span>
         </div>
         <div class="ff-featured-grid">
             <MudSkeleton SkeletonType="SkeletonType.Rectangle" Class="ff-featured-skeleton" />
@@ -23,8 +23,8 @@ else if (_fetch.Data is { Count: > 0 } featured)
 {
     <section class="ff-featured">
         <div class="ff-featured-head">
-            <h2>Featured this week</h2>
-            <span class="meta">Curated · updated Mondays</span>
+            <h2>@L["Species_Featured_Heading"]</h2>
+            <span class="meta">@L["Species_Featured_Meta"]</span>
         </div>
         <div class="ff-featured-grid">
             <SpeciesCard Species="@featured[0]" Variant="SpeciesCardVariant.Featured"
@@ -45,6 +45,7 @@ else if (_fetch.Data is { Count: > 0 } featured)
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         _fetch = new Fetch<IReadOnlyList<SpeciesDtoForList>>(
             SpeciesClient.GetFeaturedAsync,
             () => InvokeAsync(StateHasChanged));
@@ -54,5 +55,9 @@ else if (_fetch.Data is { Count: > 0 } featured)
     private Task HandleClick(SpeciesDtoForList species) =>
         OnSpeciesClick.InvokeAsync(species);
 
-    public void Dispose() => (_fetch as IDisposable)?.Dispose();
+    public override void Dispose()
+    {
+        base.Dispose();
+        (_fetch as IDisposable)?.Dispose();
+    }
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesFilterDialog.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesFilterDialog.razor
@@ -1,11 +1,12 @@
 @namespace FaunaFinder.Client.Components.Species
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts
 @using EcoData.Wildlife.Contracts.Dtos
 
 <MudDialog>
     <TitleContent>
         <div class="ff-modal-head">
-            <h3>Refine the catalogue</h3>
+            <h3>@L["Species_Filter_Heading"]</h3>
             @if (Facets is not null)
             {
                 <span class="ff-modal-head-meta">@TotalFacetCountsLabel</span>
@@ -18,9 +19,9 @@
             @* Taxonomic group *@
             <section class="ff-modal-section">
                 <div class="ff-modal-section-title">
-                    <span>Taxonomic group</span>
+                    <span>@L["Species_Filter_Section_Taxa"]</span>
                     <button type="button" class="ff-link-btn" @onclick="ToggleSelectAllTaxa">
-                        @(AllTaxaSelected ? "Clear all" : "Select all")
+                        @(AllTaxaSelected ? L["Common_ClearAll"] : L["Common_SelectAll"])
                     </button>
                 </div>
                 <div class="ff-taxa-grid">
@@ -31,7 +32,7 @@
                                 class="@("ff-taxa-chip" + (on ? " is-on" : ""))"
                                 @onclick="@(() => ToggleTaxa(code))">
                             <i class="@TaxonIcons.GetIcon(code)"></i>
-                            <span>@TaxonIcons.GetLabel(code)</span>
+                            <span>@L[TaxonIcons.GetLabelKey(code)]</span>
                             <span class="count">@TaxaCountFor(code)</span>
                         </button>
                     }
@@ -41,8 +42,8 @@
             @* Conservation status *@
             <section class="ff-modal-section">
                 <div class="ff-modal-section-title">
-                    <span>Conservation status (IUCN)</span>
-                    <span class="ff-modal-section-meta">@(_selectedStatuses.Count) selected</span>
+                    <span>@L["Species_Filter_Section_Status"]</span>
+                    <span class="ff-modal-section-meta">@L["Species_Filter_StatusMeta_Selected", _selectedStatuses.Count]</span>
                 </div>
                 <div class="ff-status-list">
                     @foreach (var status in StatusOptions)
@@ -52,7 +53,7 @@
                                 class="@("ff-status-row" + (on ? " is-on" : ""))"
                                 @onclick="@(() => ToggleStatus(status))">
                             <span class="ff-status-pill @($"status-{status}")">@status</span>
-                            <span class="label">@StatusLabel(status)</span>
+                            <span class="label">@L[$"Species_Iucn_{status}"]</span>
                             <span class="n">@StatusCountFor(status)</span>
                         </button>
                     }
@@ -62,27 +63,27 @@
             @* Qualifiers *@
             <section class="ff-modal-section">
                 <div class="ff-modal-section-title">
-                    <span>Qualifiers</span>
+                    <span>@L["Species_Filter_Section_Qualifiers"]</span>
                 </div>
                 <div class="ff-checkbox-row">
                     <MudCheckBox T="bool" Value="_isEndemic"
                                  ValueChanged="@((bool v) => _isEndemic = v)"
                                  Color="Color.Primary" Dense="true" />
-                    <label>Endemic to Puerto Rico only</label>
+                    <label>@L["Species_Filter_Qualifier_EndemicLabel"]</label>
                     <span class="n">@(Facets?.EndemicCount.ToString("N0") ?? "—")</span>
                 </div>
                 <div class="ff-checkbox-row">
                     <MudCheckBox T="bool" Value="_observedRecently"
                                  ValueChanged="@((bool v) => _observedRecently = v)"
                                  Color="Color.Primary" Dense="true" />
-                    <label>Observed in the last 12 months</label>
+                    <label>@L["Species_Filter_Qualifier_ObservedLabel"]</label>
                     <span class="n">@(Facets?.RecentlyObservedCount.ToString("N0") ?? "—")</span>
                 </div>
                 <div class="ff-checkbox-row">
                     <MudCheckBox T="bool" Value="_hasPhoto"
                                  ValueChanged="@((bool v) => _hasPhoto = v)"
                                  Color="Color.Primary" Dense="true" />
-                    <label>Has photo</label>
+                    <label>@L["Species_Filter_Qualifier_HasPhotoLabel"]</label>
                     <span class="n">@(Facets?.WithImageCount.ToString("N0") ?? "—")</span>
                 </div>
             </section>
@@ -90,16 +91,16 @@
             @* Range *@
             <section class="ff-modal-section">
                 <div class="ff-modal-section-title">
-                    <span>Minimum municipios present</span>
-                    <span class="ff-modal-section-meta">≥ @_minMunicipalities</span>
+                    <span>@L["Species_Filter_Section_MinMunicipios"]</span>
+                    <span class="ff-modal-section-meta">@L["Species_Filter_MinMunicipios_Meta", _minMunicipalities]</span>
                 </div>
                 <div class="ff-range-row">
                     <MudSlider T="int" @bind-Value="_minMunicipalities"
                                Min="1" Max="78" Step="1" Color="Color.Primary" />
                     <div class="ff-range-labels">
-                        <span>1 (rare)</span>
+                        <span>@L["Species_Filter_MinMunicipios_Rare"]</span>
                         <span>39</span>
-                        <span>78 (ubiquitous)</span>
+                        <span>@L["Species_Filter_MinMunicipios_Ubiquitous"]</span>
                     </div>
                 </div>
             </section>
@@ -107,10 +108,10 @@
     </DialogContent>
 
     <DialogActions>
-        <button type="button" class="ff-modal-reset" @onclick="Reset">Reset all filters</button>
+        <button type="button" class="ff-modal-reset" @onclick="Reset">@L["Species_Filter_Reset"]</button>
         <MudSpacer />
-        <MudButton OnClick="Cancel" Variant="Variant.Text">Cancel</MudButton>
-        <MudButton OnClick="Apply" Variant="Variant.Filled" Color="Color.Primary">Apply</MudButton>
+        <MudButton OnClick="Cancel" Variant="Variant.Text">@L["Common_Cancel"]</MudButton>
+        <MudButton OnClick="Apply" Variant="Variant.Filled" Color="Color.Primary">@L["Common_Apply"]</MudButton>
     </DialogActions>
 </MudDialog>
 
@@ -139,6 +140,7 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         _selectedTaxa = new HashSet<string>(Initial.TaxonCodes, StringComparer.OrdinalIgnoreCase);
         _selectedStatuses = new HashSet<IucnStatus>(Initial.IucnStatuses);
         _isEndemic = Initial.IsEndemic;
@@ -188,20 +190,8 @@
     private int? StatusCountFor(IucnStatus status) =>
         Facets?.Statuses.FirstOrDefault(s => s.Status == status)?.Count;
 
-    private static string StatusLabel(IucnStatus s) => s switch
-    {
-        IucnStatus.LC => "Least Concern",
-        IucnStatus.NT => "Near Threatened",
-        IucnStatus.VU => "Vulnerable",
-        IucnStatus.EN => "Endangered",
-        IucnStatus.CR => "Critically Endangered",
-        IucnStatus.DD => "Data Deficient",
-        IucnStatus.EX => "Extinct",
-        _ => s.ToString()
-    };
-
     private string TotalFacetCountsLabel =>
-        Facets is null ? "" : $"{Facets.Taxa.Sum(t => t.Count):N0} records";
+        Facets is null ? "" : L["Species_Filter_TotalRecords", Facets.Taxa.Sum(t => t.Count).ToString("N0")];
 
     private void Reset()
     {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesGrid.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesGrid.razor
@@ -6,6 +6,7 @@
 @implements IAsyncDisposable
 @inject ISpeciesHttpClient SpeciesClient
 @inject IBrowserViewportService Viewport
+@inject ILocalizer L
 
 <NuiVirtualizedGrid @ref="_grid"
                     TItem="SpeciesDtoForList"
@@ -33,8 +34,8 @@
     </LoadingTemplate>
     <EmptyTemplate>
         <NuiEmptyState Icon="@Icons.Material.Outlined.SearchOff"
-                       Title="No species match"
-                       Description="Try adjusting your filters or search terms." />
+                       Title="@L[EmptyTitleKey]"
+                       Description="@L[EmptyDescriptionKey]" />
     </EmptyTemplate>
     <ItemTemplate Context="species">
         <SpeciesCard Species="species" OnClick="HandleClick" />
@@ -53,6 +54,10 @@
 @code {
     private const int PageSize = 24;
 
+    // Kept as const keys so the Razor attribute form compiles; L resolves them at render.
+    private const string EmptyTitleKey = "Species_Grid_Empty_Title";
+    private const string EmptyDescriptionKey = "Species_Grid_Empty_Description";
+
     [Parameter] public SpeciesFilterResult Filter { get; set; } = SpeciesFilterResult.Empty;
     [Parameter] public string? Search { get; set; }
     [Parameter] public SpeciesSort Sort { get; set; } = SpeciesSort.ScientificNameAsc;
@@ -70,10 +75,13 @@
 
     protected override async Task OnInitializedAsync()
     {
+        L.LanguageChanged += OnLanguageChanged;
         ApplyBreakpoint(await Viewport.GetCurrentBreakpointAsync());
         _viewportSubscriptionId = Guid.NewGuid();
         await Viewport.SubscribeAsync(_viewportSubscriptionId, OnBreakpointChanged);
     }
+
+    private void OnLanguageChanged() => InvokeAsync(StateHasChanged);
 
     private Task OnBreakpointChanged(BrowserViewportEventArgs args)
     {
@@ -125,6 +133,7 @@
 
     public async ValueTask DisposeAsync()
     {
+        L.LanguageChanged -= OnLanguageChanged;
         if (_viewportSubscriptionId != Guid.Empty)
         {
             await Viewport.UnsubscribeAsync(_viewportSubscriptionId);

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesHero.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesHero.razor
@@ -1,4 +1,5 @@
 @namespace FaunaFinder.Client.Components.Species
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts.Dtos
 @using EcoData.Common.i18n
 
@@ -28,33 +29,37 @@
     <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap" Class="mb-2">
         @if (!string.IsNullOrEmpty(Species.GRank))
         {
-            <NuiStatusBadge Status="@GetRankStatus(Species.GRank)" Text="@($"Global: {Species.GRank}")" Size="NuiStatusSize.Small" />
+            <NuiStatusBadge Status="@GetRankStatus(Species.GRank)"
+                            Text="@GlobalRankText"
+                            Size="NuiStatusSize.Small" />
         }
         @if (!string.IsNullOrEmpty(Species.SRank))
         {
-            <NuiStatusBadge Status="@GetRankStatus(Species.SRank)" Text="@($"State: {Species.SRank}")" Size="NuiStatusSize.Small" />
+            <NuiStatusBadge Status="@GetRankStatus(Species.SRank)"
+                            Text="@StateRankText"
+                            Size="NuiStatusSize.Small" />
         }
         <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
-            @(Species.IsFauna ? "Fauna" : "Flora")
+            @(Species.IsFauna ? L["SpeciesDetail_Kingdom_Fauna"] : L["SpeciesDetail_Kingdom_Flora"])
         </MudChip>
     </MudStack>
 
     @if (!string.IsNullOrEmpty(Species.ElCode))
     {
         <MudText Typo="Typo.caption" Color="Color.Secondary">
-            Element Code: @Species.ElCode
+            @L["SpeciesDetail_ElCode", Species.ElCode]
         </MudText>
     }
 
     @if (Species.Categories is { Count: > 0 })
     {
         <MudDivider Class="my-4" />
-        <MudText Typo="Typo.subtitle2" Class="mb-2">Categories</MudText>
+        <MudText Typo="Typo.subtitle2" Class="mb-2">@L["SpeciesDetail_Categories_Heading"]</MudText>
         <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
             @foreach (var category in Species.Categories)
             {
                 <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
-                    @ResolveLocale(category.Name)
+                    @Locale.Resolve(category.Name)
                 </MudChip>
             }
         </MudStack>
@@ -65,20 +70,12 @@
     [Parameter, EditorRequired]
     public required SpeciesDtoForDetail Species { get; set; }
 
-    private string CommonName
-    {
-        get
-        {
-            var en = Species.CommonName.FirstOrDefault(n => n.Code == "en");
-            return en?.Value ?? Species.CommonName.FirstOrDefault()?.Value ?? Species.ScientificName;
-        }
-    }
+    [CascadingParameter] public LocaleContext Locale { get; set; } = LocaleContext.English;
 
-    private static string ResolveLocale(IReadOnlyList<LocaleValue> values)
-    {
-        var en = values.FirstOrDefault(n => n.Code == "en");
-        return en?.Value ?? values.FirstOrDefault()?.Value ?? "";
-    }
+    private string CommonName => Locale.Resolve(Species.CommonName, fallback: Species.ScientificName);
+
+    private string GlobalRankText => L["SpeciesDetail_Rank_Global", Species.GRank];
+    private string StateRankText => L["SpeciesDetail_Rank_State", Species.SRank];
 
     private static NuiStatusType GetRankStatus(string rank) => rank.ToUpperInvariant() switch
     {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesStatsRow.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesStatsRow.razor
@@ -1,45 +1,46 @@
 @namespace FaunaFinder.Client.Components.Species
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts.Dtos
 
 <section class="ff-stats">
     <div class="ff-stat">
-        <div class="ff-stat-label">Total species</div>
+        <div class="ff-stat-label">@L["Species_Stats_Total_Label"]</div>
         <div class="ff-stat-value">@FormatNumber(Stats?.TotalSpecies)</div>
         <div class="ff-stat-sub">
             @if (Stats is { AddedThisQuarter: > 0 } s)
             {
-                <span class="up">▲ @s.AddedThisQuarter</span> <text>this quarter</text>
+                @((MarkupString)L["Species_Stats_Total_Sub_Delta", DeltaMarkup(s.AddedThisQuarter)])
             }
             else
             {
-                <text>—</text>
+                @L["Species_Stats_Total_Sub_None"]
             }
         </div>
     </div>
 
     <div class="ff-stat">
-        <div class="ff-stat-label">Endemic to P.R.</div>
+        <div class="ff-stat-label">@L["Species_Stats_Endemic_Label"]</div>
         <div class="ff-stat-value">@FormatNumber(Stats?.EndemicCount)</div>
         <div class="ff-stat-sub">@EndemicShare</div>
     </div>
 
     <div class="ff-stat">
-        <div class="ff-stat-label">Threatened · VU–CR</div>
+        <div class="ff-stat-label">@L["Species_Stats_Threatened_Label"]</div>
         <div class="ff-stat-value">@FormatNumber(Stats?.ThreatenedCount)</div>
         <div class="ff-stat-sub">
             @if (Stats is { ReclassifiedThisQuarter: > 0 } r)
             {
-                <span class="up">▲ @r.ReclassifiedThisQuarter</span> <text>reclassified</text>
+                @((MarkupString)L["Species_Stats_Threatened_Sub_Delta", DeltaMarkup(r.ReclassifiedThisQuarter)])
             }
             else
             {
-                <text>—</text>
+                @L["Species_Stats_Total_Sub_None"]
             }
         </div>
     </div>
 
     <div class="ff-stat">
-        <div class="ff-stat-label">Municipios covered</div>
+        <div class="ff-stat-label">@L["Species_Stats_Municipios_Label"]</div>
         <div class="ff-stat-value">
             @FormatNumber(Stats?.MunicipalitiesCovered)
             <span class="unit">/ @(Stats?.TotalMunicipalities ?? 78)</span>
@@ -53,13 +54,17 @@
 
     private static string FormatNumber(int? n) => n is { } v ? v.ToString("N0") : "—";
 
+    // Wraps the delta number in the "up" span so the translated sentence can
+    // still colour the ▲N portion via `.up` CSS without losing localization.
+    private static string DeltaMarkup(int n) => $"<span class=\"up\">▲ {n}</span>";
+
     private string EndemicShare
     {
         get
         {
             if (Stats is null || Stats.TotalSpecies == 0) return "—";
             var pct = 100.0 * Stats.EndemicCount / Stats.TotalSpecies;
-            return $"{pct:0.0}% of catalogue";
+            return L["Species_Stats_Endemic_Sub", pct.ToString("0.0")];
         }
     }
 
@@ -69,7 +74,7 @@
         {
             if (Stats is null || Stats.TotalMunicipalities == 0) return "—";
             var pct = 100.0 * Stats.MunicipalitiesCovered / Stats.TotalMunicipalities;
-            return $"{pct:0}% island coverage";
+            return L["Species_Stats_Municipios_Sub", pct.ToString("0")];
         }
     }
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesToolbar.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/SpeciesToolbar.razor
@@ -1,16 +1,17 @@
 @namespace FaunaFinder.Client.Components.Species
+@inherits LocalizedComponentBase
 @using EcoData.Wildlife.Contracts
 @using EcoData.Wildlife.Contracts.Dtos
 @using EcoData.Wildlife.Contracts.Parameters
 
 <div class="ff-grid-head">
-    <h2>Find what you're looking for</h2>
+    <h2>@L["Species_Toolbar_Heading"]</h2>
     <span class="meta">@RecordsMeta</span>
 </div>
 
 <NuiSearchBar Value="@SearchText"
               ValueChanged="OnSearchChanged"
-              Placeholder="Search by common name, scientific name, or species…"
+              Placeholder="@SearchPlaceholder"
               ShowFilterButton="true"
               HasActiveFilters="@HasActiveFilters"
               FilterCount="@ActiveFilterCount"
@@ -23,7 +24,7 @@
         <ActivatorContent>
             <button type="button" class="ff-sort-btn">
                 <MudIcon Icon="@Icons.Material.Filled.Sort" Size="Size.Small" />
-                <span>Sort: @SortLabel</span>
+                <span>@L["Species_Toolbar_Sort_Prefix"] @SortLabel</span>
             </button>
         </ActivatorContent>
         <ChildContent>
@@ -39,7 +40,7 @@
                         <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small"
                                  Class="mr-2" Style="visibility:hidden" />
                     }
-                    @option.Label
+                    @L[option.LabelKey]
                 </MudMenuItem>
             }
         </ChildContent>
@@ -52,7 +53,7 @@
         @if (Filter.TaxonCodes.Count > 0)
         {
             <span class="ff-active-chip">
-                Taxon: @TaxaLabel
+                @L["Species_Chip_Taxon", TaxaLabel]
                 <button type="button" @onclick="ClearTaxa" aria-label="Clear taxa filter">
                     <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Small" />
                 </button>
@@ -61,7 +62,7 @@
         @if (Filter.IucnStatuses.Count > 0)
         {
             <span class="ff-active-chip">
-                Status: @string.Join(", ", Filter.IucnStatuses)
+                @L["Species_Chip_Status", string.Join(", ", Filter.IucnStatuses)]
                 <button type="button" @onclick="ClearStatuses" aria-label="Clear status filter">
                     <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Small" />
                 </button>
@@ -70,7 +71,7 @@
         @if (Filter.IsEndemic)
         {
             <span class="ff-active-chip">
-                Endemic only
+                @L["Species_Chip_Endemic"]
                 <button type="button" @onclick="ClearEndemic" aria-label="Clear endemic filter">
                     <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Small" />
                 </button>
@@ -79,7 +80,7 @@
         @if (Filter.ObservedRecently)
         {
             <span class="ff-active-chip">
-                Observed in last 12 months
+                @L["Species_Chip_ObservedRecently"]
                 <button type="button" @onclick="ClearObservedRecently" aria-label="Clear recently observed">
                     <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Small" />
                 </button>
@@ -88,7 +89,7 @@
         @if (Filter.HasPhoto)
         {
             <span class="ff-active-chip">
-                Has photo
+                @L["Species_Chip_HasPhoto"]
                 <button type="button" @onclick="ClearHasPhoto" aria-label="Clear has-photo filter">
                     <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Small" />
                 </button>
@@ -97,7 +98,7 @@
         @if (Filter.MinMunicipalityCount is > 1)
         {
             <span class="ff-active-chip">
-                ≥ @Filter.MinMunicipalityCount municipios
+                @L["Species_Chip_MinMunicipios", Filter.MinMunicipalityCount!]
                 <button type="button" @onclick="ClearMinMunicipalities" aria-label="Clear minimum municipios">
                     <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Small" />
                 </button>
@@ -121,16 +122,24 @@
 
     [Parameter] public SpeciesStatsDto? Stats { get; set; }
 
-    private static readonly (SpeciesSort Value, string Label)[] SortOptions =
+    private string SearchPlaceholder => L["Species_Toolbar_SearchPlaceholder"];
+
+    private static readonly (SpeciesSort Value, string LabelKey)[] SortOptions =
     [
-        (SpeciesSort.ScientificNameAsc, "Scientific name ↑"),
-        (SpeciesSort.ScientificNameDesc, "Scientific name ↓"),
-        (SpeciesSort.RecentlyObserved, "Recently observed"),
-        (SpeciesSort.MostMunicipalities, "Most widespread"),
+        (SpeciesSort.ScientificNameAsc, "Species_Toolbar_Sort_ScientificAsc"),
+        (SpeciesSort.ScientificNameDesc, "Species_Toolbar_Sort_ScientificDesc"),
+        (SpeciesSort.RecentlyObserved, "Species_Toolbar_Sort_Recent"),
+        (SpeciesSort.MostMunicipalities, "Species_Toolbar_Sort_MostWidespread"),
     ];
 
-    private string SortLabel => SortOptions.FirstOrDefault(o => o.Value == Sort).Label
-        ?? "Scientific name ↑";
+    private string SortLabel
+    {
+        get
+        {
+            var entry = SortOptions.FirstOrDefault(o => o.Value == Sort);
+            return L[entry.LabelKey ?? "Species_Toolbar_Sort_ScientificAsc"];
+        }
+    }
 
     private bool HasActiveFilters =>
         Filter.TaxonCodes.Count > 0
@@ -156,15 +165,15 @@
     }
 
     private string TaxaLabel => string.Join(", ",
-        Filter.TaxonCodes.Select(TaxonIcons.GetLabel));
+        Filter.TaxonCodes.Select(code => L[TaxonIcons.GetLabelKey(code)]));
 
     private string RecordsMeta => Stats is null
-        ? "Loading catalogue…"
-        : $"{Stats.TotalSpecies:N0} records · {Stats.MunicipalitiesCovered} municipios";
+        ? L["Species_Toolbar_RecordsMeta_Loading"]
+        : L["Species_Toolbar_RecordsMeta", Stats.TotalSpecies.ToString("N0"), Stats.MunicipalitiesCovered];
 
     private string VisibleCounterText => Stats is null
         ? ""
-        : $"of {Stats.TotalSpecies:N0}";
+        : L["Species_Toolbar_Counter_Of", Stats.TotalSpecies.ToString("N0")];
 
     private Task OnSearchChanged(string? value) => SearchTextChanged.InvokeAsync(value);
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/TaxonIcons.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Species/TaxonIcons.cs
@@ -3,9 +3,11 @@ using System.Collections.Frozen;
 namespace FaunaFinder.Client.Components.Species;
 
 /// <summary>
-/// Maps taxon codes to Font Awesome 6 free class names, loaded via CDN in App.razor.
-/// Material Icons lacks proper taxonomic iconography (no bird/frog/dragon), so we fall
-/// through to FA for the taxon badges specifically.
+/// Maps taxon codes to Font Awesome 6 free class names + translation keys.
+/// Material Icons lacks proper taxonomic iconography (no bird/frog/dragon),
+/// so we fall through to FA for the taxon badges. Labels are indirected
+/// through ILocalizer keys (<see cref="GetLabelKey"/>) so call-sites can
+/// translate them at render time.
 /// </summary>
 public static class TaxonIcons
 {
@@ -22,17 +24,17 @@ public static class TaxonIcons
             ["fungi"] = "fa-solid fa-seedling",
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly FrozenDictionary<string, string> Labels =
+    private static readonly FrozenDictionary<string, string> LabelKeys =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["bird"] = "Bird",
-            ["plant"] = "Plant",
-            ["reptile"] = "Reptile",
-            ["amphib"] = "Amphibian",
-            ["fish"] = "Fish",
-            ["mammal"] = "Mammal",
-            ["invert"] = "Invertebrate",
-            ["fungi"] = "Fungus",
+            ["bird"] = "Species_Taxa_Bird",
+            ["plant"] = "Species_Taxa_Plant",
+            ["reptile"] = "Species_Taxa_Reptile",
+            ["amphib"] = "Species_Taxa_Amphib",
+            ["fish"] = "Species_Taxa_Fish",
+            ["mammal"] = "Species_Taxa_Mammal",
+            ["invert"] = "Species_Taxa_Invert",
+            ["fungi"] = "Species_Taxa_Fungi",
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     public static IReadOnlyList<string> OrderedCodes { get; } =
@@ -43,8 +45,12 @@ public static class TaxonIcons
             ? icon
             : "fa-solid fa-paw";
 
-    public static string GetLabel(string? code) =>
-        code is not null && Labels.TryGetValue(code, out var label)
-            ? label
-            : code ?? "—";
+    /// <summary>
+    /// Returns the translation key for the taxon label (e.g. <c>"Species_Taxa_Bird"</c>).
+    /// Resolve via <c>ILocalizer</c> at the call site.
+    /// </summary>
+    public static string GetLabelKey(string? code) =>
+        code is not null && LabelKeys.TryGetValue(code, out var key)
+            ? key
+            : "Species_Taxa_Bird";
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -52,19 +52,38 @@
 
             <MudSpacer />
 
-            @* EN/ES toggle — shown on every breakpoint *@
-            <div class="ff-lang-toggle" role="group" aria-label="Language">
-                <button type="button"
-                        class="@(L.CurrentLanguage == "en" ? "is-on" : "")"
-                        @onclick="@(() => SetLocale("en"))">
-                    EN
-                </button>
-                <button type="button"
-                        class="@(L.CurrentLanguage == "es" ? "is-on" : "")"
-                        @onclick="@(() => SetLocale("es"))">
-                    ES
-                </button>
-            </div>
+            @* Language dropdown — shown on every breakpoint. Driven off
+               L.GetAvailableLanguages() so new locales register themselves
+               in the menu without touching this markup. *@
+            <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
+                <ActivatorContent>
+                    <button type="button" class="ff-lang-btn" aria-label="Language">
+                        <MudIcon Icon="@Icons.Material.Filled.Language" Size="Size.Small" />
+                        <span class="ff-lang-btn-code">@L.CurrentLanguage.ToUpperInvariant()</span>
+                        <MudIcon Icon="@Icons.Material.Filled.KeyboardArrowDown" Size="Size.Small" />
+                    </button>
+                </ActivatorContent>
+                <ChildContent>
+                    @foreach (var lang in L.GetAvailableLanguages())
+                    {
+                        var langCode = lang.Code;
+                        var isActive = string.Equals(langCode, L.CurrentLanguage, StringComparison.OrdinalIgnoreCase);
+                        <MudMenuItem OnClick="@(() => SetLocale(langCode))">
+                            @if (isActive)
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" Class="mr-2" />
+                            }
+                            else
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small"
+                                         Class="mr-2" Style="visibility:hidden" />
+                            }
+                            <span class="ff-lang-item-name">@lang.Name</span>
+                            <span class="ff-lang-item-code">@langCode.ToUpperInvariant()</span>
+                        </MudMenuItem>
+                    }
+                </ChildContent>
+            </MudMenu>
 
             @* Mobile: Action button(s) at far right *@
             <MudHidden Breakpoint="Breakpoint.MdAndUp">

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -52,20 +52,33 @@
 
             <MudSpacer />
 
-            @* Language picker — native <select>. Styled as a compact pill
-               via scoped CSS; the OS provides the dropdown UI which sidesteps
-               every MudBlazor popover quirk we've been hitting. *@
-            <select class="ff-lang-select"
-                    value="@L.CurrentLanguage"
-                    @onchange="OnLanguageSelected"
-                    aria-label="Language">
+            @* Language dropdown — MudMenu using its built-in activator
+               (Label + StartIcon + EndIcon) instead of ActivatorContent.
+               The Activator-content route wouldn't open inside MudAppBar;
+               built-in mode uses MudBlazor's tested internal wiring. *@
+            <MudMenu Label="@L.CurrentLanguage.ToUpperInvariant()"
+                     StartIcon="@Icons.Material.Filled.Language"
+                     EndIcon="@Icons.Material.Filled.KeyboardArrowDown"
+                     Variant="Variant.Text"
+                     Color="Color.Inherit"
+                     Size="Size.Small"
+                     AriaLabel="Language"
+                     AnchorOrigin="Origin.BottomRight"
+                     TransformOrigin="Origin.TopRight"
+                     Class="ff-lang-menu">
                 @foreach (var lang in L.GetAvailableLanguages())
                 {
-                    <option value="@lang.Code" selected="@(lang.Code == L.CurrentLanguage)">
-                        @lang.Code.ToUpperInvariant() · @lang.Name
-                    </option>
+                    var langCode = lang.Code;
+                    var isActive = string.Equals(langCode, L.CurrentLanguage, StringComparison.OrdinalIgnoreCase);
+                    <MudMenuItem OnClick="@(() => L.SetLanguage(langCode))">
+                        <div class="@(isActive ? "ff-lang-item is-active" : "ff-lang-item")">
+                            <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" />
+                            <span class="ff-lang-item-name">@lang.Name</span>
+                            <span class="ff-lang-item-code">@langCode.ToUpperInvariant()</span>
+                        </div>
+                    </MudMenuItem>
                 }
-            </select>
+            </MudMenu>
 
             @* Mobile: Action button(s) at far right *@
             <MudHidden Breakpoint="Breakpoint.MdAndUp">
@@ -213,14 +226,6 @@
     }
 
     private void SetLocale(string code) => L.SetLanguage(code);
-
-    private void OnLanguageSelected(ChangeEventArgs e)
-    {
-        if (e.Value is string code && !string.IsNullOrEmpty(code))
-        {
-            L.SetLanguage(code);
-        }
-    }
 
     public void Dispose()
     {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -1,6 +1,8 @@
+@using EcoData.Common.i18n
 @inherits LayoutComponentBase
 @inject INativeNavigationManager Navigation
 @inject INativeNavbarManager Navbar
+@inject ILocalizer L
 @implements IDisposable
 
 <MudThemeProvider Theme="FaunaFinderTheme.Default" />
@@ -41,10 +43,10 @@
             @* Desktop: Navigation links *@
             <MudHidden Breakpoint="Breakpoint.SmAndDown">
                 <nav class="ff-nav ml-6">
-                    <a href="/" class="@GetNavLinkClass("/", exact: true)">Map</a>
-                    <a href="/species" class="@GetNavLinkClass("/species")">Species</a>
-                    <a href="/municipalities" class="@GetNavLinkClass("/municipalities")">Municipalities</a>
-                    <a href="/categories" class="@GetNavLinkClass("/categories")">Categories</a>
+                    <a href="/" class="@GetNavLinkClass("/", exact: true)">@L["Nav_Map"]</a>
+                    <a href="/species" class="@GetNavLinkClass("/species")">@L["Nav_Species"]</a>
+                    <a href="/municipalities" class="@GetNavLinkClass("/municipalities")">@L["Nav_Municipios"]</a>
+                    <a href="/categories" class="@GetNavLinkClass("/categories")">@L["Nav_Categories"]</a>
                 </nav>
             </MudHidden>
 
@@ -53,13 +55,13 @@
             @* EN/ES toggle — shown on every breakpoint *@
             <div class="ff-lang-toggle" role="group" aria-label="Language">
                 <button type="button"
-                        class="@(_locale.Code == "en" ? "is-on" : "")"
-                        @onclick="@(() => SetLocale(LocaleContext.English))">
+                        class="@(L.CurrentLanguage == "en" ? "is-on" : "")"
+                        @onclick="@(() => SetLocale("en"))">
                     EN
                 </button>
                 <button type="button"
-                        class="@(_locale.Code == "es" ? "is-on" : "")"
-                        @onclick="@(() => SetLocale(LocaleContext.Spanish))">
+                        class="@(L.CurrentLanguage == "es" ? "is-on" : "")"
+                        @onclick="@(() => SetLocale("es"))">
                     ES
                 </button>
             </div>
@@ -95,28 +97,28 @@
                            OnClick="@(() => NavigateToTab(NavigationTab.Map))">
                     <MudStack AlignItems="AlignItems.Center" Spacing="0">
                         <MudIcon Icon="@Icons.Material.Filled.Map" Size="Size.Medium" />
-                        <MudText Typo="Typo.caption">Map</MudText>
+                        <MudText Typo="Typo.caption">@L["Nav_Map"]</MudText>
                     </MudStack>
                 </MudButton>
                 <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Species)" Class="bottom-nav-item"
                            OnClick="@(() => NavigateToTab(NavigationTab.Species))">
                     <MudStack AlignItems="AlignItems.Center" Spacing="0">
                         <MudIcon Icon="@Icons.Material.Filled.Pets" Size="Size.Medium" />
-                        <MudText Typo="Typo.caption">Species</MudText>
+                        <MudText Typo="Typo.caption">@L["Nav_Species"]</MudText>
                     </MudStack>
                 </MudButton>
                 <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Municipalities)" Class="bottom-nav-item"
                            OnClick="@(() => NavigateToTab(NavigationTab.Municipalities))">
                     <MudStack AlignItems="AlignItems.Center" Spacing="0">
                         <MudIcon Icon="@Icons.Material.Filled.LocationCity" Size="Size.Medium" />
-                        <MudText Typo="Typo.caption">Municipios</MudText>
+                        <MudText Typo="Typo.caption">@L["Nav_Municipios"]</MudText>
                     </MudStack>
                 </MudButton>
                 <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Categories)" Class="bottom-nav-item"
                            OnClick="@(() => NavigateToTab(NavigationTab.Categories))">
                     <MudStack AlignItems="AlignItems.Center" Spacing="0">
                         <MudIcon Icon="@Icons.Material.Filled.Category" Size="Size.Medium" />
-                        <MudText Typo="Typo.caption">Categories</MudText>
+                        <MudText Typo="Typo.caption">@L["Nav_Categories"]</MudText>
                     </MudStack>
                 </MudButton>
             </MudStack>
@@ -146,6 +148,8 @@
     {
         Navigation.OnStateChanged += HandleNavigationStateChanged;
         Navbar.OnStateChanged += HandleNavbarStateChanged;
+        L.LanguageChanged += HandleLanguageChanged;
+        _locale = L.CurrentLanguage == "es" ? LocaleContext.Spanish : LocaleContext.English;
         UpdateCurrentTab();
     }
 
@@ -157,6 +161,12 @@
 
     private void HandleNavbarStateChanged()
     {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleLanguageChanged()
+    {
+        _locale = L.CurrentLanguage == "es" ? LocaleContext.Spanish : LocaleContext.English;
         InvokeAsync(StateHasChanged);
     }
 
@@ -201,15 +211,12 @@
         Navigation.NavigateTo(path);
     }
 
-    private void SetLocale(LocaleContext locale)
-    {
-        if (_locale.Code == locale.Code) return;
-        _locale = locale;
-    }
+    private void SetLocale(string code) => L.SetLanguage(code);
 
     public void Dispose()
     {
         Navigation.OnStateChanged -= HandleNavigationStateChanged;
         Navbar.OnStateChanged -= HandleNavbarStateChanged;
+        L.LanguageChanged -= HandleLanguageChanged;
     }
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -52,42 +52,26 @@
 
             <MudSpacer />
 
-            @* Language dropdown — shown on every breakpoint. Driven off
-               L.GetAvailableLanguages() so new locales register themselves
-               in the menu without touching this markup. *@
-            <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight"
-                     ActivationEvent="@MouseEvent.LeftClick">
-                <ActivatorContent>
-                    <MudButton Variant="Variant.Text"
-                               Color="Color.Inherit"
-                               Size="Size.Small"
-                               StartIcon="@Icons.Material.Filled.Language"
-                               EndIcon="@Icons.Material.Filled.KeyboardArrowDown"
-                               Class="ff-lang-btn">
-                        @L.CurrentLanguage.ToUpperInvariant()
-                    </MudButton>
-                </ActivatorContent>
-                <ChildContent>
-                    @foreach (var lang in L.GetAvailableLanguages())
-                    {
-                        var langCode = lang.Code;
-                        var isActive = string.Equals(langCode, L.CurrentLanguage, StringComparison.OrdinalIgnoreCase);
-                        <MudMenuItem OnClick="@(() => SetLocale(langCode))">
-                            @if (isActive)
-                            {
-                                <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" Class="mr-2" />
-                            }
-                            else
-                            {
-                                <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small"
-                                         Class="mr-2" Style="visibility:hidden" />
-                            }
-                            <span class="ff-lang-item-name">@lang.Name</span>
-                            <span class="ff-lang-item-code">@langCode.ToUpperInvariant()</span>
-                        </MudMenuItem>
-                    }
-                </ChildContent>
-            </MudMenu>
+            @* Language dropdown — MudSelect keeps the activator wiring
+               simple and works reliably inside the MudAppBar. Driven off
+               L.GetAvailableLanguages() so new locales show up automatically. *@
+            <MudSelect T="string"
+                       Value="@L.CurrentLanguage"
+                       ValueChanged="OnLanguageSelected"
+                       Variant="Variant.Text"
+                       Margin="Margin.Dense"
+                       Dense="true"
+                       Class="ff-lang-select"
+                       AdornmentIcon="@Icons.Material.Filled.Language"
+                       AdornmentColor="Color.Inherit"
+                       Adornment="Adornment.Start">
+                @foreach (var lang in L.GetAvailableLanguages())
+                {
+                    <MudSelectItem T="string" Value="@lang.Code">
+                        @lang.Name
+                    </MudSelectItem>
+                }
+            </MudSelect>
 
             @* Mobile: Action button(s) at far right *@
             <MudHidden Breakpoint="Breakpoint.MdAndUp">
@@ -235,6 +219,11 @@
     }
 
     private void SetLocale(string code) => L.SetLanguage(code);
+
+    private void OnLanguageSelected(string? code)
+    {
+        if (!string.IsNullOrEmpty(code)) L.SetLanguage(code);
+    }
 
     public void Dispose()
     {

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -58,11 +58,14 @@
             <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight"
                      ActivationEvent="@MouseEvent.LeftClick">
                 <ActivatorContent>
-                    <button type="button" class="ff-lang-btn" aria-label="Language">
-                        <MudIcon Icon="@Icons.Material.Filled.Language" Size="Size.Small" />
-                        <span class="ff-lang-btn-code">@L.CurrentLanguage.ToUpperInvariant()</span>
-                        <MudIcon Icon="@Icons.Material.Filled.KeyboardArrowDown" Size="Size.Small" />
-                    </button>
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Inherit"
+                               Size="Size.Small"
+                               StartIcon="@Icons.Material.Filled.Language"
+                               EndIcon="@Icons.Material.Filled.KeyboardArrowDown"
+                               Class="ff-lang-btn">
+                        @L.CurrentLanguage.ToUpperInvariant()
+                    </MudButton>
                 </ActivatorContent>
                 <ChildContent>
                     @foreach (var lang in L.GetAvailableLanguages())

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -55,7 +55,8 @@
             @* Language dropdown — shown on every breakpoint. Driven off
                L.GetAvailableLanguages() so new locales register themselves
                in the menu without touching this markup. *@
-            <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
+            <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight"
+                     ActivationEvent="@MouseEvent.LeftClick">
                 <ActivatorContent>
                     <button type="button" class="ff-lang-btn" aria-label="Language">
                         <MudIcon Icon="@Icons.Material.Filled.Language" Size="Size.Small" />

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -52,26 +52,20 @@
 
             <MudSpacer />
 
-            @* Language dropdown — MudSelect keeps the activator wiring
-               simple and works reliably inside the MudAppBar. Driven off
-               L.GetAvailableLanguages() so new locales show up automatically. *@
-            <MudSelect T="string"
-                       Value="@L.CurrentLanguage"
-                       ValueChanged="OnLanguageSelected"
-                       Variant="Variant.Text"
-                       Margin="Margin.Dense"
-                       Dense="true"
-                       Class="ff-lang-select"
-                       AdornmentIcon="@Icons.Material.Filled.Language"
-                       AdornmentColor="Color.Inherit"
-                       Adornment="Adornment.Start">
+            @* Language picker — native <select>. Styled as a compact pill
+               via scoped CSS; the OS provides the dropdown UI which sidesteps
+               every MudBlazor popover quirk we've been hitting. *@
+            <select class="ff-lang-select"
+                    value="@L.CurrentLanguage"
+                    @onchange="OnLanguageSelected"
+                    aria-label="Language">
                 @foreach (var lang in L.GetAvailableLanguages())
                 {
-                    <MudSelectItem T="string" Value="@lang.Code">
-                        @lang.Name
-                    </MudSelectItem>
+                    <option value="@lang.Code" selected="@(lang.Code == L.CurrentLanguage)">
+                        @lang.Code.ToUpperInvariant() · @lang.Name
+                    </option>
                 }
-            </MudSelect>
+            </select>
 
             @* Mobile: Action button(s) at far right *@
             <MudHidden Breakpoint="Breakpoint.MdAndUp">
@@ -220,9 +214,12 @@
 
     private void SetLocale(string code) => L.SetLanguage(code);
 
-    private void OnLanguageSelected(string? code)
+    private void OnLanguageSelected(ChangeEventArgs e)
     {
-        if (!string.IsNullOrEmpty(code)) L.SetLanguage(code);
+        if (e.Value is string code && !string.IsNullOrEmpty(code))
+        {
+            L.SetLanguage(code);
+        }
     }
 
     public void Dispose()

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
@@ -75,54 +75,78 @@
     background: rgba(255, 255, 255, 0.1);
 }
 
-/* Language picker — native <select> styled as a pill for the dark bar.
-   Chevron is an inline SVG data URI so we don't drag in an asset. */
-.ff-lang-select {
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    background-color: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: 999px;
-    color: #ffffff;
-    cursor: pointer;
-    font: 600 11px/1 'Inter', sans-serif;
-    letter-spacing: 0.06em;
-    padding: 6px 26px 6px 14px;
-    min-width: 0;
-    width: auto;
-    transition: background-color 0.2s ease, border-color 0.2s ease;
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6' fill='none'><path d='M1 1l4 4 4-4' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-    background-repeat: no-repeat;
-    background-position: right 10px center;
-    background-size: 10px 6px;
+/* Language dropdown — MudMenu in built-in activator mode. MudMenu
+   renders an internal MudButton; we style it as a pine pill and
+   leave the popover to MudBlazor. Scoped ::deep reaches into
+   MudBlazor's DOM. */
+::deep .ff-lang-menu {
+    margin-left: 0;
 }
 
-.ff-lang-select:hover {
-    background-color: rgba(255, 255, 255, 0.14);
-    border-color: rgba(255, 255, 255, 0.22);
+::deep .ff-lang-menu > .mud-button-root {
+    background: rgba(255, 255, 255, 0.08) !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    border-radius: 999px !important;
+    color: rgba(255, 255, 255, 0.9) !important;
+    font: 600 11px/1 'Inter', sans-serif !important;
+    letter-spacing: 0.06em !important;
+    text-transform: none !important;
+    padding: 4px 8px 4px 12px !important;
+    min-width: 0 !important;
+    transition: background-color 0.2s ease, border-color 0.2s ease,
+                color 0.2s ease;
 }
 
-.ff-lang-select:focus {
-    outline: none;
-    border-color: rgba(255, 255, 255, 0.4);
+::deep .ff-lang-menu > .mud-button-root:hover {
+    background: rgba(255, 255, 255, 0.14) !important;
+    border-color: rgba(255, 255, 255, 0.22) !important;
+    color: #ffffff !important;
 }
 
-/* The dropdown list (option nodes) is rendered by the OS so we can't
-   style it deeply; make the options use the app surface colour at least. */
-.ff-lang-select option {
-    background: var(--fauna-surface, #ffffff);
-    color: var(--fauna-fg, #111);
+::deep .ff-lang-menu > .mud-button-root .mud-icon-root {
+    color: currentColor !important;
+    font-size: 16px !important;
+}
+
+/* Menu item layout: check + name + code */
+.ff-lang-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 180px;
+}
+
+.ff-lang-item ::deep .mud-icon-root {
+    visibility: hidden;
+    font-size: 16px !important;
+    color: var(--fauna-primary, #1f4d3a);
+}
+
+.ff-lang-item.is-active ::deep .mud-icon-root {
+    visibility: visible;
+}
+
+.ff-lang-item-name {
+    flex: 1;
     font: 500 13px/1.3 'Inter', sans-serif;
     letter-spacing: 0;
 }
 
-/* Mobile — smaller, tucked next to the back/title */
+.ff-lang-item-code {
+    font: 600 10px/1 'JetBrains Mono', monospace;
+    letter-spacing: 0.08em;
+    color: var(--fauna-fg-4, #888);
+}
+
+/* Mobile — tighter pill */
 @media (max-width: 959.95px) {
-    .ff-lang-select {
+    ::deep .ff-lang-menu {
         margin-left: auto;
-        font-size: 10px;
-        padding: 5px 22px 5px 10px;
+    }
+
+    ::deep .ff-lang-menu > .mud-button-root {
+        font-size: 10px !important;
+        padding: 3px 6px 3px 10px !important;
     }
 }
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
@@ -75,52 +75,58 @@
     background: rgba(255, 255, 255, 0.1);
 }
 
-/* Language toggle — pill */
-::deep .ff-lang-toggle {
+/* Language dropdown — activator button */
+::deep .ff-lang-btn {
     display: inline-flex;
     align-items: center;
+    gap: 6px;
     background: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 999px;
-    padding: 2px;
-    font-family: 'Inter', sans-serif;
-    font-weight: 600;
-    font-size: 10px;
-    letter-spacing: 0.08em;
-}
-
-::deep .ff-lang-toggle button {
-    background: transparent;
-    border: 0;
-    color: rgba(255, 255, 255, 0.7);
-    padding: 5px 10px;
-    border-radius: 999px;
+    padding: 5px 8px 5px 10px;
+    color: rgba(255, 255, 255, 0.85);
     cursor: pointer;
-    font: inherit;
-    letter-spacing: inherit;
-    min-width: 32px;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    font: 600 11px/1 'Inter', sans-serif;
+    letter-spacing: 0.08em;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
-::deep .ff-lang-toggle button:hover {
+::deep .ff-lang-btn:hover {
     color: #ffffff;
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.22);
 }
 
-::deep .ff-lang-toggle button.is-on {
-    background: #ffffff;
-    color: var(--fauna-primary, #1f4d3a);
+::deep .ff-lang-btn .ff-lang-btn-code {
+    min-width: 18px;
+    text-align: center;
 }
 
-/* Mobile — compact pill so it sits alongside back/title */
+::deep .ff-lang-btn .mud-icon-root {
+    color: currentColor !important;
+}
+
+/* Menu item layout: check | language name | code */
+::deep .ff-lang-item-name {
+    flex: 1;
+    font: 500 13px/1.3 'Inter', sans-serif;
+    letter-spacing: 0;
+}
+
+::deep .ff-lang-item-code {
+    font: 600 10px/1 'JetBrains Mono', monospace;
+    letter-spacing: 0.08em;
+    color: var(--fauna-fg-4, #888);
+    margin-left: 12px;
+}
+
+/* Mobile — slightly tighter button so it fits alongside back/title */
 @media (max-width: 959.95px) {
-    ::deep .ff-lang-toggle {
+    ::deep .ff-lang-btn {
         margin-left: auto;
-        font-size: 9px;
-    }
-
-    ::deep .ff-lang-toggle button {
-        padding: 4px 8px;
-        min-width: 28px;
+        font-size: 10px;
+        padding: 4px 6px 4px 8px;
+        gap: 4px;
     }
 }
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
@@ -75,64 +75,54 @@
     background: rgba(255, 255, 255, 0.1);
 }
 
-/* Language dropdown — MudSelect themed to sit in the dark app bar.
-   The field gets a rounded surface + light glyph so it reads as a pill
-   rather than a form input. */
-::deep .ff-lang-select {
-    width: auto;
-    min-width: 90px;
-    max-width: 140px;
-    margin: 0;
-}
-
-::deep .ff-lang-select .mud-input-slot,
-::deep .ff-lang-select .mud-input-control {
-    color: #ffffff !important;
-}
-
-::deep .ff-lang-select .mud-input {
-    background: rgba(255, 255, 255, 0.08);
+/* Language picker — native <select> styled as a pill for the dark bar.
+   Chevron is an inline SVG data URI so we don't drag in an asset. */
+.ff-lang-select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background-color: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 999px;
-    padding: 2px 10px 2px 14px;
     color: #ffffff;
+    cursor: pointer;
     font: 600 11px/1 'Inter', sans-serif;
     letter-spacing: 0.06em;
+    padding: 6px 26px 6px 14px;
+    min-width: 0;
+    width: auto;
     transition: background-color 0.2s ease, border-color 0.2s ease;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6' fill='none'><path d='M1 1l4 4 4-4' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 10px 6px;
 }
 
-::deep .ff-lang-select .mud-input:hover {
-    background: rgba(255, 255, 255, 0.14);
+.ff-lang-select:hover {
+    background-color: rgba(255, 255, 255, 0.14);
     border-color: rgba(255, 255, 255, 0.22);
 }
 
-/* Hide the underline that MudSelect's text variant paints */
-::deep .ff-lang-select .mud-input:before,
-::deep .ff-lang-select .mud-input:after {
-    display: none !important;
+.ff-lang-select:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.4);
 }
 
-::deep .ff-lang-select .mud-input-adornment .mud-icon-root,
-::deep .ff-lang-select .mud-select-icon {
-    color: rgba(255, 255, 255, 0.85) !important;
+/* The dropdown list (option nodes) is rendered by the OS so we can't
+   style it deeply; make the options use the app surface colour at least. */
+.ff-lang-select option {
+    background: var(--fauna-surface, #ffffff);
+    color: var(--fauna-fg, #111);
+    font: 500 13px/1.3 'Inter', sans-serif;
+    letter-spacing: 0;
 }
 
-::deep .ff-lang-select input {
-    color: #ffffff !important;
-    caret-color: transparent;
-    cursor: pointer;
-}
-
-/* Mobile — tuck closer to the edge */
+/* Mobile — smaller, tucked next to the back/title */
 @media (max-width: 959.95px) {
-    ::deep .ff-lang-select {
-        min-width: 72px;
+    .ff-lang-select {
         margin-left: auto;
-    }
-
-    ::deep .ff-lang-select .mud-input {
         font-size: 10px;
-        padding: 2px 6px 2px 10px;
+        padding: 5px 22px 5px 10px;
     }
 }
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
@@ -75,34 +75,29 @@
     background: rgba(255, 255, 255, 0.1);
 }
 
-/* Language dropdown — activator button */
+/* Language dropdown — MudButton activator, themed as a pill */
 ::deep .ff-lang-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: 999px;
-    padding: 5px 8px 5px 10px;
-    color: rgba(255, 255, 255, 0.85);
-    cursor: pointer;
-    font: 600 11px/1 'Inter', sans-serif;
-    letter-spacing: 0.08em;
+    background: rgba(255, 255, 255, 0.08) !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    border-radius: 999px !important;
+    padding: 4px 10px 4px 12px !important;
+    min-width: 0 !important;
+    color: rgba(255, 255, 255, 0.85) !important;
+    font: 600 11px/1 'Inter', sans-serif !important;
+    letter-spacing: 0.08em !important;
+    text-transform: none !important;
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 ::deep .ff-lang-btn:hover {
-    color: #ffffff;
-    background: rgba(255, 255, 255, 0.14);
-    border-color: rgba(255, 255, 255, 0.22);
+    color: #ffffff !important;
+    background: rgba(255, 255, 255, 0.14) !important;
+    border-color: rgba(255, 255, 255, 0.22) !important;
 }
 
-::deep .ff-lang-btn .ff-lang-btn-code {
-    min-width: 18px;
-    text-align: center;
-}
-
-::deep .ff-lang-btn .mud-icon-root {
+::deep .ff-lang-btn .mud-button-icon-start,
+::deep .ff-lang-btn .mud-button-icon-end {
+    font-size: 16px !important;
     color: currentColor !important;
 }
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
@@ -75,53 +75,64 @@
     background: rgba(255, 255, 255, 0.1);
 }
 
-/* Language dropdown — MudButton activator, themed as a pill */
-::deep .ff-lang-btn {
-    background: rgba(255, 255, 255, 0.08) !important;
-    border: 1px solid rgba(255, 255, 255, 0.12) !important;
-    border-radius: 999px !important;
-    padding: 4px 10px 4px 12px !important;
-    min-width: 0 !important;
-    color: rgba(255, 255, 255, 0.85) !important;
-    font: 600 11px/1 'Inter', sans-serif !important;
-    letter-spacing: 0.08em !important;
-    text-transform: none !important;
-    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+/* Language dropdown — MudSelect themed to sit in the dark app bar.
+   The field gets a rounded surface + light glyph so it reads as a pill
+   rather than a form input. */
+::deep .ff-lang-select {
+    width: auto;
+    min-width: 90px;
+    max-width: 140px;
+    margin: 0;
 }
 
-::deep .ff-lang-btn:hover {
+::deep .ff-lang-select .mud-input-slot,
+::deep .ff-lang-select .mud-input-control {
     color: #ffffff !important;
-    background: rgba(255, 255, 255, 0.14) !important;
-    border-color: rgba(255, 255, 255, 0.22) !important;
 }
 
-::deep .ff-lang-btn .mud-button-icon-start,
-::deep .ff-lang-btn .mud-button-icon-end {
-    font-size: 16px !important;
-    color: currentColor !important;
+::deep .ff-lang-select .mud-input {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    padding: 2px 10px 2px 14px;
+    color: #ffffff;
+    font: 600 11px/1 'Inter', sans-serif;
+    letter-spacing: 0.06em;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
-/* Menu item layout: check | language name | code */
-::deep .ff-lang-item-name {
-    flex: 1;
-    font: 500 13px/1.3 'Inter', sans-serif;
-    letter-spacing: 0;
+::deep .ff-lang-select .mud-input:hover {
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.22);
 }
 
-::deep .ff-lang-item-code {
-    font: 600 10px/1 'JetBrains Mono', monospace;
-    letter-spacing: 0.08em;
-    color: var(--fauna-fg-4, #888);
-    margin-left: 12px;
+/* Hide the underline that MudSelect's text variant paints */
+::deep .ff-lang-select .mud-input:before,
+::deep .ff-lang-select .mud-input:after {
+    display: none !important;
 }
 
-/* Mobile — slightly tighter button so it fits alongside back/title */
+::deep .ff-lang-select .mud-input-adornment .mud-icon-root,
+::deep .ff-lang-select .mud-select-icon {
+    color: rgba(255, 255, 255, 0.85) !important;
+}
+
+::deep .ff-lang-select input {
+    color: #ffffff !important;
+    caret-color: transparent;
+    cursor: pointer;
+}
+
+/* Mobile — tuck closer to the edge */
 @media (max-width: 959.95px) {
-    ::deep .ff-lang-btn {
+    ::deep .ff-lang-select {
+        min-width: 72px;
         margin-left: auto;
+    }
+
+    ::deep .ff-lang-select .mud-input {
         font-size: 10px;
-        padding: 4px 6px 4px 8px;
-        gap: 4px;
+        padding: 2px 6px 2px 10px;
     }
 }
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Localization/FaunaFinderStrings.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Localization/FaunaFinderStrings.cs
@@ -1,0 +1,460 @@
+using EcoData.Common.i18n;
+
+namespace FaunaFinder.Client.Localization;
+
+/// <summary>
+/// All user-visible UI strings for FaunaFinder, in both English and Spanish.
+/// Feed into <see cref="Localizer"/> at DI registration.
+///
+/// <para>Key convention: <c>Feature_Section_Purpose</c> — e.g. <c>Species_Hero_Lede</c>,
+/// <c>Muni_Stats_EndemicHotspots_Label</c>. Keep keys stable; translate values.</para>
+///
+/// <para>Brand names (FaunaFinder, Puerto Rico) stay as literals in markup.</para>
+/// </summary>
+public static class FaunaFinderStrings
+{
+    public static IReadOnlyList<ILanguage> Languages { get; } =
+    [
+        new Language("en", "English", IsDefault: true),
+        new Language("es", "Español"),
+    ];
+
+    public static IReadOnlyList<ITranslation> Translations
+    {
+        get
+        {
+            var list = new List<ITranslation>(En.Count * 2);
+            foreach (var (key, value) in En)
+            {
+                list.Add(new Translation("en", key, value));
+            }
+            foreach (var (key, value) in Es)
+            {
+                list.Add(new Translation("es", key, value));
+            }
+            return list;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // English
+    // -------------------------------------------------------------------
+    private static readonly Dictionary<string, string> En = new(StringComparer.Ordinal)
+    {
+        // Common / shared
+        ["Common_Loading"] = "Loading…",
+        ["Common_Cancel"] = "Cancel",
+        ["Common_Apply"] = "Apply",
+        ["Common_Close"] = "Close",
+        ["Common_Back"] = "Back",
+        ["Common_ViewDetails"] = "View details",
+        ["Common_ViewAll"] = "View all",
+        ["Common_Search"] = "Search",
+        ["Common_Sort"] = "Sort",
+        ["Common_Clear"] = "Clear",
+        ["Common_SelectAll"] = "Select all",
+        ["Common_ClearAll"] = "Clear all",
+        ["Common_SearchOff"] = "No results",
+        ["Common_Verified"] = "Verified",
+
+        // Layout / navigation
+        ["Nav_Map"] = "Map",
+        ["Nav_Species"] = "Species",
+        ["Nav_Municipios"] = "Municipios",
+        ["Nav_Categories"] = "Categories",
+
+        // Hero (shared eyebrow)
+        ["Hero_Eyebrow"] = "Volume 03 · Living Atlas",
+        ["Hero_LastSync"] = "Last sync · {0}",
+
+        // Species page — hero
+        ["Species_PageTitle"] = "FaunaFinder — Species",
+        ["Species_Hero_HeadingLead"] = "Species of",
+        ["Species_Hero_HeadingTail"] = ", catalogued and observed.",
+        ["Species_Hero_Lede"] = "A living field guide to the island's flora and fauna — drawn from verified sightings across 78 municipios. Browse by taxon, conservation status, or habitat; follow any record through to its distribution map and source observations.",
+        ["Species_Hero_RecordsLine"] = "{0} records · {1} municipios",
+        ["Species_Hero_UpdatedDaily"] = "Updated daily",
+        ["Species_Hero_RecordsPending"] = "— records · — municipios",
+
+        // Species page — stats row
+        ["Species_Stats_Total_Label"] = "Total species",
+        ["Species_Stats_Total_Sub_Delta"] = "{0} this quarter",
+        ["Species_Stats_Total_Sub_None"] = "—",
+        ["Species_Stats_Endemic_Label"] = "Endemic to P.R.",
+        ["Species_Stats_Endemic_Sub"] = "{0}% of catalogue",
+        ["Species_Stats_Threatened_Label"] = "Threatened · VU–CR",
+        ["Species_Stats_Threatened_Sub_Delta"] = "{0} reclassified",
+        ["Species_Stats_Municipios_Label"] = "Municipios covered",
+        ["Species_Stats_Municipios_Sub"] = "{0}% island coverage",
+
+        // Species page — featured row
+        ["Species_Featured_Heading"] = "Featured this week",
+        ["Species_Featured_Meta"] = "Curated · updated Mondays",
+
+        // Species page — toolbar
+        ["Species_Toolbar_Heading"] = "Find what you're looking for",
+        ["Species_Toolbar_RecordsMeta"] = "{0} records · {1} municipios",
+        ["Species_Toolbar_RecordsMeta_Loading"] = "Loading catalogue…",
+        ["Species_Toolbar_SearchPlaceholder"] = "Search by common name, scientific name, or species…",
+        ["Species_Toolbar_Counter_Of"] = "of {0}",
+        ["Species_Toolbar_Sort_Prefix"] = "Sort:",
+        ["Species_Toolbar_Sort_ScientificAsc"] = "Scientific name ↑",
+        ["Species_Toolbar_Sort_ScientificDesc"] = "Scientific name ↓",
+        ["Species_Toolbar_Sort_Recent"] = "Recently observed",
+        ["Species_Toolbar_Sort_MostWidespread"] = "Most widespread",
+
+        // Species page — active-filter chips
+        ["Species_Chip_Taxon"] = "Taxon: {0}",
+        ["Species_Chip_Status"] = "Status: {0}",
+        ["Species_Chip_Endemic"] = "Endemic only",
+        ["Species_Chip_ObservedRecently"] = "Observed in last 12 months",
+        ["Species_Chip_HasPhoto"] = "Has photo",
+        ["Species_Chip_MinMunicipios"] = "≥ {0} municipios",
+
+        // Species page — filter dialog
+        ["Species_Filter_Heading"] = "Refine the catalogue",
+        ["Species_Filter_TotalRecords"] = "{0} records",
+        ["Species_Filter_Section_Taxa"] = "Taxonomic group",
+        ["Species_Filter_Section_Status"] = "Conservation status (IUCN)",
+        ["Species_Filter_Section_Qualifiers"] = "Qualifiers",
+        ["Species_Filter_Section_MinMunicipios"] = "Minimum municipios present",
+        ["Species_Filter_Qualifier_EndemicLabel"] = "Endemic to Puerto Rico only",
+        ["Species_Filter_Qualifier_ObservedLabel"] = "Observed in the last 12 months",
+        ["Species_Filter_Qualifier_HasPhotoLabel"] = "Has photo",
+        ["Species_Filter_StatusMeta_Selected"] = "{0} selected",
+        ["Species_Filter_MinMunicipios_Meta"] = "≥ {0}",
+        ["Species_Filter_MinMunicipios_Rare"] = "1 (rare)",
+        ["Species_Filter_MinMunicipios_Ubiquitous"] = "78 (ubiquitous)",
+        ["Species_Filter_Reset"] = "Reset all filters",
+
+        // Species page — taxa labels (chip + filter grid)
+        ["Species_Taxa_Bird"] = "Bird",
+        ["Species_Taxa_Plant"] = "Plant",
+        ["Species_Taxa_Reptile"] = "Reptile",
+        ["Species_Taxa_Amphib"] = "Amphibian",
+        ["Species_Taxa_Fish"] = "Fish",
+        ["Species_Taxa_Mammal"] = "Mammal",
+        ["Species_Taxa_Invert"] = "Invertebrate",
+        ["Species_Taxa_Fungi"] = "Fungus",
+
+        // IUCN conservation status labels (full text — short codes stay as-is)
+        ["Species_Iucn_LC"] = "Least Concern",
+        ["Species_Iucn_NT"] = "Near Threatened",
+        ["Species_Iucn_VU"] = "Vulnerable",
+        ["Species_Iucn_EN"] = "Endangered",
+        ["Species_Iucn_CR"] = "Critically Endangered",
+        ["Species_Iucn_DD"] = "Data Deficient",
+        ["Species_Iucn_EX"] = "Extinct",
+
+        // Species card / grid
+        ["Species_Card_Municipios"] = "{0} municipios",
+        ["Species_Card_EndemicBadge"] = "Endemic PR",
+        ["Species_Grid_LoadingMore"] = "Loading more records…",
+        ["Species_Grid_LoadMore"] = "Load more records",
+        ["Species_Grid_EndOfCatalogue"] = "— end of catalogue —",
+        ["Species_Grid_Empty_Title"] = "No species match",
+        ["Species_Grid_Empty_Description"] = "Try adjusting your filters or search terms.",
+
+        // Species card — relative time
+        ["Time_MinutesAgo"] = "{0}m ago",
+        ["Time_HoursAgo"] = "{0}h ago",
+        ["Time_DaysAgo"] = "{0}d ago",
+        ["Time_MonthsAgo"] = "{0}mo ago",
+        ["Time_YearsAgo"] = "{0}y ago",
+
+        // Species detail
+        ["SpeciesDetail_Rank_Global"] = "Global: {0}",
+        ["SpeciesDetail_Rank_State"] = "State: {0}",
+        ["SpeciesDetail_Kingdom_Fauna"] = "Fauna",
+        ["SpeciesDetail_Kingdom_Flora"] = "Flora",
+        ["SpeciesDetail_ElCode"] = "Element Code: {0}",
+        ["SpeciesDetail_Categories_Heading"] = "Categories",
+        ["SpeciesDetail_Municipalities_Heading"] = "Municipalities",
+        ["SpeciesDetail_Municipalities_Empty_Title"] = "No municipalities",
+        ["SpeciesDetail_Municipalities_Empty_Description"] = "This species has no recorded municipality associations yet.",
+        ["SpeciesDetail_NotFound_Title"] = "Species not found",
+        ["SpeciesDetail_NotFound_Description"] = "The species you're looking for doesn't exist or has been removed.",
+
+        // Municipalities page — hero
+        ["Muni_PageTitle"] = "FaunaFinder — Municipios",
+        ["Muni_Hero_HeadingLead"] = "Municipios of",
+        ["Muni_Hero_HeadingTail"] = ", mapped and observed.",
+        ["Muni_Hero_Lede"] = "A geographic index to Puerto Rico's 78 municipios — each annotated with the species recorded inside its boundaries. Search by name, sort by biodiversity, or tap any pin to pull up a municipio's full roster and its notable residents.",
+        ["Muni_Hero_RecordsLine"] = "{0} municipios · {1} records",
+        ["Muni_Hero_RecordsPending"] = "— municipios · — records",
+        ["Muni_Hero_Hint"] = "Tap a pin or row to drill in",
+
+        // Municipalities page — stats row
+        ["Muni_Stats_Total_Label"] = "Total municipios",
+        ["Muni_Stats_Total_Unit"] = "/ {0} tracked",
+        ["Muni_Stats_Total_Sub"] = "100% island coverage",
+        ["Muni_Stats_Species_Label"] = "Species catalogued",
+        ["Muni_Stats_Species_Sub"] = "across the island",
+        ["Muni_Stats_Avg_Label"] = "Avg · species / municipio",
+        ["Muni_Stats_Avg_Sub"] = "{0} municipios contribute",
+        ["Muni_Stats_Hotspots_Label"] = "Endemic hotspots",
+        ["Muni_Stats_Hotspots_Sub"] = "≥ 10 endemic species present",
+
+        // Municipalities — tab pill
+        ["Muni_Tab_Map"] = "Map",
+        ["Muni_Tab_List"] = "List",
+
+        // Municipalities — list
+        ["Muni_List_SearchPlaceholder"] = "Search municipios by name…",
+        ["Muni_List_VisibleAll"] = "{0} municipios",
+        ["Muni_List_VisibleFiltered"] = "{0} of {1}",
+        ["Muni_List_Loading"] = "Loading…",
+        ["Muni_List_Sort_SpeciesCountDesc"] = "species count ↓",
+        ["Muni_List_Sort_NameAsc"] = "name A–Z",
+        ["Muni_List_Sort_Prefix"] = "Sort:",
+        ["Muni_List_Empty"] = "No municipios match \"{0}\"",
+        ["Muni_List_Foot_Loading"] = "loading municipios",
+        ["Muni_List_Foot_Total"] = "{0} municipios tracked",
+
+        // Municipalities — map legend + detail card
+        ["Muni_Map_Legend_Title"] = "Municipios",
+        ["Muni_Map_Legend_Selected"] = "Selected",
+        ["Muni_Map_Legend_Boundary"] = "Boundary",
+        ["Muni_DetailCard_Species_Label"] = "Species",
+        ["Muni_DetailCard_Fips_Label"] = "FIPS",
+        ["Muni_DetailCard_CountRecorded"] = "{0} species recorded",
+        ["Muni_DetailCard_CountPending"] = "Species count pending",
+        ["Muni_Card_SpeciesCount"] = "{0} species",
+
+        // Municipalities — detail route
+        ["MuniDetail_Subline"] = "{0} · FIPS {1}",
+        ["MuniDetail_Centroid"] = "Centroid · {0}″N {1}″W",
+        ["MuniDetail_Species_Heading"] = "Species",
+        ["MuniDetail_Species_Empty_Title"] = "No species recorded",
+        ["MuniDetail_Species_Empty_Description"] = "No species have been associated with this municipio yet.",
+        ["MuniDetail_NotFound_Title"] = "Municipio not found",
+        ["MuniDetail_NotFound_Description"] = "The municipio you're looking for doesn't exist or has been removed.",
+
+        // Categories page
+        ["Categories_PageTitle"] = "Categories",
+        ["Categories_Empty_Title"] = "No categories",
+        ["Categories_Empty_Description"] = "No species categories have been created yet.",
+        ["CategoryDetail_SpeciesCount"] = "{0} Species",
+        ["CategoryDetail_Empty_Title"] = "No species",
+        ["CategoryDetail_Empty_Description"] = "No species have been categorized here yet.",
+
+        // Home (map page)
+        ["Home_MapLoading"] = "Loading map…",
+        ["Home_SidebarEmpty"] = "Tap a municipio to see its species",
+        ["Map_Panel_Eyebrow"] = "Municipio",
+        ["Map_Panel_NoSpecies_Title"] = "No species recorded",
+        ["Map_Panel_NoSpecies_Description"] = "No species have been observed in this municipio yet.",
+        ["Map_Panel_SpeciesObserved"] = "{0} species observed",
+    };
+
+    // -------------------------------------------------------------------
+    // Spanish
+    // -------------------------------------------------------------------
+    private static readonly Dictionary<string, string> Es = new(StringComparer.Ordinal)
+    {
+        // Common / shared
+        ["Common_Loading"] = "Cargando…",
+        ["Common_Cancel"] = "Cancelar",
+        ["Common_Apply"] = "Aplicar",
+        ["Common_Close"] = "Cerrar",
+        ["Common_Back"] = "Atrás",
+        ["Common_ViewDetails"] = "Ver detalles",
+        ["Common_ViewAll"] = "Ver todos",
+        ["Common_Search"] = "Buscar",
+        ["Common_Sort"] = "Ordenar",
+        ["Common_Clear"] = "Limpiar",
+        ["Common_SelectAll"] = "Seleccionar todos",
+        ["Common_ClearAll"] = "Limpiar todos",
+        ["Common_SearchOff"] = "Sin resultados",
+        ["Common_Verified"] = "Verificado",
+
+        // Layout / navigation
+        ["Nav_Map"] = "Mapa",
+        ["Nav_Species"] = "Especies",
+        ["Nav_Municipios"] = "Municipios",
+        ["Nav_Categories"] = "Categorías",
+
+        // Hero
+        ["Hero_Eyebrow"] = "Volumen 03 · Atlas Viviente",
+        ["Hero_LastSync"] = "Última sincronización · {0}",
+
+        // Species page — hero
+        ["Species_PageTitle"] = "FaunaFinder — Especies",
+        ["Species_Hero_HeadingLead"] = "Especies de",
+        ["Species_Hero_HeadingTail"] = ", catalogadas y observadas.",
+        ["Species_Hero_Lede"] = "Una guía de campo viva de la flora y fauna de la isla — construida con avistamientos verificados en los 78 municipios. Explora por taxón, estado de conservación o hábitat; sigue cualquier registro hasta su mapa de distribución y observaciones originales.",
+        ["Species_Hero_RecordsLine"] = "{0} registros · {1} municipios",
+        ["Species_Hero_UpdatedDaily"] = "Actualizado a diario",
+        ["Species_Hero_RecordsPending"] = "— registros · — municipios",
+
+        // Species page — stats row
+        ["Species_Stats_Total_Label"] = "Total de especies",
+        ["Species_Stats_Total_Sub_Delta"] = "{0} este trimestre",
+        ["Species_Stats_Total_Sub_None"] = "—",
+        ["Species_Stats_Endemic_Label"] = "Endémicas de P.R.",
+        ["Species_Stats_Endemic_Sub"] = "{0}% del catálogo",
+        ["Species_Stats_Threatened_Label"] = "Amenazadas · VU–CR",
+        ["Species_Stats_Threatened_Sub_Delta"] = "{0} reclasificadas",
+        ["Species_Stats_Municipios_Label"] = "Municipios cubiertos",
+        ["Species_Stats_Municipios_Sub"] = "{0}% de la isla cubierta",
+
+        // Species page — featured row
+        ["Species_Featured_Heading"] = "Destacadas esta semana",
+        ["Species_Featured_Meta"] = "Curado · actualizado los lunes",
+
+        // Species page — toolbar
+        ["Species_Toolbar_Heading"] = "Encuentra lo que buscas",
+        ["Species_Toolbar_RecordsMeta"] = "{0} registros · {1} municipios",
+        ["Species_Toolbar_RecordsMeta_Loading"] = "Cargando catálogo…",
+        ["Species_Toolbar_SearchPlaceholder"] = "Busca por nombre común, nombre científico o especie…",
+        ["Species_Toolbar_Counter_Of"] = "de {0}",
+        ["Species_Toolbar_Sort_Prefix"] = "Orden:",
+        ["Species_Toolbar_Sort_ScientificAsc"] = "Nombre científico ↑",
+        ["Species_Toolbar_Sort_ScientificDesc"] = "Nombre científico ↓",
+        ["Species_Toolbar_Sort_Recent"] = "Observadas recientemente",
+        ["Species_Toolbar_Sort_MostWidespread"] = "Más extendidas",
+
+        // Species page — active-filter chips
+        ["Species_Chip_Taxon"] = "Taxón: {0}",
+        ["Species_Chip_Status"] = "Estado: {0}",
+        ["Species_Chip_Endemic"] = "Solo endémicas",
+        ["Species_Chip_ObservedRecently"] = "Observadas en los últimos 12 meses",
+        ["Species_Chip_HasPhoto"] = "Con foto",
+        ["Species_Chip_MinMunicipios"] = "≥ {0} municipios",
+
+        // Species page — filter dialog
+        ["Species_Filter_Heading"] = "Refinar el catálogo",
+        ["Species_Filter_TotalRecords"] = "{0} registros",
+        ["Species_Filter_Section_Taxa"] = "Grupo taxonómico",
+        ["Species_Filter_Section_Status"] = "Estado de conservación (UICN)",
+        ["Species_Filter_Section_Qualifiers"] = "Criterios",
+        ["Species_Filter_Section_MinMunicipios"] = "Mínimo de municipios",
+        ["Species_Filter_Qualifier_EndemicLabel"] = "Solo endémicas de Puerto Rico",
+        ["Species_Filter_Qualifier_ObservedLabel"] = "Observadas en los últimos 12 meses",
+        ["Species_Filter_Qualifier_HasPhotoLabel"] = "Con foto",
+        ["Species_Filter_StatusMeta_Selected"] = "{0} seleccionadas",
+        ["Species_Filter_MinMunicipios_Meta"] = "≥ {0}",
+        ["Species_Filter_MinMunicipios_Rare"] = "1 (raras)",
+        ["Species_Filter_MinMunicipios_Ubiquitous"] = "78 (ubicuas)",
+        ["Species_Filter_Reset"] = "Restablecer filtros",
+
+        // Species page — taxa labels
+        ["Species_Taxa_Bird"] = "Ave",
+        ["Species_Taxa_Plant"] = "Planta",
+        ["Species_Taxa_Reptile"] = "Reptil",
+        ["Species_Taxa_Amphib"] = "Anfibio",
+        ["Species_Taxa_Fish"] = "Pez",
+        ["Species_Taxa_Mammal"] = "Mamífero",
+        ["Species_Taxa_Invert"] = "Invertebrado",
+        ["Species_Taxa_Fungi"] = "Hongo",
+
+        // IUCN conservation status labels
+        ["Species_Iucn_LC"] = "Preocupación menor",
+        ["Species_Iucn_NT"] = "Casi amenazada",
+        ["Species_Iucn_VU"] = "Vulnerable",
+        ["Species_Iucn_EN"] = "En peligro",
+        ["Species_Iucn_CR"] = "En peligro crítico",
+        ["Species_Iucn_DD"] = "Datos insuficientes",
+        ["Species_Iucn_EX"] = "Extinta",
+
+        // Species card / grid
+        ["Species_Card_Municipios"] = "{0} municipios",
+        ["Species_Card_EndemicBadge"] = "Endémica PR",
+        ["Species_Grid_LoadingMore"] = "Cargando más registros…",
+        ["Species_Grid_LoadMore"] = "Cargar más registros",
+        ["Species_Grid_EndOfCatalogue"] = "— fin del catálogo —",
+        ["Species_Grid_Empty_Title"] = "Sin coincidencias",
+        ["Species_Grid_Empty_Description"] = "Ajusta los filtros o los términos de búsqueda.",
+
+        // Relative time
+        ["Time_MinutesAgo"] = "hace {0} min",
+        ["Time_HoursAgo"] = "hace {0} h",
+        ["Time_DaysAgo"] = "hace {0} d",
+        ["Time_MonthsAgo"] = "hace {0} meses",
+        ["Time_YearsAgo"] = "hace {0} años",
+
+        // Species detail
+        ["SpeciesDetail_Rank_Global"] = "Global: {0}",
+        ["SpeciesDetail_Rank_State"] = "Estatal: {0}",
+        ["SpeciesDetail_Kingdom_Fauna"] = "Fauna",
+        ["SpeciesDetail_Kingdom_Flora"] = "Flora",
+        ["SpeciesDetail_ElCode"] = "Código de elemento: {0}",
+        ["SpeciesDetail_Categories_Heading"] = "Categorías",
+        ["SpeciesDetail_Municipalities_Heading"] = "Municipios",
+        ["SpeciesDetail_Municipalities_Empty_Title"] = "Sin municipios",
+        ["SpeciesDetail_Municipalities_Empty_Description"] = "Esta especie aún no tiene municipios asociados.",
+        ["SpeciesDetail_NotFound_Title"] = "Especie no encontrada",
+        ["SpeciesDetail_NotFound_Description"] = "La especie que buscas no existe o fue eliminada.",
+
+        // Municipalities page — hero
+        ["Muni_PageTitle"] = "FaunaFinder — Municipios",
+        ["Muni_Hero_HeadingLead"] = "Municipios de",
+        ["Muni_Hero_HeadingTail"] = ", en el mapa y observados.",
+        ["Muni_Hero_Lede"] = "Un índice geográfico de los 78 municipios de Puerto Rico — cada uno anotado con las especies registradas dentro de sus límites. Busca por nombre, ordena por biodiversidad, o toca un pin para abrir el registro completo del municipio y sus residentes más destacados.",
+        ["Muni_Hero_RecordsLine"] = "{0} municipios · {1} registros",
+        ["Muni_Hero_RecordsPending"] = "— municipios · — registros",
+        ["Muni_Hero_Hint"] = "Toca un pin o una fila para profundizar",
+
+        // Municipalities page — stats row
+        ["Muni_Stats_Total_Label"] = "Total de municipios",
+        ["Muni_Stats_Total_Unit"] = "/ {0} rastreados",
+        ["Muni_Stats_Total_Sub"] = "100% de la isla",
+        ["Muni_Stats_Species_Label"] = "Especies catalogadas",
+        ["Muni_Stats_Species_Sub"] = "en toda la isla",
+        ["Muni_Stats_Avg_Label"] = "Prom · especies / municipio",
+        ["Muni_Stats_Avg_Sub"] = "{0} municipios aportan",
+        ["Muni_Stats_Hotspots_Label"] = "Focos endémicos",
+        ["Muni_Stats_Hotspots_Sub"] = "≥ 10 especies endémicas presentes",
+
+        // Municipalities — tab pill
+        ["Muni_Tab_Map"] = "Mapa",
+        ["Muni_Tab_List"] = "Lista",
+
+        // Municipalities — list
+        ["Muni_List_SearchPlaceholder"] = "Busca municipios por nombre…",
+        ["Muni_List_VisibleAll"] = "{0} municipios",
+        ["Muni_List_VisibleFiltered"] = "{0} de {1}",
+        ["Muni_List_Loading"] = "Cargando…",
+        ["Muni_List_Sort_SpeciesCountDesc"] = "cantidad de especies ↓",
+        ["Muni_List_Sort_NameAsc"] = "nombre A–Z",
+        ["Muni_List_Sort_Prefix"] = "Orden:",
+        ["Muni_List_Empty"] = "Ningún municipio coincide con \"{0}\"",
+        ["Muni_List_Foot_Loading"] = "cargando municipios",
+        ["Muni_List_Foot_Total"] = "{0} municipios rastreados",
+
+        // Municipalities — map legend + detail card
+        ["Muni_Map_Legend_Title"] = "Municipios",
+        ["Muni_Map_Legend_Selected"] = "Seleccionado",
+        ["Muni_Map_Legend_Boundary"] = "Límite",
+        ["Muni_DetailCard_Species_Label"] = "Especies",
+        ["Muni_DetailCard_Fips_Label"] = "FIPS",
+        ["Muni_DetailCard_CountRecorded"] = "{0} especies registradas",
+        ["Muni_DetailCard_CountPending"] = "Conteo pendiente",
+        ["Muni_Card_SpeciesCount"] = "{0} especies",
+
+        // Municipalities — detail route
+        ["MuniDetail_Subline"] = "{0} · FIPS {1}",
+        ["MuniDetail_Centroid"] = "Centroide · {0}″N {1}″O",
+        ["MuniDetail_Species_Heading"] = "Especies",
+        ["MuniDetail_Species_Empty_Title"] = "Sin especies",
+        ["MuniDetail_Species_Empty_Description"] = "Aún no se han asociado especies con este municipio.",
+        ["MuniDetail_NotFound_Title"] = "Municipio no encontrado",
+        ["MuniDetail_NotFound_Description"] = "El municipio que buscas no existe o fue eliminado.",
+
+        // Categories page
+        ["Categories_PageTitle"] = "Categorías",
+        ["Categories_Empty_Title"] = "Sin categorías",
+        ["Categories_Empty_Description"] = "Aún no se han creado categorías de especies.",
+        ["CategoryDetail_SpeciesCount"] = "{0} especies",
+        ["CategoryDetail_Empty_Title"] = "Sin especies",
+        ["CategoryDetail_Empty_Description"] = "Aún no se ha categorizado ninguna especie aquí.",
+
+        // Home (map page)
+        ["Home_MapLoading"] = "Cargando mapa…",
+        ["Home_SidebarEmpty"] = "Toca un municipio para ver sus especies",
+        ["Map_Panel_Eyebrow"] = "Municipio",
+        ["Map_Panel_NoSpecies_Title"] = "Sin especies registradas",
+        ["Map_Panel_NoSpecies_Description"] = "Aún no se han observado especies en este municipio.",
+        ["Map_Panel_SpeciesObserved"] = "{0} especies observadas",
+    };
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Localization/LocalizedComponentBase.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Localization/LocalizedComponentBase.cs
@@ -1,0 +1,31 @@
+using EcoData.Common.i18n;
+using Microsoft.AspNetCore.Components;
+
+namespace FaunaFinder.Client.Localization;
+
+/// <summary>
+/// Base for any component that renders strings from <see cref="ILocalizer"/>.
+/// Subscribes to <see cref="ILocalizer.LanguageChanged"/> in <see cref="OnInitialized"/>
+/// and re-renders when the locale flips, so call-sites can write
+/// <c>@L["SomeKey"]</c> without wiring the subscription themselves.
+///
+/// <para>Subclasses that need their own init or disposal logic should call
+/// <c>base.OnInitialized()</c> / <c>base.Dispose()</c>.</para>
+/// </summary>
+public abstract class LocalizedComponentBase : ComponentBase, IDisposable
+{
+    [Inject]
+    protected ILocalizer L { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        L.LanguageChanged += HandleLanguageChanged;
+    }
+
+    private void HandleLanguageChanged() => InvokeAsync(StateHasChanged);
+
+    public virtual void Dispose()
+    {
+        L.LanguageChanged -= HandleLanguageChanged;
+    }
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Categories.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Categories.razor
@@ -7,8 +7,9 @@
 @inject ISpeciesHttpClient SpeciesHttpClient
 @inject INativeNavbarManager Navbar
 @inject NavigationManager NavigationManager
+@inject ILocalizer L
 
-<PageTitle>FaunaFinder - Categories</PageTitle>
+<PageTitle>FaunaFinder — @L["Categories_PageTitle"]</PageTitle>
 
 @if (Id is not null)
 {
@@ -24,12 +25,12 @@
         else if ((_speciesInCategoryFetch.Data?.Count ?? 0) == 0)
         {
             <NuiEmptyState Icon="@Icons.Material.Outlined.Pets"
-                           Title="No species"
-                           Description="No species have been categorized here yet." />
+                           Title="@L[CategoryDetailEmptyTitle]"
+                           Description="@L[CategoryDetailEmptyDescription]" />
         }
         else
         {
-            <NuiSectionHeader Title="@($"{_speciesInCategoryFetch.Data!.Count} Species")" />
+            <NuiSectionHeader Title="@SpeciesCountHeading" />
             <MudList T="SpeciesDtoForList" Dense="true">
                 @foreach (var species in _speciesInCategoryFetch.Data!)
                 {
@@ -63,8 +64,8 @@ else
         else if ((_categoriesFetch.Data?.Count ?? 0) == 0)
         {
             <NuiEmptyState Icon="@Icons.Material.Outlined.Category"
-                           Title="No categories"
-                           Description="No species categories have been created yet." />
+                           Title="@L[CategoriesEmptyTitle]"
+                           Description="@L[CategoriesEmptyDescription]" />
         }
         else
         {
@@ -86,18 +87,35 @@ else
 @code {
     [Parameter] public Guid? Id { get; set; }
 
+    // Keys exposed as consts so the Razor attribute form (`Title="@L[Key]"`)
+    // compiles without nested-quote issues.
+    private const string CategoriesEmptyTitle = "Categories_Empty_Title";
+    private const string CategoriesEmptyDescription = "Categories_Empty_Description";
+    private const string CategoryDetailEmptyTitle = "CategoryDetail_Empty_Title";
+    private const string CategoryDetailEmptyDescription = "CategoryDetail_Empty_Description";
+
     private string? _categoryName;
     private IFetch<IReadOnlyList<SpeciesCategoryDtoForList>> _categoriesFetch = default!;
     private IFetch<IReadOnlyList<SpeciesDtoForList>>? _speciesInCategoryFetch;
     private Guid? _loadedCategoryId;
 
+    private string SpeciesCountHeading =>
+        L["CategoryDetail_SpeciesCount", _speciesInCategoryFetch?.Data?.Count ?? 0];
+
     protected override void OnInitialized()
     {
-        Navbar.SetTitle("Categories");
+        Navbar.SetTitle(L["Nav_Categories"]);
+        L.LanguageChanged += OnLanguageChanged;
         _categoriesFetch = new Fetch<IReadOnlyList<SpeciesCategoryDtoForList>>(
             CategoryHttpClient.GetAllAsync,
             () => InvokeAsync(StateHasChanged)
         );
+    }
+
+    private void OnLanguageChanged()
+    {
+        if (Id is null) Navbar.SetTitle(L["Nav_Categories"]);
+        InvokeAsync(StateHasChanged);
     }
 
     protected override async Task OnParametersSetAsync()
@@ -126,6 +144,7 @@ else
 
     public void Dispose()
     {
+        L.LanguageChanged -= OnLanguageChanged;
         (_categoriesFetch as IDisposable)?.Dispose();
         (_speciesInCategoryFetch as IDisposable)?.Dispose();
     }

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Home.razor
@@ -8,9 +8,10 @@
 @inject IMunicipalityHttpClient MunicipalityHttpClient
 @inject ISpeciesHttpClient SpeciesHttpClient
 @inject NavigationManager NavigationManager
+@inject ILocalizer L
 @implements IDisposable
 
-<PageTitle>FaunaFinder - Map</PageTitle>
+<PageTitle>FaunaFinder — @L["Nav_Map"]</PageTitle>
 
 <div class="map-page">
     <div class="map-container">
@@ -19,7 +20,7 @@
             <MudOverlay Visible="true" DarkBackground="false" Absolute="true" Class="map-loading-overlay" ZIndex="1000">
                 <MudStack AlignItems="AlignItems.Center">
                     <MudProgressCircular Indeterminate="true" Color="Color.Primary" />
-                    <MudText Typo="Typo.body2">Loading map...</MudText>
+                    <MudText Typo="Typo.body2">@L["Home_MapLoading"]</MudText>
                 </MudStack>
             </MudOverlay>
         }
@@ -70,12 +71,15 @@
 
     protected override void OnInitialized()
     {
+        L.LanguageChanged += OnLanguageChanged;
         _mapController.OnGeoJsonClicked += OnGeoJsonClicked;
         _mapInitFetch = new Fetch<bool>(
             InitMapAsync,
             () => InvokeAsync(StateHasChanged)
         );
     }
+
+    private void OnLanguageChanged() => InvokeAsync(StateHasChanged);
 
     protected override async Task OnInitializedAsync()
     {
@@ -169,6 +173,7 @@
 
     public void Dispose()
     {
+        L.LanguageChanged -= OnLanguageChanged;
         _mapController.OnGeoJsonClicked -= OnGeoJsonClicked;
         (_mapInitFetch as IDisposable)?.Dispose();
         (_speciesFetch as IDisposable)?.Dispose();

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Municipalities.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Municipalities.razor
@@ -12,8 +12,9 @@
 @inject ISpeciesHttpClient SpeciesClient
 @inject INativeNavbarManager Navbar
 @inject NavigationManager NavigationManager
+@inject ILocalizer L
 
-<PageTitle>FaunaFinder - Municipios</PageTitle>
+<PageTitle>@L["Muni_PageTitle"]</PageTitle>
 
 @if (Id is not null)
 {
@@ -29,17 +30,19 @@
             <MudPaper Elevation="0" Class="pa-4 pa-md-6 rounded-lg border-solid border mud-border-lines-default mb-4">
                 <MudText Typo="Typo.h5" GutterBottom="true">@detail.Name</MudText>
                 <MudText Typo="Typo.subtitle1" Color="Color.Secondary" Class="mb-2">
-                    @detail.StateName · FIPS @detail.CountyFipsCode
+                    @L["MuniDetail_Subline", detail.StateName, detail.CountyFipsCode]
                 </MudText>
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    Centroid · @detail.CentroidLatitude.ToString("0.0000")″N @Math.Abs(detail.CentroidLongitude).ToString("0.0000")″W
+                    @L["MuniDetail_Centroid",
+                        detail.CentroidLatitude.ToString("0.0000"),
+                        Math.Abs(detail.CentroidLongitude).ToString("0.0000")]
                 </MudText>
             </MudPaper>
 
             <MudPaper Elevation="0" Class="pa-4 pa-md-6 rounded-lg border-solid border mud-border-lines-default">
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-4">
                     <MudIcon Icon="@Icons.Material.Filled.Pets" Color="Color.Primary" />
-                    <MudText Typo="Typo.h6">Species</MudText>
+                    <MudText Typo="Typo.h6">@L["MuniDetail_Species_Heading"]</MudText>
                     <MudSpacer />
                     @if (_detailSpeciesFetch?.Data is { Count: > 0 } list)
                     {
@@ -63,8 +66,8 @@
                 else if (_detailSpeciesFetch.Data is null || _detailSpeciesFetch.Data.Count == 0)
                 {
                     <NuiEmptyState Icon="@Icons.Material.Outlined.Pets"
-                                   Title="No species recorded"
-                                   Description="No species have been associated with this municipio yet." />
+                                   Title="@L[MuniDetailSpeciesEmptyTitle]"
+                                   Description="@L[MuniDetailSpeciesEmptyDescription]" />
                 }
                 else
                 {
@@ -81,8 +84,8 @@
         else
         {
             <NuiEmptyState Icon="@Icons.Material.Outlined.SearchOff"
-                           Title="Municipio not found"
-                           Description="The municipio you're looking for doesn't exist or has been removed." />
+                           Title="@L[MuniDetailNotFoundTitle]"
+                           Description="@L[MuniDetailNotFoundDescription]" />
         }
     </NuiPageLayout>
 }
@@ -101,11 +104,11 @@ else
         <nav class="mm-tabs" role="tablist" aria-label="Municipios view">
             <label for="mm-tab-map" class="mm-tab" role="tab">
                 <MudIcon Icon="@Icons.Material.Filled.Map" Size="Size.Small" />
-                Map
+                @L["Muni_Tab_Map"]
             </label>
             <label for="mm-tab-list" class="mm-tab" role="tab">
                 <MudIcon Icon="@Icons.Material.Filled.List" Size="Size.Small" />
-                List
+                @L["Muni_Tab_List"]
                 <span class="count">@(_municipalities?.Count ?? 0)</span>
             </label>
         </nav>
@@ -130,6 +133,13 @@ else
 @code {
     [Parameter] public Guid? Id { get; set; }
 
+    // Keys held as consts so they can appear in Razor attribute forms
+    // (`Title="@L[SomeKey]"`) without tripping the nested-quote rule.
+    private const string MuniDetailSpeciesEmptyTitle = "MuniDetail_Species_Empty_Title";
+    private const string MuniDetailSpeciesEmptyDescription = "MuniDetail_Species_Empty_Description";
+    private const string MuniDetailNotFoundTitle = "MuniDetail_NotFound_Title";
+    private const string MuniDetailNotFoundDescription = "MuniDetail_NotFound_Description";
+
     private IFetch<SpeciesStatsDto?>? _statsFetch;
     private IReadOnlyList<MunicipalityDtoForList>? _municipalities;
     private IReadOnlyDictionary<Guid, int>? _countsMap;
@@ -143,7 +153,8 @@ else
 
     protected override void OnInitialized()
     {
-        Navbar.SetTitle("Municipios");
+        Navbar.SetTitle(L["Nav_Municipios"]);
+        L.LanguageChanged += OnLanguageChanged;
 
         _statsFetch = new Fetch<SpeciesStatsDto?>(
             SpeciesClient.GetStatsAsync,
@@ -238,8 +249,15 @@ else
         return Task.CompletedTask;
     }
 
+    private void OnLanguageChanged()
+    {
+        if (Id is null) Navbar.SetTitle(L["Nav_Municipios"]);
+        InvokeAsync(StateHasChanged);
+    }
+
     public void Dispose()
     {
+        L.LanguageChanged -= OnLanguageChanged;
         _listCts?.Cancel();
         _listCts?.Dispose();
         (_statsFetch as IDisposable)?.Dispose();

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Species.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Species.razor
@@ -14,8 +14,9 @@
 @inject NavigationManager NavigationManager
 @inject IDialogService Dialogs
 @inject IBrowserViewportService Viewport
+@inject ILocalizer L
 
-<PageTitle>FaunaFinder - Species</PageTitle>
+<PageTitle>@L["Species_PageTitle"]</PageTitle>
 
 @if (Id is not null)
 {
@@ -33,7 +34,7 @@
             <MudPaper Elevation="0" Class="pa-4 pa-md-6 rounded-lg border-solid border mud-border-lines-default mb-4">
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-4">
                     <MudIcon Icon="@Icons.Material.Filled.LocationCity" Color="Color.Primary" />
-                    <MudText Typo="Typo.h6">Municipalities</MudText>
+                    <MudText Typo="Typo.h6">@L["SpeciesDetail_Municipalities_Heading"]</MudText>
                     <MudSpacer />
                     <MudText Typo="Typo.caption" Color="Color.Secondary">
                         @detail.MunicipalityIds.Count
@@ -54,8 +55,8 @@
                 else if ((_municipalitiesFetch.Data?.Count ?? 0) == 0)
                 {
                     <NuiEmptyState Icon="@Icons.Material.Outlined.LocationOff"
-                                   Title="No municipalities"
-                                   Description="This species has no recorded municipality associations yet." />
+                                   Title="@L[SpeciesDetailMunicipalitiesEmptyTitle]"
+                                   Description="@L[SpeciesDetailMunicipalitiesEmptyDescription]" />
                 }
                 else
                 {
@@ -75,8 +76,9 @@
         }
         else
         {
-            <NuiEmptyState Icon="@Icons.Material.Outlined.SearchOff" Title="Species not found"
-                           Description="The species you're looking for doesn't exist or has been removed." />
+            <NuiEmptyState Icon="@Icons.Material.Outlined.SearchOff"
+                           Title="@L[SpeciesDetailNotFoundTitle]"
+                           Description="@L[SpeciesDetailNotFoundDescription]" />
         }
     </NuiPageLayout>
 }
@@ -108,6 +110,13 @@ else
 @code {
     [Parameter] public Guid? Id { get; set; }
 
+    // Keys held as consts so they can appear in Razor attribute forms
+    // (`Title="@L[SomeKey]"`) without tripping the nested-quote rule.
+    private const string SpeciesDetailMunicipalitiesEmptyTitle = "SpeciesDetail_Municipalities_Empty_Title";
+    private const string SpeciesDetailMunicipalitiesEmptyDescription = "SpeciesDetail_Municipalities_Empty_Description";
+    private const string SpeciesDetailNotFoundTitle = "SpeciesDetail_NotFound_Title";
+    private const string SpeciesDetailNotFoundDescription = "SpeciesDetail_NotFound_Description";
+
     private IFetch<SpeciesDtoForDetail?>? _detailFetch;
     private IFetch<IReadOnlyList<MunicipalityDtoForList>>? _municipalitiesFetch;
     private IFetch<SpeciesStatsDto?>? _statsFetch;
@@ -121,7 +130,8 @@ else
 
     protected override void OnInitialized()
     {
-        Navbar.SetTitle("Species");
+        Navbar.SetTitle(L["Nav_Species"]);
+        L.LanguageChanged += OnLanguageChanged;
 
         _statsFetch = new Fetch<SpeciesStatsDto?>(
             SpeciesHttpClient.GetStatsAsync,
@@ -255,8 +265,16 @@ else
     private void NavigateToMunicipality(Guid municipalityId) =>
         NavigationManager.NavigateTo($"/municipalities/{municipalityId}");
 
+    private void OnLanguageChanged()
+    {
+        // Nav title needs refreshing since we seeded it from L in OnInitialized.
+        Navbar.SetTitle(Id is null ? L["Nav_Species"] : Navbar.State.Title ?? L["Nav_Species"]);
+        InvokeAsync(StateHasChanged);
+    }
+
     public void Dispose()
     {
+        L.LanguageChanged -= OnLanguageChanged;
         (_detailFetch as IDisposable)?.Dispose();
         (_municipalitiesFetch as IDisposable)?.Dispose();
         (_statsFetch as IDisposable)?.Dispose();

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Program.cs
@@ -1,6 +1,8 @@
+using EcoData.Common.i18n;
 using EcoData.Locations.Application.Client;
 using EcoData.NativeUi;
 using EcoData.Wildlife.Application.Client;
+using FaunaFinder.Client.Localization;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 
@@ -13,5 +15,10 @@ builder.Services.AddWildlifeClient(baseAddress);
 
 builder.Services.AddNativeUi();
 builder.Services.AddMudServices();
+
+// Localization — single Localizer instance fed from FaunaFinderStrings.
+builder.Services.AddSingleton<ILocalizer>(_ => new Localizer(
+    FaunaFinderStrings.Languages,
+    FaunaFinderStrings.Translations));
 
 await builder.Build().RunAsync();

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/_Imports.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/_Imports.razor
@@ -16,6 +16,7 @@
 @using FaunaFinder.Client.Components.Map
 @using FaunaFinder.Client.Components.Shared
 @using FaunaFinder.Client.Localization
+@using EcoData.Common.i18n
 @using EcoData.NativeUi
 @using EcoData.NativeUi.Components.EmptyState
 @using EcoData.NativeUi.Components.IconBox

--- a/src/Features/Common/EcoData.Common.i18n/ILocalizer.cs
+++ b/src/Features/Common/EcoData.Common.i18n/ILocalizer.cs
@@ -35,4 +35,10 @@ public interface ILocalizer
     /// Gets all available languages.
     /// </summary>
     IReadOnlyList<ILanguage> GetAvailableLanguages();
+
+    /// <summary>
+    /// Fired whenever <see cref="SetLanguage"/> actually changes the locale.
+    /// Components subscribe to re-render their localized content.
+    /// </summary>
+    event Action LanguageChanged;
 }

--- a/src/Features/Common/EcoData.Common.i18n/Language.cs
+++ b/src/Features/Common/EcoData.Common.i18n/Language.cs
@@ -1,0 +1,6 @@
+namespace EcoData.Common.i18n;
+
+/// <summary>
+/// Simple value-type implementation of <see cref="ILanguage"/>.
+/// </summary>
+public sealed record Language(string Code, string Name, bool IsDefault = false) : ILanguage;

--- a/src/Features/Common/EcoData.Common.i18n/Localizer.cs
+++ b/src/Features/Common/EcoData.Common.i18n/Localizer.cs
@@ -1,0 +1,90 @@
+using System.Globalization;
+
+namespace EcoData.Common.i18n;
+
+/// <summary>
+/// Concrete in-memory <see cref="ILocalizer"/>. Translations are registered
+/// at construction time; missing keys return the key itself so developers
+/// can spot gaps without the UI crashing.
+/// </summary>
+public sealed class Localizer : ILocalizer
+{
+    private readonly IReadOnlyList<ILanguage> _languages;
+    private readonly Dictionary<string, Dictionary<string, string>> _byLanguage;
+    private readonly string _defaultLanguage;
+
+    public string CurrentLanguage { get; private set; }
+
+    /// <summary>
+    /// Fired whenever <see cref="SetLanguage"/> actually changes the locale.
+    /// Components subscribe to this to re-render localized content.
+    /// </summary>
+    public event Action? LanguageChanged;
+
+    public Localizer(
+        IReadOnlyList<ILanguage> languages,
+        IReadOnlyList<ITranslation> translations)
+    {
+        if (languages.Count == 0)
+        {
+            throw new ArgumentException("At least one language must be provided.", nameof(languages));
+        }
+
+        _languages = languages;
+        _defaultLanguage = languages.FirstOrDefault(l => l.IsDefault)?.Code ?? languages[0].Code;
+        CurrentLanguage = _defaultLanguage;
+
+        _byLanguage = languages.ToDictionary(
+            l => l.Code,
+            _ => new Dictionary<string, string>(StringComparer.Ordinal),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var t in translations)
+        {
+            if (_byLanguage.TryGetValue(t.LanguageCode, out var bucket))
+            {
+                bucket[t.Key] = t.Value;
+            }
+        }
+    }
+
+    public string this[string key] => Resolve(key);
+
+    public string this[string key, params object[] args] =>
+        string.Format(CultureInfo.CurrentCulture, Resolve(key), args);
+
+    public void SetLanguage(string languageCode)
+    {
+        if (string.Equals(languageCode, CurrentLanguage, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+        if (!_byLanguage.ContainsKey(languageCode))
+        {
+            return;
+        }
+        CurrentLanguage = languageCode;
+        LanguageChanged?.Invoke();
+    }
+
+    public IReadOnlyList<ILanguage> GetAvailableLanguages() => _languages;
+
+    private string Resolve(string key)
+    {
+        if (_byLanguage.TryGetValue(CurrentLanguage, out var bucket)
+            && bucket.TryGetValue(key, out var value))
+        {
+            return value;
+        }
+
+        // Fall back to the default language before surfacing the raw key.
+        if (!string.Equals(CurrentLanguage, _defaultLanguage, StringComparison.OrdinalIgnoreCase)
+            && _byLanguage.TryGetValue(_defaultLanguage, out var defaultBucket)
+            && defaultBucket.TryGetValue(key, out var defaultValue))
+        {
+            return defaultValue;
+        }
+
+        return key;
+    }
+}

--- a/src/Features/Common/EcoData.Common.i18n/Translation.cs
+++ b/src/Features/Common/EcoData.Common.i18n/Translation.cs
@@ -1,0 +1,6 @@
+namespace EcoData.Common.i18n;
+
+/// <summary>
+/// Simple value-type implementation of <see cref="ITranslation"/>.
+/// </summary>
+public sealed record Translation(string LanguageCode, string Key, string Value) : ITranslation;


### PR DESCRIPTION
Implements the long-dormant `ILocalizer` contract in `EcoData.Common.i18n` (you scaffolded the interfaces but left the concrete for later) and extracts every user-visible string in FaunaFinder into it. The EN/ES pill now swaps the UI live.

## What's in here

### `EcoData.Common.i18n`
- **`Localizer : ILocalizer`** — dictionary-backed, falls back to the default language before surfacing the raw key, raises a `LanguageChanged` event so components can re-render.
- **`Language` + `Translation`** records filling the scaffolded interfaces.
- **`ILocalizer`** contract gains an `event Action LanguageChanged` so consumers injecting the interface can subscribe.

### `FaunaFinder.Client`
- **`Localization/FaunaFinderStrings.cs`** — ~170 EN + ES pairs, keys shaped `Feature_Section_Purpose`. Covers nav, hero, stats, toolbar, filter dialog, cards, featured, empty states, categories, municipios, map panel, and relative-time formatters.
- **`Localization/LocalizedComponentBase.cs`** — `ComponentBase` that subscribes to `L.LanguageChanged` and re-renders. Components use `@inherits LocalizedComponentBase` and get `@L["key"]` working for free.
- **`Program.cs`** registers `Localizer` as a singleton (so every component observes the same `LanguageChanged` signal).
- **`MainLayout`** wires the EN/ES pill to `L.SetLanguage(code)`. It also keeps cascading `LocaleContext` (for DB `LocaleValue[]` resolution — species common names, category names) and flips the cascade in sync when the language changes.
- **Every page + component with visible strings** now routes through `L`:
  - `Pages/`: Species, Municipalities, Categories, Home
  - `Components/Species/`: EditorialHero, StatsRow, FeaturedRow, Card, Grid, Toolbar, FilterDialog, Hero (detail)
  - `Components/Municipalities/`: EditorialHero, StatsRow, List, Map, DetailCard, legacy MunicipalityCard
  - `Components/Map/MapSpeciesPanel`
- **`TaxonIcons.GetLabel` → `GetLabelKey`** — returns a translation key, callers resolve via `L`. Labels translate with the rest instead of sitting as hardcoded English.
- **`SpeciesCard.FormatLastSeen`** uses `Time_MinutesAgo` / `Time_HoursAgo` / `Time_DaysAgo` / `Time_MonthsAgo` / `Time_YearsAgo`. "3d ago" → "hace 3 d".

## Unchanged on purpose
- `LocaleContext` keeps its role resolving `LocaleValue[]` lists from the database. It runs alongside `ILocalizer` — same EN/ES state, orthogonal concern (DB content vs. UI chrome). No duplication.
- Brand names (FaunaFinder, Puerto Rico) stay as literals in markup — they don't translate.

## Follow-ups worth keeping in mind
- Category `Name` (DB field) is still a `LocaleValue[]`, resolved via `Locale.Resolve(category.Name)` — needs Spanish values on the data side where they're missing.
- No persistence of language choice across reloads. Easiest add: stash the selected code in `localStorage` and seed the `Localizer` in `Program.cs`.
- If EcoPortal wants i18n, it now has everything it needs — register a `Localizer` with its own `Strings` dictionary.

## Test plan
- [ ] Click ES → every visible string swaps to Spanish across every page without needing a reload.
- [ ] Click EN → everything reverts.
- [ ] Species toolbar chips, filter dialog sections/buttons, IUCN labels, taxa labels, "View details" button on municipios list, detail card, relative-time card footer all translate.
- [ ] App bar title stays in sync (nav labels, page titles in the mobile top bar).
- [ ] Species detail & municipio detail headings + empty states translate.
- [ ] Home map "Loading map…" translates mid-fetch (toggle ES right as the map loads).