### PR TITLE
feat(sensors): introduce Phenomenon model so the system understands reading semantics

### DIFF
--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/PhenomenonEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/PhenomenonEndpoints.cs
@@ -1,0 +1,45 @@
+using EcoData.Sensors.Contracts.Dtos;
+using EcoData.Sensors.DataAccess.Interfaces;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+
+namespace EcoData.Sensors.Api.Endpoints;
+
+public static class PhenomenonEndpoints
+{
+    public static IEndpointRouteBuilder MapPhenomenonEndpoints(this IEndpointRouteBuilder app)
+    {
+        var phenomenaGroup = app.MapGroup("/sensors/phenomena").WithTags("Phenomena");
+
+        phenomenaGroup
+            .MapGet(
+                "/",
+                (string? capability, IPhenomenonRepository repository, CancellationToken ct) =>
+                    string.IsNullOrWhiteSpace(capability)
+                        ? repository.GetAllAsync(ct)
+                        : repository.GetByCapabilityAsync(capability, ct)
+            )
+            .WithName("GetPhenomena");
+
+        phenomenaGroup
+            .MapGet(
+                "/{id:guid}",
+                async Task<Results<Ok<PhenomenonDtoForDetail>, NotFound>> (
+                    Guid id,
+                    IPhenomenonRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var phenomenon = await repository.GetByIdAsync(id, ct);
+                    return phenomenon is null
+                        ? TypedResults.NotFound()
+                        : TypedResults.Ok(phenomenon);
+                }
+            )
+            .WithName("GetPhenomenonById");
+
+        return app;
+    }
+}

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/ReferenceDataEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/ReferenceDataEndpoints.cs
@@ -68,6 +68,38 @@ public static class ReferenceDataEndpoints
             )
             .WithName("GetParameterById");
 
+        var phenomenaGroup = app.MapGroup("/sensors/phenomena").WithTags("Phenomena");
+
+        phenomenaGroup
+            .MapGet(
+                "/",
+                async (string? capability, IPhenomenonRepository repository, CancellationToken ct) =>
+                {
+                    var phenomena = string.IsNullOrWhiteSpace(capability)
+                        ? await repository.GetAllAsync(ct)
+                        : await repository.GetByCapabilityAsync(capability, ct);
+                    return TypedResults.Ok(phenomena);
+                }
+            )
+            .WithName("GetPhenomena");
+
+        phenomenaGroup
+            .MapGet(
+                "/{id:guid}",
+                async Task<Results<Ok<PhenomenonDtoForDetail>, NotFound>> (
+                    Guid id,
+                    IPhenomenonRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var phenomenon = await repository.GetByIdAsync(id, ct);
+                    return phenomenon is null
+                        ? TypedResults.NotFound()
+                        : TypedResults.Ok(phenomenon);
+                }
+            )
+            .WithName("GetPhenomenonById");
+
         return app;
     }
 }

--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/ReferenceDataEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/ReferenceDataEndpoints.cs
@@ -68,38 +68,6 @@ public static class ReferenceDataEndpoints
             )
             .WithName("GetParameterById");
 
-        var phenomenaGroup = app.MapGroup("/sensors/phenomena").WithTags("Phenomena");
-
-        phenomenaGroup
-            .MapGet(
-                "/",
-                async (string? capability, IPhenomenonRepository repository, CancellationToken ct) =>
-                {
-                    var phenomena = string.IsNullOrWhiteSpace(capability)
-                        ? await repository.GetAllAsync(ct)
-                        : await repository.GetByCapabilityAsync(capability, ct);
-                    return TypedResults.Ok(phenomena);
-                }
-            )
-            .WithName("GetPhenomena");
-
-        phenomenaGroup
-            .MapGet(
-                "/{id:guid}",
-                async Task<Results<Ok<PhenomenonDtoForDetail>, NotFound>> (
-                    Guid id,
-                    IPhenomenonRepository repository,
-                    CancellationToken ct
-                ) =>
-                {
-                    var phenomenon = await repository.GetByIdAsync(id, ct);
-                    return phenomenon is null
-                        ? TypedResults.NotFound()
-                        : TypedResults.Ok(phenomenon);
-                }
-            )
-            .WithName("GetPhenomenonById");
-
         return app;
     }
 }

--- a/src/Features/Sensors/EcoData.Sensors.Api/SensorsApiExtensions.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/SensorsApiExtensions.cs
@@ -13,6 +13,7 @@ public static class SensorsApiExtensions
         app.MapSensorHealthConfigEndpoints();
         app.MapSensorAlertEndpoints();
         app.MapReferenceDataEndpoints();
+        app.MapPhenomenonEndpoints();
         app.MapGeoTestEndpoints();
         app.MapUserSubscriptionEndpoints();
         app.MapUserNotificationEndpoints();

--- a/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/ParameterDto.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/ParameterDto.cs
@@ -2,19 +2,33 @@ namespace EcoData.Sensors.Contracts.Dtos;
 
 public sealed record ParameterDtoForList(
     Guid Id,
+    Guid? SourceId,
     string Code,
     string Name,
     string DefaultUnit,
-    Guid SensorTypeId,
-    string SensorTypeName
+    Guid? SensorTypeId,
+    string? SensorTypeName,
+    Guid PhenomenonId,
+    string PhenomenonCode,
+    string SourceUnit,
+    double UnitFactor,
+    double UnitOffset,
+    string ValueShape
 );
 
 public sealed record ParameterDtoForDetail(
     Guid Id,
+    Guid? SourceId,
     string Code,
     string Name,
     string DefaultUnit,
-    Guid SensorTypeId,
-    string SensorTypeName,
+    Guid? SensorTypeId,
+    string? SensorTypeName,
+    Guid PhenomenonId,
+    string PhenomenonCode,
+    string SourceUnit,
+    double UnitFactor,
+    double UnitOffset,
+    string ValueShape,
     DateTimeOffset CreatedAt
 );

--- a/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/PhenomenonDto.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/PhenomenonDto.cs
@@ -1,0 +1,23 @@
+namespace EcoData.Sensors.Contracts.Dtos;
+
+public sealed record PhenomenonDtoForList(
+    Guid Id,
+    string Code,
+    string Name,
+    string? Description,
+    string CanonicalUnit,
+    string DefaultValueShape,
+    IReadOnlyList<string> Capabilities
+);
+
+public sealed record PhenomenonDtoForDetail(
+    Guid Id,
+    string Code,
+    string Name,
+    string? Description,
+    string CanonicalUnit,
+    string DefaultValueShape,
+    IReadOnlyList<string> Capabilities,
+    DateTimeOffset CreatedAt,
+    int ParameterCount
+);

--- a/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/ReadingDto.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Contracts/Dtos/ReadingDto.cs
@@ -27,5 +27,8 @@ public sealed record ReadingDtoForCreate(
     string? Description,
     double Value,
     string Unit,
-    DateTimeOffset RecordedAt
+    DateTimeOffset RecordedAt,
+    Guid? PhenomenonId = null,
+    Guid? ParameterId = null,
+    double? CanonicalValue = null
 );

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/DependencyInjection.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using EcoData.Sensors.DataAccess.Interfaces;
 using EcoData.Sensors.DataAccess.Repositories;
+using EcoData.Sensors.DataAccess.Resolvers;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EcoData.Sensors.DataAccess;
@@ -11,11 +12,13 @@ public static class DependencyInjection
         services.AddScoped<ISensorRepository, SensorRepository>();
         services.AddScoped<ISensorTypeRepository, SensorTypeRepository>();
         services.AddScoped<IParameterRepository, ParameterRepository>();
+        services.AddScoped<IPhenomenonRepository, PhenomenonRepository>();
         services.AddScoped<ISensorHealthRepository, SensorHealthRepository>();
         services.AddScoped<IReadingRepository, ReadingRepository>();
         services.AddScoped<IIngestionLogRepository, IngestionLogRepository>();
         services.AddScoped<IUserSensorSubscriptionRepository, UserSensorSubscriptionRepository>();
         services.AddScoped<IUserNotificationRepository, UserNotificationRepository>();
+        services.AddScoped<ParameterResolver>();
 
         return services;
     }

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Interfaces/IPhenomenonRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Interfaces/IPhenomenonRepository.cs
@@ -1,0 +1,25 @@
+using EcoData.Sensors.Contracts.Dtos;
+
+namespace EcoData.Sensors.DataAccess.Interfaces;
+
+public interface IPhenomenonRepository
+{
+    Task<IReadOnlyList<PhenomenonDtoForList>> GetAllAsync(
+        CancellationToken cancellationToken = default
+    );
+
+    Task<IReadOnlyList<PhenomenonDtoForList>> GetByCapabilityAsync(
+        string capability,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<PhenomenonDtoForDetail?> GetByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<PhenomenonDtoForDetail?> GetByCodeAsync(
+        string code,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Interfaces/IPhenomenonRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Interfaces/IPhenomenonRepository.cs
@@ -4,11 +4,11 @@ namespace EcoData.Sensors.DataAccess.Interfaces;
 
 public interface IPhenomenonRepository
 {
-    Task<IReadOnlyList<PhenomenonDtoForList>> GetAllAsync(
+    IAsyncEnumerable<PhenomenonDtoForList> GetAllAsync(
         CancellationToken cancellationToken = default
     );
 
-    Task<IReadOnlyList<PhenomenonDtoForList>> GetByCapabilityAsync(
+    IAsyncEnumerable<PhenomenonDtoForList> GetByCapabilityAsync(
         string capability,
         CancellationToken cancellationToken = default
     );

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/PhenomenonRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/PhenomenonRepository.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using EcoData.Sensors.Contracts.Dtos;
 using EcoData.Sensors.Database;
 using EcoData.Sensors.DataAccess.Interfaces;
@@ -8,44 +9,58 @@ namespace EcoData.Sensors.DataAccess.Repositories;
 public sealed class PhenomenonRepository(IDbContextFactory<SensorsDbContext> contextFactory)
     : IPhenomenonRepository
 {
-    public async Task<IReadOnlyList<PhenomenonDtoForList>> GetAllAsync(
-        CancellationToken cancellationToken = default
+    public async IAsyncEnumerable<PhenomenonDtoForList> GetAllAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
-        return await context
-            .Phenomena.OrderBy(p => p.Name)
-            .Select(p => new PhenomenonDtoForList(
-                p.Id,
-                p.Code,
-                p.Name,
-                p.Description,
-                p.CanonicalUnit,
-                p.DefaultValueShape.ToString(),
-                p.Capabilities
-            ))
-            .ToListAsync(cancellationToken);
+
+        await foreach (
+            var phenomenon in context
+                .Phenomena.OrderBy(p => p.Name)
+                .Select(p => new PhenomenonDtoForList(
+                    p.Id,
+                    p.Code,
+                    p.Name,
+                    p.Description,
+                    p.CanonicalUnit,
+                    p.DefaultValueShape.ToString(),
+                    p.Capabilities
+                ))
+                .AsAsyncEnumerable()
+                .WithCancellation(cancellationToken)
+        )
+        {
+            yield return phenomenon;
+        }
     }
 
-    public async Task<IReadOnlyList<PhenomenonDtoForList>> GetByCapabilityAsync(
+    public async IAsyncEnumerable<PhenomenonDtoForList> GetByCapabilityAsync(
         string capability,
-        CancellationToken cancellationToken = default
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
-        return await context
-            .Phenomena.Where(p => p.Capabilities.Contains(capability))
-            .OrderBy(p => p.Name)
-            .Select(p => new PhenomenonDtoForList(
-                p.Id,
-                p.Code,
-                p.Name,
-                p.Description,
-                p.CanonicalUnit,
-                p.DefaultValueShape.ToString(),
-                p.Capabilities
-            ))
-            .ToListAsync(cancellationToken);
+
+        await foreach (
+            var phenomenon in context
+                .Phenomena.Where(p => p.Capabilities.Contains(capability))
+                .OrderBy(p => p.Name)
+                .Select(p => new PhenomenonDtoForList(
+                    p.Id,
+                    p.Code,
+                    p.Name,
+                    p.Description,
+                    p.CanonicalUnit,
+                    p.DefaultValueShape.ToString(),
+                    p.Capabilities
+                ))
+                .AsAsyncEnumerable()
+                .WithCancellation(cancellationToken)
+        )
+        {
+            yield return phenomenon;
+        }
     }
 
     public async Task<PhenomenonDtoForDetail?> GetByIdAsync(

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/PhenomenonRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/PhenomenonRepository.cs
@@ -1,0 +1,94 @@
+using EcoData.Sensors.Contracts.Dtos;
+using EcoData.Sensors.Database;
+using EcoData.Sensors.DataAccess.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace EcoData.Sensors.DataAccess.Repositories;
+
+public sealed class PhenomenonRepository(IDbContextFactory<SensorsDbContext> contextFactory)
+    : IPhenomenonRepository
+{
+    public async Task<IReadOnlyList<PhenomenonDtoForList>> GetAllAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        return await context
+            .Phenomena.OrderBy(p => p.Name)
+            .Select(p => new PhenomenonDtoForList(
+                p.Id,
+                p.Code,
+                p.Name,
+                p.Description,
+                p.CanonicalUnit,
+                p.DefaultValueShape.ToString(),
+                p.Capabilities
+            ))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<PhenomenonDtoForList>> GetByCapabilityAsync(
+        string capability,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        return await context
+            .Phenomena.Where(p => p.Capabilities.Contains(capability))
+            .OrderBy(p => p.Name)
+            .Select(p => new PhenomenonDtoForList(
+                p.Id,
+                p.Code,
+                p.Name,
+                p.Description,
+                p.CanonicalUnit,
+                p.DefaultValueShape.ToString(),
+                p.Capabilities
+            ))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<PhenomenonDtoForDetail?> GetByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        return await context
+            .Phenomena.Where(p => p.Id == id)
+            .Select(p => new PhenomenonDtoForDetail(
+                p.Id,
+                p.Code,
+                p.Name,
+                p.Description,
+                p.CanonicalUnit,
+                p.DefaultValueShape.ToString(),
+                p.Capabilities,
+                p.CreatedAt,
+                p.Parameters.Count
+            ))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<PhenomenonDtoForDetail?> GetByCodeAsync(
+        string code,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        return await context
+            .Phenomena.Where(p => p.Code == code)
+            .Select(p => new PhenomenonDtoForDetail(
+                p.Id,
+                p.Code,
+                p.Name,
+                p.Description,
+                p.CanonicalUnit,
+                p.DefaultValueShape.ToString(),
+                p.Capabilities,
+                p.CreatedAt,
+                p.Parameters.Count
+            ))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/ReadingRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/ReadingRepository.cs
@@ -166,6 +166,9 @@ public sealed class ReadingRepository(IDbContextFactory<SensorsDbContext> contex
             Unit = dto.Unit,
             RecordedAt = dto.RecordedAt.ToUniversalTime(),
             IngestedAt = now,
+            PhenomenonId = dto.PhenomenonId,
+            ParameterId = dto.ParameterId,
+            CanonicalValue = dto.CanonicalValue,
         });
 
         context.Readings.AddRange(entities);

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/SensorTypeRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/SensorTypeRepository.cs
@@ -36,11 +36,18 @@ public sealed class SensorTypeRepository(IDbContextFactory<SensorsDbContext> con
                 st.CreatedAt,
                 st.Parameters.Select(p => new ParameterDtoForList(
                     p.Id,
+                    p.SourceId,
                     p.Code,
                     p.Name,
                     p.DefaultUnit,
                     p.SensorTypeId,
-                    st.Name
+                    st.Name,
+                    p.PhenomenonId,
+                    p.Phenomenon!.Code,
+                    p.SourceUnit,
+                    p.UnitFactor,
+                    p.UnitOffset,
+                    p.ValueShape.ToString()
                 )).ToList()
             ))
             .FirstOrDefaultAsync(cancellationToken);
@@ -59,11 +66,18 @@ public sealed class SensorTypeRepository(IDbContextFactory<SensorsDbContext> con
                 st.CreatedAt,
                 st.Parameters.Select(p => new ParameterDtoForList(
                     p.Id,
+                    p.SourceId,
                     p.Code,
                     p.Name,
                     p.DefaultUnit,
                     p.SensorTypeId,
-                    st.Name
+                    st.Name,
+                    p.PhenomenonId,
+                    p.Phenomenon!.Code,
+                    p.SourceUnit,
+                    p.UnitFactor,
+                    p.UnitOffset,
+                    p.ValueShape.ToString()
                 )).ToList()
             ))
             .FirstOrDefaultAsync(cancellationToken);
@@ -80,11 +94,18 @@ public sealed class ParameterRepository(IDbContextFactory<SensorsDbContext> cont
             .OrderBy(p => p.Name)
             .Select(p => new ParameterDtoForList(
                 p.Id,
+                p.SourceId,
                 p.Code,
                 p.Name,
                 p.DefaultUnit,
                 p.SensorTypeId,
-                p.SensorType!.Name
+                p.SensorType != null ? p.SensorType.Name : null,
+                p.PhenomenonId,
+                p.Phenomenon!.Code,
+                p.SourceUnit,
+                p.UnitFactor,
+                p.UnitOffset,
+                p.ValueShape.ToString()
             ))
             .ToListAsync(cancellationToken);
     }
@@ -99,11 +120,18 @@ public sealed class ParameterRepository(IDbContextFactory<SensorsDbContext> cont
             .OrderBy(p => p.Name)
             .Select(p => new ParameterDtoForList(
                 p.Id,
+                p.SourceId,
                 p.Code,
                 p.Name,
                 p.DefaultUnit,
                 p.SensorTypeId,
-                p.SensorType!.Name
+                p.SensorType != null ? p.SensorType.Name : null,
+                p.PhenomenonId,
+                p.Phenomenon!.Code,
+                p.SourceUnit,
+                p.UnitFactor,
+                p.UnitOffset,
+                p.ValueShape.ToString()
             ))
             .ToListAsync(cancellationToken);
     }
@@ -115,11 +143,18 @@ public sealed class ParameterRepository(IDbContextFactory<SensorsDbContext> cont
             .Where(p => p.Id == id)
             .Select(p => new ParameterDtoForDetail(
                 p.Id,
+                p.SourceId,
                 p.Code,
                 p.Name,
                 p.DefaultUnit,
                 p.SensorTypeId,
-                p.SensorType!.Name,
+                p.SensorType != null ? p.SensorType.Name : null,
+                p.PhenomenonId,
+                p.Phenomenon!.Code,
+                p.SourceUnit,
+                p.UnitFactor,
+                p.UnitOffset,
+                p.ValueShape.ToString(),
                 p.CreatedAt
             ))
             .FirstOrDefaultAsync(cancellationToken);
@@ -132,11 +167,18 @@ public sealed class ParameterRepository(IDbContextFactory<SensorsDbContext> cont
             .Where(p => p.Code == code)
             .Select(p => new ParameterDtoForDetail(
                 p.Id,
+                p.SourceId,
                 p.Code,
                 p.Name,
                 p.DefaultUnit,
                 p.SensorTypeId,
-                p.SensorType!.Name,
+                p.SensorType != null ? p.SensorType.Name : null,
+                p.PhenomenonId,
+                p.Phenomenon!.Code,
+                p.SourceUnit,
+                p.UnitFactor,
+                p.UnitOffset,
+                p.ValueShape.ToString(),
                 p.CreatedAt
             ))
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Resolvers/ParameterResolver.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Resolvers/ParameterResolver.cs
@@ -14,24 +14,10 @@ public sealed class ParameterResolver(IDbContextFactory<SensorsDbContext> contex
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 
         var parameters = await context
-            .Parameters.AsNoTracking()
-            .Where(p => p.SourceId == sourceId || p.SourceId == null)
+            .Parameters.Where(p => p.SourceId == sourceId || p.SourceId == null)
             .ToListAsync(cancellationToken);
 
         return new ParameterLookup(sourceId, parameters);
-    }
-
-    public async Task<ResolvedReading> ResolveAsync(
-        Guid? sourceId,
-        string rawCode,
-        string rawUnit,
-        double rawValue,
-        DateTimeOffset recordedAt,
-        CancellationToken cancellationToken = default
-    )
-    {
-        var lookup = await LoadLookupAsync(sourceId, cancellationToken);
-        return lookup.Resolve(rawCode, rawUnit, rawValue, recordedAt);
     }
 }
 

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Resolvers/ParameterResolver.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Resolvers/ParameterResolver.cs
@@ -1,0 +1,107 @@
+using EcoData.Sensors.Database;
+using EcoData.Sensors.Database.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace EcoData.Sensors.DataAccess.Resolvers;
+
+public sealed class ParameterResolver(IDbContextFactory<SensorsDbContext> contextFactory)
+{
+    public async Task<ParameterLookup> LoadLookupAsync(
+        Guid? sourceId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var parameters = await context
+            .Parameters.AsNoTracking()
+            .Where(p => p.SourceId == sourceId || p.SourceId == null)
+            .ToListAsync(cancellationToken);
+
+        return new ParameterLookup(sourceId, parameters);
+    }
+
+    public async Task<ResolvedReading> ResolveAsync(
+        Guid? sourceId,
+        string rawCode,
+        string rawUnit,
+        double rawValue,
+        DateTimeOffset recordedAt,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var lookup = await LoadLookupAsync(sourceId, cancellationToken);
+        return lookup.Resolve(rawCode, rawUnit, rawValue, recordedAt);
+    }
+}
+
+public sealed class ParameterLookup
+{
+    private readonly Dictionary<string, Parameter> _bySourceCode;
+    private readonly Dictionary<string, Parameter> _byGlobalCode;
+
+    public ParameterLookup(Guid? sourceId, IReadOnlyList<Parameter> parameters)
+    {
+        SourceId = sourceId;
+        _bySourceCode = parameters
+            .Where(p => p.SourceId == sourceId)
+            .ToDictionary(p => p.Code, StringComparer.OrdinalIgnoreCase);
+        _byGlobalCode = parameters
+            .Where(p => p.SourceId == null)
+            .ToDictionary(p => p.Code, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public Guid? SourceId { get; }
+
+    public ResolvedReading Resolve(
+        string rawCode,
+        string rawUnit,
+        double rawValue,
+        DateTimeOffset recordedAt
+    )
+    {
+        if (
+            !_bySourceCode.TryGetValue(rawCode, out var parameter)
+            && !_byGlobalCode.TryGetValue(rawCode, out parameter)
+        )
+        {
+            return ResolvedReading.Unresolved(rawCode, rawUnit, rawValue, recordedAt);
+        }
+
+        var canonical = parameter.ValueShape switch
+        {
+            ValueShape.CumulativeSinceReset => throw new NotSupportedException(
+                "CumulativeSinceReset values require stateful resolution; not implemented yet."
+            ),
+            _ => rawValue * parameter.UnitFactor + parameter.UnitOffset,
+        };
+
+        return new ResolvedReading(
+            PhenomenonId: parameter.PhenomenonId,
+            ParameterId: parameter.Id,
+            CanonicalValue: canonical,
+            RawCode: rawCode,
+            RawUnit: rawUnit,
+            RawValue: rawValue,
+            RecordedAt: recordedAt
+        );
+    }
+}
+
+public readonly record struct ResolvedReading(
+    Guid? PhenomenonId,
+    Guid? ParameterId,
+    double? CanonicalValue,
+    string RawCode,
+    string RawUnit,
+    double RawValue,
+    DateTimeOffset RecordedAt
+)
+{
+    public static ResolvedReading Unresolved(
+        string rawCode,
+        string rawUnit,
+        double rawValue,
+        DateTimeOffset recordedAt
+    ) => new(null, null, null, rawCode, rawUnit, rawValue, recordedAt);
+}

--- a/src/Features/Sensors/EcoData.Sensors.Database/Migrations/20260425165019_AddPhenomenonModel.Designer.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/Migrations/20260425165019_AddPhenomenonModel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EcoData.Sensors.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EcoData.Sensors.Database.Migrations
 {
     [DbContext(typeof(SensorsDbContext))]
-    partial class SensorsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425165019_AddPhenomenonModel")]
+    partial class AddPhenomenonModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Features/Sensors/EcoData.Sensors.Database/Migrations/20260425165019_AddPhenomenonModel.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/Migrations/20260425165019_AddPhenomenonModel.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoData.Sensors.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPhenomenonModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_parameters_code",
+                table: "parameters");
+
+            migrationBuilder.AddColumn<double>(
+                name: "canonical_value",
+                table: "readings",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "parameter_id",
+                table: "readings",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "phenomenon_id",
+                table: "readings",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "sensor_type_id",
+                table: "parameters",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "phenomenon_id",
+                table: "parameters",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "source_id",
+                table: "parameters",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "source_unit",
+                table: "parameters",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<double>(
+                name: "unit_factor",
+                table: "parameters",
+                type: "double precision",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<double>(
+                name: "unit_offset",
+                table: "parameters",
+                type: "double precision",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "value_shape",
+                table: "parameters",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateTable(
+                name: "phenomena",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    code = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    canonical_unit = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    default_value_shape = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    capabilities = table.Column<string[]>(type: "text[]", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_phenomena", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_readings_parameter_id",
+                table: "readings",
+                column: "parameter_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_readings_phenomenon_id",
+                table: "readings",
+                column: "phenomenon_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_readings_sensor_id_phenomenon_id_recorded_at",
+                table: "readings",
+                columns: new[] { "sensor_id", "phenomenon_id", "recorded_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_parameters_phenomenon_id",
+                table: "parameters",
+                column: "phenomenon_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_parameters_source_id_code",
+                table: "parameters",
+                columns: new[] { "source_id", "code" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_phenomena_code",
+                table: "phenomena",
+                column: "code",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_parameters_phenomena_phenomenon_id",
+                table: "parameters",
+                column: "phenomenon_id",
+                principalTable: "phenomena",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_readings_parameters_parameter_id",
+                table: "readings",
+                column: "parameter_id",
+                principalTable: "parameters",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_readings_phenomena_phenomenon_id",
+                table: "readings",
+                column: "phenomenon_id",
+                principalTable: "phenomena",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_parameters_phenomena_phenomenon_id",
+                table: "parameters");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_readings_parameters_parameter_id",
+                table: "readings");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_readings_phenomena_phenomenon_id",
+                table: "readings");
+
+            migrationBuilder.DropTable(
+                name: "phenomena");
+
+            migrationBuilder.DropIndex(
+                name: "ix_readings_parameter_id",
+                table: "readings");
+
+            migrationBuilder.DropIndex(
+                name: "ix_readings_phenomenon_id",
+                table: "readings");
+
+            migrationBuilder.DropIndex(
+                name: "ix_readings_sensor_id_phenomenon_id_recorded_at",
+                table: "readings");
+
+            migrationBuilder.DropIndex(
+                name: "ix_parameters_phenomenon_id",
+                table: "parameters");
+
+            migrationBuilder.DropIndex(
+                name: "ix_parameters_source_id_code",
+                table: "parameters");
+
+            migrationBuilder.DropColumn(
+                name: "canonical_value",
+                table: "readings");
+
+            migrationBuilder.DropColumn(
+                name: "parameter_id",
+                table: "readings");
+
+            migrationBuilder.DropColumn(
+                name: "phenomenon_id",
+                table: "readings");
+
+            migrationBuilder.DropColumn(
+                name: "phenomenon_id",
+                table: "parameters");
+
+            migrationBuilder.DropColumn(
+                name: "source_id",
+                table: "parameters");
+
+            migrationBuilder.DropColumn(
+                name: "source_unit",
+                table: "parameters");
+
+            migrationBuilder.DropColumn(
+                name: "unit_factor",
+                table: "parameters");
+
+            migrationBuilder.DropColumn(
+                name: "unit_offset",
+                table: "parameters");
+
+            migrationBuilder.DropColumn(
+                name: "value_shape",
+                table: "parameters");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "sensor_type_id",
+                table: "parameters",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_parameters_code",
+                table: "parameters",
+                column: "code",
+                unique: true);
+        }
+    }
+}

--- a/src/Features/Sensors/EcoData.Sensors.Database/Models/Parameter.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/Models/Parameter.cs
@@ -6,13 +6,20 @@ namespace EcoData.Sensors.Database.Models;
 public sealed class Parameter
 {
     public required Guid Id { get; set; }
+    public required Guid? SourceId { get; set; }
     public required string Code { get; set; }
     public required string Name { get; set; }
     public required string DefaultUnit { get; set; }
-    public required Guid SensorTypeId { get; set; }
+    public required Guid? SensorTypeId { get; set; }
+    public required Guid PhenomenonId { get; set; }
+    public required string SourceUnit { get; set; }
+    public required double UnitFactor { get; set; }
+    public required double UnitOffset { get; set; }
+    public required ValueShape ValueShape { get; set; }
     public required DateTimeOffset CreatedAt { get; set; }
 
     public SensorType? SensorType { get; set; }
+    public Phenomenon? Phenomenon { get; set; }
 
     public sealed class EntityConfiguration : IEntityTypeConfiguration<Parameter>
     {
@@ -28,11 +35,25 @@ public sealed class Parameter
 
             builder.Property(static e => e.DefaultUnit).HasMaxLength(50).IsRequired();
 
+            builder.Property(static e => e.SourceUnit).HasMaxLength(50).IsRequired();
+
+            builder
+                .Property(static e => e.ValueShape)
+                .HasConversion<string>()
+                .HasMaxLength(30)
+                .IsRequired();
+
             builder.Property(static e => e.CreatedAt).IsRequired();
 
-            builder.HasIndex(static e => e.Code).IsUnique();
+            builder.HasIndex(static e => new { e.SourceId, e.Code }).IsUnique();
 
             builder.HasIndex(static e => e.SensorTypeId);
+
+            builder
+                .HasOne(static e => e.Phenomenon)
+                .WithMany(static p => p.Parameters)
+                .HasForeignKey(static e => e.PhenomenonId)
+                .OnDelete(DeleteBehavior.Restrict);
         }
     }
 }

--- a/src/Features/Sensors/EcoData.Sensors.Database/Models/Phenomenon.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/Models/Phenomenon.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EcoData.Sensors.Database.Models;
+
+public sealed class Phenomenon
+{
+    public required Guid Id { get; set; }
+    public required string Code { get; set; }
+    public required string Name { get; set; }
+    public required string? Description { get; set; }
+    public required string CanonicalUnit { get; set; }
+    public required ValueShape DefaultValueShape { get; set; }
+    public required string[] Capabilities { get; set; }
+    public required DateTimeOffset CreatedAt { get; set; }
+
+    public ICollection<Parameter> Parameters { get; set; } = [];
+
+    public sealed class EntityConfiguration : IEntityTypeConfiguration<Phenomenon>
+    {
+        public void Configure(EntityTypeBuilder<Phenomenon> builder)
+        {
+            builder.ToTable("phenomena");
+
+            builder.HasKey(static e => e.Id);
+
+            builder.Property(static e => e.Code).HasMaxLength(50).IsRequired();
+
+            builder.Property(static e => e.Name).HasMaxLength(100).IsRequired();
+
+            builder.Property(static e => e.Description).HasMaxLength(500);
+
+            builder.Property(static e => e.CanonicalUnit).HasMaxLength(30).IsRequired();
+
+            builder
+                .Property(static e => e.DefaultValueShape)
+                .HasConversion<string>()
+                .HasMaxLength(30)
+                .IsRequired();
+
+            builder.Property(static e => e.Capabilities).HasColumnType("text[]").IsRequired();
+
+            builder.Property(static e => e.CreatedAt).IsRequired();
+
+            builder.HasIndex(static e => e.Code).IsUnique();
+        }
+    }
+}

--- a/src/Features/Sensors/EcoData.Sensors.Database/Models/Reading.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/Models/Reading.cs
@@ -14,7 +14,13 @@ public sealed class Reading
     public required DateTimeOffset RecordedAt { get; set; }
     public required DateTimeOffset IngestedAt { get; set; }
 
+    public Guid? PhenomenonId { get; set; }
+    public Guid? ParameterId { get; set; }
+    public double? CanonicalValue { get; set; }
+
     public Sensor? Sensor { get; set; }
+    public Phenomenon? Phenomenon { get; set; }
+    public Parameter? ResolvedParameter { get; set; }
 
     public sealed class EntityConfiguration : IEntityTypeConfiguration<Reading>
     {
@@ -40,6 +46,25 @@ public sealed class Reading
                 e.Parameter,
                 e.RecordedAt,
             });
+
+            builder.HasIndex(static e => new
+            {
+                e.SensorId,
+                e.PhenomenonId,
+                e.RecordedAt,
+            });
+
+            builder
+                .HasOne(static e => e.Phenomenon)
+                .WithMany()
+                .HasForeignKey(static e => e.PhenomenonId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            builder
+                .HasOne(static e => e.ResolvedParameter)
+                .WithMany()
+                .HasForeignKey(static e => e.ParameterId)
+                .OnDelete(DeleteBehavior.SetNull);
         }
     }
 }

--- a/src/Features/Sensors/EcoData.Sensors.Database/Models/ValueShape.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/Models/ValueShape.cs
@@ -1,0 +1,9 @@
+namespace EcoData.Sensors.Database.Models;
+
+public enum ValueShape
+{
+    Instantaneous,
+    IntervalTotal,
+    CumulativeSinceReset,
+    Rate,
+}

--- a/src/Features/Sensors/EcoData.Sensors.Database/SensorsDbContext.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/SensorsDbContext.cs
@@ -7,6 +7,7 @@ public sealed class SensorsDbContext(DbContextOptions<SensorsDbContext> options)
 {
     public DbSet<Sensor> Sensors => Set<Sensor>();
     public DbSet<SensorType> SensorTypes => Set<SensorType>();
+    public DbSet<Phenomenon> Phenomena => Set<Phenomenon>();
     public DbSet<Parameter> Parameters => Set<Parameter>();
     public DbSet<Reading> Readings => Set<Reading>();
     public DbSet<Alert> Alerts => Set<Alert>();
@@ -22,6 +23,7 @@ public sealed class SensorsDbContext(DbContextOptions<SensorsDbContext> options)
         modelBuilder.HasPostgresExtension("postgis");
         modelBuilder.ApplyConfiguration(new Sensor.EntityConfiguration());
         modelBuilder.ApplyConfiguration(new SensorType.EntityConfiguration());
+        modelBuilder.ApplyConfiguration(new Phenomenon.EntityConfiguration());
         modelBuilder.ApplyConfiguration(new Parameter.EntityConfiguration());
         modelBuilder.ApplyConfiguration(new Reading.EntityConfiguration());
         modelBuilder.ApplyConfiguration(new Alert.EntityConfiguration());

--- a/src/Features/Sensors/EcoData.Sensors.Ingestion/Program.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Ingestion/Program.cs
@@ -4,6 +4,7 @@ using EcoData.Organization.DataAccess;
 using EcoData.Organization.Database.Extensions;
 using EcoData.Sensors.DataAccess;
 using EcoData.Sensors.Database.Extensions;
+using EcoData.Sensors.Ingestion.Seeders;
 using EcoData.Sensors.Ingestion.Services;
 using EcoData.Sensors.Ingestion.Workers;
 
@@ -21,6 +22,11 @@ builder.Services.AddHttpClient<IUsgsApiClient, UsgsApiClient>(client =>
 {
     client.BaseAddress = new Uri("https://waterservices.usgs.gov/nwis/iv/");
 });
+
+// Phenomenon + USGS parameter mapping seeder runs before the worker so canonical resolution is ready on first ingest.
+// Backfill resolves canonical values on any readings ingested before the mappings existed. Both run once at startup.
+builder.Services.AddHostedService<PhenomenonSeeder>();
+builder.Services.AddHostedService<ReadingBackfillService>();
 builder.Services.AddHostedService<UsgsIngestionWorker>();
 
 var host = builder.Build();

--- a/src/Features/Sensors/EcoData.Sensors.Ingestion/Seeders/PhenomenonSeeder.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Ingestion/Seeders/PhenomenonSeeder.cs
@@ -1,0 +1,197 @@
+using EcoData.Organization.DataAccess.Interfaces;
+using EcoData.Sensors.Database;
+using EcoData.Sensors.Database.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace EcoData.Sensors.Ingestion.Seeders;
+
+public sealed class PhenomenonSeeder(
+    IDbContextFactory<SensorsDbContext> contextFactory,
+    IDataSourceRepository dataSourceRepository,
+    ILogger<PhenomenonSeeder> logger
+) : IHostedService
+{
+    private const string UsgsDataSourceName = "USGS Puerto Rico";
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await SeedPhenomenaAsync(cancellationToken);
+        await SeedUsgsParameterMappingsAsync(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private async Task SeedPhenomenaAsync(CancellationToken ct)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+
+        var existingCodes = await context
+            .Phenomena.Select(p => p.Code)
+            .ToListAsync(ct);
+
+        var existingSet = existingCodes.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var now = DateTimeOffset.UtcNow;
+
+        var toAdd = PhenomenonCatalog
+            .All.Where(p => !existingSet.Contains(p.Code))
+            .Select(p => new Phenomenon
+            {
+                Id = Guid.CreateVersion7(),
+                Code = p.Code,
+                Name = p.Name,
+                Description = p.Description,
+                CanonicalUnit = p.CanonicalUnit,
+                DefaultValueShape = p.DefaultValueShape,
+                Capabilities = p.Capabilities,
+                CreatedAt = now,
+            })
+            .ToList();
+
+        if (toAdd.Count == 0)
+        {
+            logger.LogDebug("All {Total} phenomena already seeded", PhenomenonCatalog.All.Count);
+            return;
+        }
+
+        context.Phenomena.AddRange(toAdd);
+        await context.SaveChangesAsync(ct);
+        logger.LogInformation("Seeded {Count} phenomena", toAdd.Count);
+    }
+
+    private async Task SeedUsgsParameterMappingsAsync(CancellationToken ct)
+    {
+        var dataSource = await dataSourceRepository.GetByNameAsync(UsgsDataSourceName, ct);
+        if (dataSource is null)
+        {
+            logger.LogWarning(
+                "USGS data source '{Name}' not found; skipping USGS parameter mapping seed. Mappings will be seeded on next worker run after the data source is created.",
+                UsgsDataSourceName
+            );
+            return;
+        }
+
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+
+        var phenomenaByCode = await context
+            .Phenomena.ToDictionaryAsync(p => p.Code, p => p.Id, StringComparer.OrdinalIgnoreCase, ct);
+
+        var existingCodes = await context
+            .Parameters.Where(p => p.SourceId == dataSource.Id)
+            .Select(p => p.Code)
+            .ToListAsync(ct);
+
+        var existingSet = existingCodes.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var now = DateTimeOffset.UtcNow;
+
+        var toAdd = new List<Parameter>();
+        foreach (var mapping in UsgsParameterMappings.All)
+        {
+            if (existingSet.Contains(mapping.Code))
+            {
+                continue;
+            }
+            if (!phenomenaByCode.TryGetValue(mapping.PhenomenonCode, out var phenomenonId))
+            {
+                logger.LogWarning(
+                    "USGS code {Code} maps to phenomenon '{PhenomenonCode}' which is not in the catalog; skipping",
+                    mapping.Code,
+                    mapping.PhenomenonCode
+                );
+                continue;
+            }
+
+            toAdd.Add(new Parameter
+            {
+                Id = Guid.CreateVersion7(),
+                SourceId = dataSource.Id,
+                Code = mapping.Code,
+                Name = mapping.Name,
+                DefaultUnit = mapping.SourceUnit,
+                SensorTypeId = null,
+                PhenomenonId = phenomenonId,
+                SourceUnit = mapping.SourceUnit,
+                UnitFactor = mapping.UnitFactor,
+                UnitOffset = mapping.UnitOffset,
+                ValueShape = mapping.ValueShape,
+                CreatedAt = now,
+            });
+        }
+
+        if (toAdd.Count == 0)
+        {
+            logger.LogDebug("All {Total} USGS parameter mappings already seeded", UsgsParameterMappings.All.Count);
+            return;
+        }
+
+        context.Parameters.AddRange(toAdd);
+        await context.SaveChangesAsync(ct);
+        logger.LogInformation("Seeded {Count} USGS parameter mappings", toAdd.Count);
+    }
+}
+
+internal sealed record PhenomenonSeed(
+    string Code,
+    string Name,
+    string? Description,
+    string CanonicalUnit,
+    ValueShape DefaultValueShape,
+    string[] Capabilities
+);
+
+internal static class PhenomenonCatalog
+{
+    public static readonly IReadOnlyList<PhenomenonSeed> All =
+    [
+        new("streamflow", "Streamflow", "Volumetric water flow rate in a stream channel", "m3/s", ValueShape.Instantaneous, ["FloodIndicator"]),
+        new("gage-height", "Gage Height", "Height of the water surface above a fixed reference at the gage", "m", ValueShape.Instantaneous, ["FloodIndicator"]),
+        new("precipitation", "Precipitation", "Liquid precipitation accumulated over a reporting interval", "mm", ValueShape.IntervalTotal, ["FloodIndicator"]),
+        new("water-level-prd2002", "Stream Water Level (PRD2002)", "Water surface elevation above the Puerto Rico Datum of 2002", "m", ValueShape.Instantaneous, ["FloodIndicator"]),
+        new("reservoir-level-lmsl", "Reservoir Level (LMSL)", "Reservoir surface elevation above local mean sea level", "m", ValueShape.Instantaneous, ["FloodIndicator", "DroughtIndicator"]),
+        new("reservoir-level-prd2002", "Reservoir Level (PRD2002)", "Reservoir surface elevation above the Puerto Rico Datum of 2002", "m", ValueShape.Instantaneous, ["FloodIndicator", "DroughtIndicator"]),
+        new("groundwater-depth", "Groundwater Depth", "Depth from land surface down to the water table", "m", ValueShape.Instantaneous, ["DroughtIndicator"]),
+        new("water-temperature", "Water Temperature", "Temperature of the water body", "degC", ValueShape.Instantaneous, ["WaterQualityIndicator"]),
+        new("ph", "pH", "Acidity or alkalinity of the water on the standard pH scale", "pH", ValueShape.Instantaneous, ["WaterQualityIndicator"]),
+        new("dissolved-oxygen", "Dissolved Oxygen", "Concentration of oxygen dissolved in water", "mg/L", ValueShape.Instantaneous, ["WaterQualityIndicator"]),
+        new("specific-conductance", "Specific Conductance", "Electrical conductivity of water normalized to 25 degC", "uS/cm", ValueShape.Instantaneous, ["WaterQualityIndicator"]),
+        new("turbidity", "Turbidity", "Cloudiness of water caused by suspended particles", "FNU", ValueShape.Instantaneous, ["WaterQualityIndicator"]),
+        new("gate-opening-height", "Gate Opening Height", "Vertical opening of a control gate", "m", ValueShape.Instantaneous, []),
+    ];
+}
+
+internal sealed record UsgsParameterMapping(
+    string Code,
+    string Name,
+    string PhenomenonCode,
+    string SourceUnit,
+    double UnitFactor,
+    double UnitOffset,
+    ValueShape ValueShape
+);
+
+internal static class UsgsParameterMappings
+{
+    private const double FeetToMeters = 0.3048;
+    private const double CubicFeetPerSecondToCubicMetersPerSecond = 0.0283168;
+    private const double InchesToMillimeters = 25.4;
+
+    public static readonly IReadOnlyList<UsgsParameterMapping> All =
+    [
+        new("00010", "Temperature, water", "water-temperature", "deg C", 1.0, 0.0, ValueShape.Instantaneous),
+        new("00045", "Precipitation, total", "precipitation", "in", InchesToMillimeters, 0.0, ValueShape.IntervalTotal),
+        new("00060", "Streamflow", "streamflow", "ft3/s", CubicFeetPerSecondToCubicMetersPerSecond, 0.0, ValueShape.Instantaneous),
+        new("00065", "Gage height", "gage-height", "ft", FeetToMeters, 0.0, ValueShape.Instantaneous),
+        new("00095", "Specific conductance", "specific-conductance", "uS/cm @25C", 1.0, 0.0, ValueShape.Instantaneous),
+        new("00300", "Dissolved oxygen", "dissolved-oxygen", "mg/l", 1.0, 0.0, ValueShape.Instantaneous),
+        new("00400", "pH, water, field", "ph", "std units", 1.0, 0.0, ValueShape.Instantaneous),
+        new("45592", "Gate opening height", "gate-opening-height", "ft", FeetToMeters, 0.0, ValueShape.Instantaneous),
+        new("63680", "Turbidity (near-IR, FNU)", "turbidity", "FNU", 1.0, 0.0, ValueShape.Instantaneous),
+        new("72019", "Depth to water level below land surface", "groundwater-depth", "ft", FeetToMeters, 0.0, ValueShape.Instantaneous),
+        new("72365", "Stream water level elevation (PRD2002)", "water-level-prd2002", "ft", FeetToMeters, 0.0, ValueShape.Instantaneous),
+        new("72375", "Reservoir elevation (LMSL, ft)", "reservoir-level-lmsl", "ft", FeetToMeters, 0.0, ValueShape.Instantaneous),
+        new("72376", "Reservoir elevation (LMSL, m)", "reservoir-level-lmsl", "m", 1.0, 0.0, ValueShape.Instantaneous),
+        new("72379", "Reservoir elevation (PRD2002, ft)", "reservoir-level-prd2002", "ft", FeetToMeters, 0.0, ValueShape.Instantaneous),
+        new("72380", "Reservoir elevation (PRD2002, m)", "reservoir-level-prd2002", "m", 1.0, 0.0, ValueShape.Instantaneous),
+    ];
+}

--- a/src/Features/Sensors/EcoData.Sensors.Ingestion/Seeders/ReadingBackfillService.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Ingestion/Seeders/ReadingBackfillService.cs
@@ -1,0 +1,68 @@
+using EcoData.Sensors.Database;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace EcoData.Sensors.Ingestion.Seeders;
+
+// Resolves phenomenon_id, parameter_id, and canonical_value on any existing
+// readings that were ingested before parameter mappings existed. Runs once on
+// startup after PhenomenonSeeder. Idempotent: subsequent runs find no
+// unresolved readings and exit immediately.
+public sealed class ReadingBackfillService(
+    IDbContextFactory<SensorsDbContext> contextFactory,
+    ILogger<ReadingBackfillService> logger
+) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var unresolvedCount = await context
+            .Readings.AsNoTracking()
+            .Where(r => r.PhenomenonId == null)
+            .LongCountAsync(cancellationToken);
+
+        if (unresolvedCount == 0)
+        {
+            logger.LogDebug("No unresolved readings to backfill");
+            return;
+        }
+
+        logger.LogInformation(
+            "Backfilling canonical values on {Count} unresolved reading(s)",
+            unresolvedCount
+        );
+
+        var rowsUpdated = await context.Database.ExecuteSqlRawAsync(
+            """
+            UPDATE readings r
+            SET phenomenon_id   = p.phenomenon_id,
+                parameter_id    = p.id,
+                canonical_value = r.value * p.unit_factor + p.unit_offset
+            FROM sensors s, parameters p
+            WHERE r.sensor_id = s.id
+              AND p.source_id = s.source_id
+              AND p.code = r.parameter
+              AND r.phenomenon_id IS NULL
+            """,
+            cancellationToken
+        );
+
+        var stillUnresolved = unresolvedCount - rowsUpdated;
+        if (stillUnresolved > 0)
+        {
+            logger.LogWarning(
+                "Backfill resolved {Resolved} reading(s); {Remaining} remain unresolved (no parameter mapping for their source/code)",
+                rowsUpdated,
+                stillUnresolved
+            );
+        }
+        else
+        {
+            logger.LogInformation("Backfill resolved {Resolved} reading(s)", rowsUpdated);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Features/Sensors/EcoData.Sensors.Ingestion/Workers/UsgsIngestionWorker.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Ingestion/Workers/UsgsIngestionWorker.cs
@@ -3,6 +3,7 @@ using EcoData.Organization.Contracts.Dtos;
 using EcoData.Organization.DataAccess.Interfaces;
 using EcoData.Sensors.Contracts.Dtos;
 using EcoData.Sensors.DataAccess.Interfaces;
+using EcoData.Sensors.DataAccess.Resolvers;
 using EcoData.Sensors.Ingestion.Services;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -17,13 +18,21 @@ public sealed class UsgsIngestionWorker(
     IIngestionLogRepository ingestionLogRepository,
     ISensorHealthRepository healthRepository,
     IMunicipalityRepository municipalityRepository,
+    ParameterResolver parameterResolver,
     IUsgsApiClient usgsApiClient,
+    IHostEnvironment hostEnvironment,
     ILogger<UsgsIngestionWorker> logger
 ) : BackgroundService
 {
     private const string UsgsOrganizationName = "USGS";
     private const string UsgsDataSourceName = "USGS Puerto Rico";
     private static readonly TimeSpan DefaultInterval = TimeSpan.FromMinutes(15);
+
+    // Dev only: cap historical catch-up so a stale local environment can't request
+    // a month of USGS data in one shot and trip the HTTP timeout. Prod always
+    // catches up from the last recorded timestamp — losing data there is worse
+    // than a slow request.
+    private static readonly TimeSpan DevMaxLookback = TimeSpan.FromHours(6);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -43,6 +52,16 @@ public sealed class UsgsIngestionWorker(
 
                 var lastLog = await ingestionLogRepository.GetLatestAsync(dataSource.Id, stoppingToken);
                 var startDt = lastLog?.LastRecordedAt;
+                if (hostEnvironment.IsDevelopment() && startDt is { } last
+                    && last < DateTimeOffset.UtcNow - DevMaxLookback)
+                {
+                    logger.LogInformation(
+                        "Dev: last recorded {Last:O} is older than {Hours}h cap; falling back to USGS short window",
+                        last,
+                        DevMaxLookback.TotalHours
+                    );
+                    startDt = null;
+                }
 
                 var response = await usgsApiClient.GetInstantaneousValuesAsync(startDt: startDt, cancellationToken: stoppingToken);
 
@@ -101,7 +120,9 @@ public sealed class UsgsIngestionWorker(
                     logger.LogInformation("Added {Count} new sensors", sensorsToAdd.Count);
                 }
 
+                var parameterLookup = await parameterResolver.LoadLookupAsync(dataSource.Id, stoppingToken);
                 var readingsToAdd = new List<ReadingDtoForCreate>();
+                var unresolvedCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var series in timeSeries)
                 {
@@ -119,14 +140,39 @@ public sealed class UsgsIngestionWorker(
                     {
                         foreach (var reading in valuesSet.Value)
                         {
-                            if (double.TryParse(reading.Value, out var value))
+                            if (!double.TryParse(reading.Value, out var value))
                             {
-                                readingsToAdd.Add(new ReadingDtoForCreate(
-                                    sensor.Id, parameterCode, variableName, value, unitCode, reading.DateTime
-                                ));
+                                continue;
                             }
+
+                            var resolved = parameterLookup.Resolve(parameterCode, unitCode, value, reading.DateTime);
+                            if (resolved.PhenomenonId is null)
+                            {
+                                unresolvedCodes.Add(parameterCode);
+                            }
+
+                            readingsToAdd.Add(new ReadingDtoForCreate(
+                                sensor.Id,
+                                parameterCode,
+                                variableName,
+                                value,
+                                unitCode,
+                                reading.DateTime,
+                                resolved.PhenomenonId,
+                                resolved.ParameterId,
+                                resolved.CanonicalValue
+                            ));
                         }
                     }
+                }
+
+                if (unresolvedCodes.Count > 0)
+                {
+                    logger.LogWarning(
+                        "Stored readings for {Count} unmapped USGS parameter code(s); add Parameter mappings to enable canonical values: {Codes}",
+                        unresolvedCodes.Count,
+                        string.Join(", ", unresolvedCodes)
+                    );
                 }
 
                 if (readingsToAdd.Count > 0)


### PR DESCRIPTION
## Summary

Adds a `Phenomenon` abstraction layer on top of source-specific `Parameter` codes so dashboards can query by semantic concept (e.g. `FloodIndicator`) instead of hardcoded USGS codes. The USGS ingestion worker now resolves every reading into a canonical phenomenon + canonical value at write time.

Closes #205.

## What's in this PR

**Schema**
- New `phenomena` table — `Code`, `Name`, `CanonicalUnit`, `DefaultValueShape`, `Capabilities` (Postgres `text[]` for tags like `FloodIndicator`, `WaterQualityIndicator`, `DroughtIndicator`).
- `parameters` extended with `SourceId`, `PhenomenonId`, `SourceUnit`, `UnitFactor`, `UnitOffset`, `ValueShape`. Unique index changed from `(code)` to `(source_id, code)` so multiple sources can re-use the same raw code. `SensorTypeId` now nullable.
- `readings` gains nullable `PhenomenonId`, `ParameterId`, `CanonicalValue` alongside the existing raw `Parameter`/`Value`/`Unit` columns. Existing UI/queries are untouched; dashboards opt into canonical fields.

**Resolver**
- `ParameterResolver` exposes a batch-friendly `LoadLookupAsync(sourceId)` that returns a `ParameterLookup` cache for in-memory resolution per worker iteration — one DB query per batch instead of per reading.
- Unit conversion via factor + offset. `CumulativeSinceReset` value shape throws `NotSupportedException` for now (no current source uses it).
- Unmapped parameter codes return `ResolvedReading.Unresolved` — readings still persist with NULL canonical fields. Worker logs a warning naming the unknown codes so admins can extend the seed.

**USGS worker**
- Calls the resolver before persisting readings.
- Caps historical catch-up to 6h **in Development only** (gated by `IHostEnvironment.IsDevelopment()`). Prevents a stale local environment from requesting a month of USGS data and tripping the 10s HTTP attempt timeout. Prod keeps full catch-up.

**Seed + backfill (both `IHostedService`, run on Ingestion startup)**
- `PhenomenonSeeder` — idempotent; seeds 13 phenomena and 15 USGS parameter mappings (every code currently observed in prod, with unit conversions baked in: `ft → m`, `ft³/s → m³/s`, `in → mm`).
- `ReadingBackfillService` — single `UPDATE … FROM sensors, parameters` that resolves canonical fields on any readings ingested before mappings existed. Idempotent. Logs how many remain unresolved (= unmapped codes).

**API**
- New read endpoints under `/sensors/phenomena` (list, by-id, `?capability=` filter).
- `ParameterDto` extended with phenomenon metadata.

## Default phenomena seeded

| Capability | Phenomena |
|---|---|
| `FloodIndicator` | streamflow, gage-height, precipitation, water-level-prd2002, reservoir-level-lmsl, reservoir-level-prd2002 |
| `DroughtIndicator` | groundwater-depth, reservoir-level-lmsl, reservoir-level-prd2002 |
| `WaterQualityIndicator` | water-temperature, ph, dissolved-oxygen, specific-conductance, turbidity |
| (none — control state) | gate-opening-height |

LMSL vs PRD2002 reservoir levels are kept as **sibling phenomena** because the datums use different reference frames; conflating them would silently produce wrong cross-reservoir comparisons.

## Migration safety

- All new columns on `readings` are **nullable** — existing 735k prod rows are unaffected.
- New NOT NULL columns on `parameters` use defaults during the migration; safe because the table is empty in prod today.
- Unique-index change from `(code)` to `(source_id, code)` is safe on an empty table.
- `ReadingBackfillService` populates canonical values for any pre-existing rows on first deploy.

## Test plan

- [ ] Apply migration to dev DB
- [ ] Restart Ingestion service; verify `PhenomenonSeeder` logs `Seeded 13 phenomena` + `Seeded 15 USGS parameter mappings`
- [ ] Verify `ReadingBackfillService` resolves any pre-existing readings
- [ ] Confirm new readings from the worker have non-null `phenomenon_id` + `canonical_value`
- [ ] Verify a known conversion (e.g. USGS `00065` gage height in ft → canonical m via factor 0.3048)
- [ ] Hit `GET /sensors/phenomena` and `GET /sensors/phenomena?capability=FloodIndicator` and confirm shape
- [ ] Sanity-check existing reading list/detail endpoints still render (DTOs unchanged externally)

## Out of scope (follow-ups)

- Configurable parsers + parse-failure tracking (separate issue, sibling design).
- Per-org Push API ingestion path (the resolver is already source-agnostic, just needs an endpoint).
- Phenomenon-rule → event emission (turns canonical readings into `Alert` rows).
- Re-resolution background job that re-runs when a Parameter mapping is added/updated (current backfill only runs on startup).