### PR TITLE
feat(eco-portal): editorial redesign of Account page

### DIFF
--- a/docs/bioacoustics.md
+++ b/docs/bioacoustics.md
@@ -1,0 +1,121 @@
+# Bioacoustics
+
+## What it is
+
+Bioacoustics is the study of sound produced by living organisms — birds, bats, frogs, insects, mammals, even fish. In an ecological monitoring context, it means deploying microphones in the environment, recording continuously (or on a schedule), and extracting biological information from the resulting audio: which species are present, how many, when they are active, and how the soundscape changes over time.
+
+It sits at the intersection of ecology, signal processing, and (increasingly) machine learning. A single recorder in one location can generate weeks of data covering dozens of species without a human ever being present — which is exactly why it fits a solo, low-budget research program.
+
+## Why it matters for research
+
+- **Non-invasive.** No trapping, no disturbance. The organism vocalizes; you listen.
+- **Scales without people.** One $50 recorder can replace dozens of point-count surveys.
+- **Works at night and in dense vegetation.** Camera traps miss vocal species; bioacoustics catches them.
+- **Detects cryptic species.** Many bats, frogs, and nocturnal birds are near-impossible to survey visually but loud on a spectrogram.
+- **Generates reusable data.** The audio files themselves are archivable and re-analyzable as better classifiers appear.
+- **Publishable on small datasets.** A single well-documented deployment is enough for a data paper or a site-descriptive study.
+
+## Core concepts
+
+### Soundscape
+
+The total acoustic environment of a place, usually decomposed into three components:
+
+- **Biophony** — sounds from living organisms (the part you usually care about).
+- **Geophony** — wind, rain, rivers, thunder.
+- **Anthrophony** — human-made sound: roads, planes, machinery, voices.
+
+A lot of bioacoustic research is really about the *ratio* between these, not any single species.
+
+### Spectrogram
+
+A 2D plot of frequency (y-axis) vs. time (x-axis), with amplitude encoded as color. Every vocalization has a characteristic shape on a spectrogram — a bird song might be a swept chirp, a frog call a stack of horizontal bands, a bat echolocation a steep downward sweep. Most classification (human or ML) happens on spectrograms rather than raw waveforms.
+
+### Acoustic indices
+
+Scalar summaries computed over a window of audio that attempt to describe soundscape complexity without identifying species. The common ones:
+
+| Index | What it captures |
+|---|---|
+| **ACI** (Acoustic Complexity Index) | How much the amplitude varies over time — high for bird-rich dawn choruses, low for constant noise |
+| **BI** (Bioacoustic Index) | Energy in the bird frequency band (2–8 kHz) |
+| **H** (Acoustic Entropy) | How evenly energy is spread across frequencies and time |
+| **NDSI** (Normalized Difference Soundscape Index) | Biophony vs. anthrophony ratio |
+| **ADI** (Acoustic Diversity Index) | Shannon diversity across frequency bins |
+
+Indices are cheap to compute, don't need training data, and are a standard first-pass analysis. Many papers are built entirely on index comparisons across sites, seasons, or disturbance gradients.
+
+### Species identification
+
+Two broad approaches:
+
+1. **Template / rule-based** — you define what a species sounds like (frequency range, duration, pattern) and match against it. Good for a handful of target species.
+2. **Machine learning classifiers** — trained on labeled audio, output species probabilities. This is where the field is now.
+
+Important pretrained models you can use for free:
+
+- **BirdNET** — Cornell's bird classifier, 6000+ species, runs on a Raspberry Pi. The de facto standard.
+- **Perch** (Google) — successor-generation bird classifier with strong transfer learning.
+- **BatDetect2** — ultrasonic bat call classifier.
+- **AnuraSet** / regional frog classifiers — growing, especially for Neotropics.
+- **Koogu**, **opensoundscape** — Python libraries for training your own.
+
+## Hardware
+
+### Audible-range recorders (birds, frogs, most mammals, insects)
+
+- **AudioMoth** (~$80) — the community standard. Open hardware, SD card, weeks of battery, schedulable.
+- **Song Meter Micro** (~$150) — friendlier, weatherproof, app-driven.
+- **DIY Raspberry Pi + USB mic** — cheapest, most flexible, needs a weatherproof enclosure and power solution. Fits naturally into an EcoData sensor node.
+
+### Ultrasonic recorders (bats, some insects)
+
+- **AudioMoth in ultrasonic mode** — records up to 384 kHz, adequate for most bats.
+- **Echo Meter Touch** — phone-attached, good for active (walking) surveys.
+- Full-spec bat detectors run into the thousands but are rarely necessary for a solo program.
+
+### Hydrophones (underwater — fish, cetaceans, aquatic insects)
+
+- **Aquarian H2a** (~$150) — entry-level, works with any recorder.
+- Niche but a real opportunity if you already have a water-sensor program.
+
+## Typical workflow
+
+1. **Deploy** recorder(s) on a schedule — e.g. 1 minute every 10 minutes, or continuous during dawn/dusk.
+2. **Retrieve** SD cards (or stream, if you have power/connectivity).
+3. **Ingest** audio into storage with metadata: site, timestamp, sensor ID, weather.
+4. **Compute acoustic indices** per window (fast, no ML needed).
+5. **Run a classifier** (BirdNET etc.) to get per-species detection events with confidence scores.
+6. **Validate** a sample of detections manually — essential for any paper.
+7. **Analyze** — diel patterns, species accumulation curves, index vs. covariate regressions.
+
+## How it fits EcoData / FaunaFinder
+
+FaunaFinder already models species at a municipality level. Bioacoustics slots in as a new **detection source** alongside whatever manual or citizen-science observations currently feed it:
+
+- A **BioacousticDevice** — another sensor type next to `WaterSensor`, with its own telemetry (battery, SD usage, recording schedule) and audio-file upload path.
+- A **Detection** record — species, confidence, timestamp, device, audio-clip reference — which feeds species presence / activity data back into FaunaFinder.
+- **Soundscape summaries** — per-site time series of acoustic indices, independent of species ID, useful on their own.
+
+The data model is small; the infrastructure work is mostly around audio storage (blob/object store, not a relational DB) and a worker that runs classifiers on ingest.
+
+## Research angles a solo operator can actually publish
+
+1. **Site-descriptive study** — deploy at one site for a few months, report species list, diel activity, seasonal change. Regional journals accept these.
+2. **Index comparison across a gradient** — urban vs. peri-urban vs. forest. Very tractable with 3–5 recorders.
+3. **Classifier evaluation** — how does BirdNET perform on your local species? Precision/recall by species is a publishable contribution, especially in under-studied regions.
+4. **Data paper** — release a labeled regional audio dataset on Zenodo / GBIF and publish a short descriptor in *Scientific Data* or *Data in Brief*.
+5. **Methods / platform paper** — describe EcoData's bioacoustic pipeline as open-source infrastructure in *SoftwareX*, *Methods in Ecology and Evolution*, or *Ecological Informatics*.
+6. **Pair with existing water/air sensors** — acoustic indices as a proxy for ecosystem health alongside chemistry. Multi-modal monitoring is a current trend.
+
+## Gotchas
+
+- **Storage grows fast.** A single AudioMoth on a light schedule can produce 10–50 GB/month. Budget for it.
+- **Wind and rain** dominate outdoor recordings. Foam windshields help; scheduling around forecasts helps more.
+- **Classifier confidence is not probability.** Validate a sample before reporting counts.
+- **False positives cluster by species.** Some species are systematically over-called by BirdNET; know which ones in your region.
+- **Legal / ethical.** Recording in public or private land may need permission; human voices in recordings are a privacy issue in some jurisdictions.
+
+## Minimum viable first deployment
+
+One AudioMoth, one tree, 1-minute-in-10 schedule, one month. Run BirdNET on the output, compute ACI and NDSI per hour, plot diel curves. That alone is enough material for a methods-oriented blog post, a conference poster, or the empirical section of a platform paper — and it validates the whole ingest pipeline end-to-end before you scale.

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/AccountSettingsSection.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/AccountSettingsSection.razor
@@ -7,167 +7,189 @@
 @inject AuthStateService AuthState
 @inject ISnackbar Snackbar
 
-<MudCard Elevation="0" Outlined="true">
-    <MudCardHeader>
-        <CardHeaderContent>
-            <MudText Typo="Typo.h6">Account Settings</MudText>
-        </CardHeaderContent>
-    </MudCardHeader>
-    <MudCardContent>
-        <MudStack Spacing="4">
-            @* Display Name *@
-            <div>
-                <MudText Typo="Typo.caption" Color="Color.Secondary">Display Name</MudText>
-                @if (_isEditingDisplayName)
-                {
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                        <MudTextField @bind-Value="_displayName"
-                                      Variant="Variant.Outlined"
-                                      Margin="Margin.Dense"
-                                      Immediate="true"
-                                      Disabled="UpdateDisplayNameCommand.IsLoading" />
-                        <MudIconButton Icon="@Icons.Material.Filled.Check"
-                                       Color="Color.Success"
-                                       Size="Size.Small"
-                                       OnClick="SaveDisplayNameAsync"
-                                       Disabled="UpdateDisplayNameCommand.IsLoading" />
-                        <MudIconButton Icon="@Icons.Material.Filled.Close"
-                                       Color="Color.Default"
-                                       Size="Size.Small"
-                                       OnClick="CancelEditDisplayName"
-                                       Disabled="UpdateDisplayNameCommand.IsLoading" />
-                    </MudStack>
-                }
-                else
-                {
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                        <MudText>@AuthState.CurrentUser?.DisplayName</MudText>
-                        <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                                       Color="Color.Default"
-                                       Size="Size.Small"
-                                       OnClick="StartEditDisplayName" />
-                    </MudStack>
-                }
-            </div>
+<MudPaper Elevation="0" Class="account-settings-card">
+    <div class="settings-header">
+        <MudText Typo="Typo.h6" Class="settings-title">Account Settings</MudText>
+    </div>
 
-            <MudDivider />
-
-            @* Email *@
-            <div>
-                <MudText Typo="Typo.caption" Color="Color.Secondary">Email</MudText>
-                @if (_isEditingEmail)
+    <div class="settings-grid">
+        @* Display Name *@
+        <div class="settings-cell">
+            <div class="settings-cell-header">
+                <span class="settings-label">Display Name</span>
+                @if (!_isEditingDisplayName)
                 {
-                    <MudStack Spacing="2">
-                        <MudTextField @bind-Value="_newEmail"
-                                      Label="New Email"
-                                      Variant="Variant.Outlined"
-                                      Margin="Margin.Dense"
-                                      InputType="InputType.Email"
-                                      Disabled="UpdateEmailCommand.IsLoading" />
-                        <MudTextField @bind-Value="_emailPassword"
-                                      Label="Current Password"
-                                      Variant="Variant.Outlined"
-                                      Margin="Margin.Dense"
-                                      InputType="InputType.Password"
-                                      Disabled="UpdateEmailCommand.IsLoading" />
-                        <MudStack Row="true" Spacing="2">
-                            <MudButton Variant="Variant.Filled"
-                                       Color="Color.Primary"
-                                       Size="Size.Small"
-                                       OnClick="SaveEmailAsync"
-                                       Disabled="UpdateEmailCommand.IsLoading">
-                                @if (UpdateEmailCommand.IsLoading)
-                                {
-                                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                                }
-                                Save
-                            </MudButton>
-                            <MudButton Variant="Variant.Outlined"
-                                       Color="Color.Default"
-                                       Size="Size.Small"
-                                       OnClick="CancelEditEmail"
-                                       Disabled="UpdateEmailCommand.IsLoading">
-                                Cancel
-                            </MudButton>
-                        </MudStack>
-                    </MudStack>
-                }
-                else
-                {
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                        <MudText>@AuthState.CurrentUser?.Email</MudText>
-                        <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                                       Color="Color.Default"
-                                       Size="Size.Small"
-                                       OnClick="StartEditEmail" />
-                    </MudStack>
-                }
-            </div>
-
-            <MudDivider />
-
-            @* Password *@
-            <div>
-                <MudText Typo="Typo.caption" Color="Color.Secondary">Password</MudText>
-                @if (_isChangingPassword)
-                {
-                    <MudStack Spacing="2">
-                        <MudTextField @bind-Value="_currentPassword"
-                                      Label="Current Password"
-                                      Variant="Variant.Outlined"
-                                      Margin="Margin.Dense"
-                                      InputType="InputType.Password"
-                                      Disabled="ChangePasswordCommand.IsLoading" />
-                        <MudTextField @bind-Value="_newPassword"
-                                      Label="New Password"
-                                      Variant="Variant.Outlined"
-                                      Margin="Margin.Dense"
-                                      InputType="InputType.Password"
-                                      Disabled="ChangePasswordCommand.IsLoading" />
-                        <MudTextField @bind-Value="_confirmPassword"
-                                      Label="Confirm New Password"
-                                      Variant="Variant.Outlined"
-                                      Margin="Margin.Dense"
-                                      InputType="InputType.Password"
-                                      Disabled="ChangePasswordCommand.IsLoading" />
-                        <MudStack Row="true" Spacing="2">
-                            <MudButton Variant="Variant.Filled"
-                                       Color="Color.Primary"
-                                       Size="Size.Small"
-                                       OnClick="SavePasswordAsync"
-                                       Disabled="ChangePasswordCommand.IsLoading">
-                                @if (ChangePasswordCommand.IsLoading)
-                                {
-                                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                                }
-                                Change Password
-                            </MudButton>
-                            <MudButton Variant="Variant.Outlined"
-                                       Color="Color.Default"
-                                       Size="Size.Small"
-                                       OnClick="CancelChangePassword"
-                                       Disabled="ChangePasswordCommand.IsLoading">
-                                Cancel
-                            </MudButton>
-                        </MudStack>
-                    </MudStack>
-                }
-                else
-                {
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                        <MudText>********</MudText>
-                        <MudButton Variant="Variant.Text"
-                                   Color="Color.Primary"
+                    <MudIconButton Icon="@Icons.Material.Outlined.Edit"
                                    Size="Size.Small"
-                                   OnClick="StartChangePassword">
-                            Change
+                                   Class="settings-edit-btn"
+                                   OnClick="StartEditDisplayName" />
+                }
+            </div>
+            @if (_isEditingDisplayName)
+            {
+                <MudStack Spacing="2" Class="mt-1">
+                    <MudTextField @bind-Value="_displayName"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  Immediate="true"
+                                  Disabled="UpdateDisplayNameCommand.IsLoading" />
+                    <MudStack Row="true" Spacing="2">
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                                   OnClick="SaveDisplayNameAsync"
+                                   Disabled="UpdateDisplayNameCommand.IsLoading">
+                            @if (UpdateDisplayNameCommand.IsLoading)
+                            {
+                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                            }
+                            Save
+                        </MudButton>
+                        <MudButton Variant="Variant.Text" Size="Size.Small"
+                                   OnClick="CancelEditDisplayName"
+                                   Disabled="UpdateDisplayNameCommand.IsLoading">
+                            Cancel
                         </MudButton>
                     </MudStack>
+                </MudStack>
+            }
+            else
+            {
+                <div class="settings-value">@AuthState.CurrentUser?.DisplayName</div>
+                <div class="settings-hint">Shown on shared dashboards</div>
+            }
+        </div>
+
+        @* Email *@
+        <div class="settings-cell">
+            <div class="settings-cell-header">
+                <span class="settings-label">Email</span>
+                @if (!_isEditingEmail)
+                {
+                    <MudIconButton Icon="@Icons.Material.Outlined.Edit"
+                                   Size="Size.Small"
+                                   Class="settings-edit-btn"
+                                   OnClick="StartEditEmail" />
                 }
             </div>
-        </MudStack>
-    </MudCardContent>
-</MudCard>
+            @if (_isEditingEmail)
+            {
+                <MudStack Spacing="2" Class="mt-1">
+                    <MudTextField @bind-Value="_newEmail"
+                                  Label="New email"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  InputType="InputType.Email"
+                                  Disabled="UpdateEmailCommand.IsLoading" />
+                    <MudTextField @bind-Value="_emailPassword"
+                                  Label="Current password"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  InputType="InputType.Password"
+                                  Disabled="UpdateEmailCommand.IsLoading" />
+                    <MudStack Row="true" Spacing="2">
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                                   OnClick="SaveEmailAsync"
+                                   Disabled="UpdateEmailCommand.IsLoading">
+                            @if (UpdateEmailCommand.IsLoading)
+                            {
+                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                            }
+                            Save
+                        </MudButton>
+                        <MudButton Variant="Variant.Text" Size="Size.Small"
+                                   OnClick="CancelEditEmail"
+                                   Disabled="UpdateEmailCommand.IsLoading">
+                            Cancel
+                        </MudButton>
+                    </MudStack>
+                </MudStack>
+            }
+            else
+            {
+                <div class="settings-value">@AuthState.CurrentUser?.Email</div>
+                <div class="settings-hint settings-hint-verified">
+                    <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Size="Size.Small" Class="mr-1" />
+                    Verified
+                </div>
+            }
+        </div>
+
+        @* Password *@
+        <div class="settings-cell">
+            <div class="settings-cell-header">
+                <span class="settings-label">Password</span>
+                @if (!_isChangingPassword)
+                {
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Primary"
+                               Size="Size.Small"
+                               Class="settings-change-btn"
+                               OnClick="StartChangePassword">
+                        Change
+                    </MudButton>
+                }
+            </div>
+            @if (_isChangingPassword)
+            {
+                <MudStack Spacing="2" Class="mt-1">
+                    <MudTextField @bind-Value="_currentPassword"
+                                  Label="Current password"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  InputType="InputType.Password"
+                                  Disabled="ChangePasswordCommand.IsLoading" />
+                    <MudTextField @bind-Value="_newPassword"
+                                  Label="New password"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  InputType="InputType.Password"
+                                  Disabled="ChangePasswordCommand.IsLoading" />
+                    <MudTextField @bind-Value="_confirmPassword"
+                                  Label="Confirm new password"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  InputType="InputType.Password"
+                                  Disabled="ChangePasswordCommand.IsLoading" />
+                    <MudStack Row="true" Spacing="2">
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                                   OnClick="SavePasswordAsync"
+                                   Disabled="ChangePasswordCommand.IsLoading">
+                            @if (ChangePasswordCommand.IsLoading)
+                            {
+                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                            }
+                            Change password
+                        </MudButton>
+                        <MudButton Variant="Variant.Text" Size="Size.Small"
+                                   OnClick="CancelChangePassword"
+                                   Disabled="ChangePasswordCommand.IsLoading">
+                            Cancel
+                        </MudButton>
+                    </MudStack>
+                </MudStack>
+            }
+            else
+            {
+                <div class="settings-value password-dots">&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;</div>
+                <div class="settings-hint">Use at least 8 characters</div>
+            }
+        </div>
+
+        @* Two-Factor Auth (Coming soon) *@
+        <div class="settings-cell settings-cell-disabled">
+            <div class="settings-cell-header">
+                <span class="settings-label">Two-Factor Auth</span>
+                <span class="coming-soon-pill">Coming soon</span>
+            </div>
+            <div class="settings-value settings-value-muted">
+                <MudIcon Icon="@Icons.Material.Outlined.Shield" Size="Size.Small" Class="mr-1" />
+                Not yet available
+            </div>
+            <div class="settings-hint">
+                An extra layer of security for your account
+            </div>
+        </div>
+    </div>
+</MudPaper>
 
 @code {
     private bool _isEditingDisplayName;

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/AccountSettingsSection.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/AccountSettingsSection.razor.css
@@ -1,0 +1,135 @@
+.account-settings-card {
+    background: var(--mud-palette-surface) !important;
+    border: 1px solid var(--mud-palette-lines-default) !important;
+    border-radius: 12px !important;
+    overflow: hidden;
+}
+
+.settings-header {
+    padding: 1.25rem 1.5rem 1rem;
+    border-bottom: 1px solid var(--mud-palette-lines-default);
+}
+
+::deep .settings-title {
+    font-family: 'Newsreader', serif;
+    font-weight: 600;
+    color: var(--mud-palette-primary);
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0;
+}
+
+.settings-cell {
+    padding: 1.25rem 1.5rem;
+    border-right: 1px solid var(--mud-palette-lines-default);
+    border-bottom: 1px solid var(--mud-palette-lines-default);
+    min-height: 120px;
+}
+
+.settings-cell:nth-child(2n) {
+    border-right: none;
+}
+
+.settings-cell:nth-last-child(-n + 2) {
+    border-bottom: none;
+}
+
+.settings-cell-disabled {
+    background: var(--mud-palette-background-gray);
+}
+
+.settings-cell-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.4rem;
+    min-height: 28px;
+}
+
+.settings-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--mud-palette-secondary);
+}
+
+::deep .settings-edit-btn {
+    color: var(--mud-palette-text-secondary) !important;
+    margin: -6px;
+}
+
+::deep .settings-change-btn {
+    font-weight: 600 !important;
+    letter-spacing: 0.1em;
+    text-transform: uppercase !important;
+    font-size: 0.7rem !important;
+    margin: -4px;
+}
+
+.settings-value {
+    font-size: 0.95rem;
+    color: var(--mud-palette-text-primary);
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.3rem;
+    word-break: break-word;
+}
+
+.settings-value-muted {
+    color: var(--mud-palette-text-secondary);
+    font-weight: 400;
+}
+
+.password-dots {
+    letter-spacing: 0.2em;
+}
+
+.settings-hint {
+    font-size: 0.75rem;
+    color: var(--mud-palette-text-secondary);
+    display: flex;
+    align-items: center;
+}
+
+.settings-hint-verified {
+    color: #1e8c3e;
+    font-weight: 500;
+}
+
+.coming-soon-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    background: var(--mud-palette-background);
+    border: 1px solid var(--mud-palette-lines-default);
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--mud-palette-text-secondary);
+}
+
+@media (max-width: 720px) {
+    .settings-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .settings-cell {
+        border-right: none;
+    }
+
+    .settings-cell:nth-last-child(-n + 2) {
+        border-bottom: 1px solid var(--mud-palette-lines-default);
+    }
+
+    .settings-cell:last-child {
+        border-bottom: none;
+    }
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/SubscribedSensorsSection.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/SubscribedSensorsSection.razor
@@ -1,91 +1,122 @@
+@using BlazingSingularity.Fetch
 @using EcoData.Sensors.Application.Client
 @using EcoData.Sensors.Contracts.Dtos
+@using EcoPortal.Client.Features.Sensors.Components
+@implements IDisposable
+@inject ISensorHttpClient SensorClient
 @inject IUserSubscriptionHttpClient SubscriptionClient
 @inject INativeNavigationManager Navigation
 
-<MudCard Elevation="0" Outlined="true">
-    <MudCardHeader>
-        <CardHeaderContent>
-            <MudText Typo="Typo.h6">My Sensors</MudText>
-        </CardHeaderContent>
-    </MudCardHeader>
-    <MudCardContent Class="pa-0">
-        @if (_isLoading)
-        {
-            <MudStack Spacing="2" Class="pa-4">
-                @for (int i = 0; i < 3; i++)
-                {
-                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="48px" />
-                }
-            </MudStack>
-        }
-        else if (_subscriptions.Count == 0)
-        {
-            <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="py-6">
-                <MudIcon Icon="@Icons.Material.Outlined.Sensors" Size="Size.Large" Color="Color.Secondary" />
-                <MudText Typo="Typo.body2" Color="Color.Secondary">No subscriptions yet</MudText>
-                <MudButton Variant="Variant.Text"
-                           Color="Color.Primary"
-                           Size="Size.Small"
-                           OnClick="@(() => Navigation.NavigateTo("/sensor-dashboard"))">
-                    Discover Sensors
-                </MudButton>
-            </MudStack>
-        }
-        else
-        {
-            <MudList T="UserSensorSubscriptionDto" Dense="true" Class="py-0">
-                @foreach (var subscription in _subscriptions)
-                {
-                    <MudListItem OnClick="@(() => NavigateToSensor(subscription.SensorId))">
-                        <div class="d-flex align-center gap-3">
-                            <MudIcon Icon="@Icons.Material.Filled.WaterDrop" Color="Color.Primary" Size="Size.Small" />
-                            <MudText>@subscription.SensorName</MudText>
-                        </div>
-                    </MudListItem>
-                    @if (subscription != _subscriptions.Last())
-                    {
-                        <MudDivider />
-                    }
-                }
-            </MudList>
-            @if (_hasMore)
+<MudPaper Elevation="0" Class="sensors-card">
+    <div class="sensors-header">
+        <MudText Typo="Typo.h6" Class="sensors-title">My Sensors</MudText>
+        <span class="sensors-count">
+            @(_sensorsFetch?.Data?.Count ?? 0) Subscribed
+        </span>
+    </div>
+
+    @if (_sensorsFetch is null || _sensorsFetch.IsLoading)
+    {
+        <div class="sensors-skeleton">
+            @for (int i = 0; i < 3; i++)
             {
-                <MudDivider />
-                <div class="pa-2">
-                    <MudButton Variant="Variant.Text"
-                               Color="Color.Primary"
-                               FullWidth="true"
-                               OnClick="@(() => Navigation.NavigateTo("/notifications/history"))">
-                        View All Subscriptions
-                    </MudButton>
-                </div>
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="72px" Class="mb-2 rounded" />
             }
+        </div>
+    }
+    else if (_sensorsFetch.Data is { Count: 0 })
+    {
+        <div class="sensors-empty">
+            <MudIcon Icon="@Icons.Material.Outlined.Sensors" Size="Size.Large" Class="sensors-empty-icon" />
+            <MudText Typo="Typo.body2" Class="sensors-empty-text">
+                You're not following any sensors yet
+            </MudText>
+            <MudButton Variant="Variant.Text" Color="Color.Primary" Size="Size.Small"
+                       OnClick="@(() => Navigation.NavigateTo("/sensor-dashboard"))">
+                Discover sensors
+            </MudButton>
+        </div>
+    }
+    else
+    {
+        <div class="sensors-list">
+            @foreach (var sensor in _sensorsFetch.Data!)
+            {
+                <SensorListItem Sensor="sensor" OnClick="HandleSensorClick" />
+            }
+        </div>
+        @if (_hasMore)
+        {
+            <div class="sensors-footer">
+                <MudButton Variant="Variant.Text" Color="Color.Primary" Size="Size.Small"
+                           OnClick="@(() => Navigation.NavigateTo("/notifications/history"))">
+                    View all subscriptions
+                </MudButton>
+            </div>
         }
-    </MudCardContent>
-</MudCard>
+    }
+</MudPaper>
 
 @code {
-    private bool _isLoading = true;
-    private List<UserSensorSubscriptionDto> _subscriptions = new();
+    private const int MaxDisplayed = 5;
+
+    [Parameter]
+    public EventCallback<int> OnCountChanged { get; set; }
+
+    private IFetch<List<SensorDtoForList>> _sensorsFetch = default!;
     private bool _hasMore;
 
     protected override async Task OnInitializedAsync()
     {
-        try
-        {
-            var allSubscriptions = await SubscriptionClient.GetSubscriptionsAsync();
-            _subscriptions = allSubscriptions.Take(5).ToList();
-            _hasMore = allSubscriptions.Count > 5;
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+        _sensorsFetch = new Fetch<List<SensorDtoForList>>(
+            LoadAsync,
+            () => InvokeAsync(StateHasChanged)
+        );
+
+        await _sensorsFetch.FetchAsync();
     }
 
-    private void NavigateToSensor(Guid sensorId)
+    private async Task<List<SensorDtoForList>> LoadAsync(CancellationToken ct)
     {
-        Navigation.NavigateTo($"/sensors/{sensorId}");
+        var subscriptions = await SubscriptionClient.GetSubscriptionsAsync();
+
+        if (OnCountChanged.HasDelegate)
+        {
+            await OnCountChanged.InvokeAsync(subscriptions.Count);
+        }
+
+        _hasMore = subscriptions.Count > MaxDisplayed;
+
+        var displayed = subscriptions.Take(MaxDisplayed).ToList();
+        var details = await Task.WhenAll(
+            displayed.Select(sub => SensorClient.GetByIdAsync(sub.SensorId, ct))
+        );
+
+        return details
+            .Where(d => d is not null)
+            .Select(d => new SensorDtoForList(
+                d!.Id,
+                d.OrganizationId,
+                d.SourceId,
+                d.ExternalId,
+                d.Name,
+                d.Latitude,
+                d.Longitude,
+                d.MunicipalityId,
+                d.IsActive,
+                d.DataSourceName
+            ))
+            .ToList();
+    }
+
+    private Task HandleSensorClick(SensorDtoForList sensor)
+    {
+        Navigation.NavigateTo($"/sensor/{sensor.Id}");
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        (_sensorsFetch as IDisposable)?.Dispose();
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/SubscribedSensorsSection.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/SubscribedSensorsSection.razor.css
@@ -1,0 +1,66 @@
+.sensors-card {
+    background: var(--mud-palette-surface) !important;
+    border: 1px solid var(--mud-palette-lines-default) !important;
+    border-radius: 12px !important;
+    overflow: hidden;
+}
+
+.sensors-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem 1.5rem 1rem;
+    border-bottom: 1px solid var(--mud-palette-lines-default);
+}
+
+::deep .sensors-title {
+    font-family: 'Newsreader', serif;
+    font-weight: 600;
+    color: var(--mud-palette-primary);
+}
+
+.sensors-count {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--mud-palette-secondary);
+}
+
+.sensors-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.75rem;
+}
+
+/* Skeleton */
+.sensors-skeleton {
+    padding: 0.75rem;
+}
+
+/* Empty */
+.sensors-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 2.5rem 1.5rem;
+}
+
+::deep .sensors-empty-icon {
+    color: var(--mud-palette-secondary) !important;
+    opacity: 0.6;
+}
+
+.sensors-empty-text {
+    color: var(--mud-palette-text-secondary);
+}
+
+/* Footer */
+.sensors-footer {
+    padding: 0.5rem 1rem;
+    border-top: 1px solid var(--mud-palette-lines-default);
+    display: flex;
+    justify-content: center;
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/Pages/AccountPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Pages/AccountPage.razor
@@ -9,113 +9,171 @@
 
 <PageTitle>Account - EcoData</PageTitle>
 
-<div class="narrow-page">
-    <MudStack Spacing="4">
-        @if (AuthState.IsAuthenticated)
-        {
-            @* Profile Card *@
-            <MudCard Elevation="0" Outlined="true">
-                <MudCardContent>
-                    <MudStack AlignItems="AlignItems.Center" Spacing="4" Class="py-4">
-                        <MudAvatar Color="Color.Primary" Size="Size.Large" Style="width: 80px; height: 80px; font-size: 2rem;">
-                            @GetUserInitial()
-                        </MudAvatar>
-                        <MudStack Spacing="1" AlignItems="AlignItems.Center">
-                            <MudText Typo="Typo.h6">@AuthState.CurrentUser?.DisplayName</MudText>
-                            <MudText Typo="Typo.body2" Color="Color.Secondary">@AuthState.CurrentUser?.Email</MudText>
-                        </MudStack>
+@if (AuthState.IsAuthenticated)
+{
+    <div class="account-page page-enter">
+        <MudContainer MaxWidth="MaxWidth.Large" Class="py-6">
+            @* Editorial header *@
+            <header class="account-header">
+                <span class="account-eyebrow">Your Account</span>
+                <h1 class="account-title">Profile &amp; <em>settings</em></h1>
+                <p class="account-subtitle">
+                    Manage how you sign in, the sensors you follow, and how EcoData reaches you
+                    when the data has something to say.
+                </p>
+            </header>
+
+            <MudGrid Spacing="4">
+                @* Left sidebar: profile + quick links *@
+                <MudItem xs="12" md="4">
+                    <MudStack Spacing="4">
+                        <MudPaper Elevation="0" Class="profile-card pa-5">
+                            <MudStack AlignItems="AlignItems.Center" Spacing="3">
+                                <MudAvatar Color="Color.Primary" Class="profile-avatar">
+                                    @GetUserInitial()
+                                </MudAvatar>
+                                <MudStack Spacing="0" AlignItems="AlignItems.Center">
+                                    <MudText Typo="Typo.h6" Class="profile-name">
+                                        @AuthState.CurrentUser?.DisplayName
+                                    </MudText>
+                                    <MudText Typo="Typo.body2" Class="profile-email">
+                                        @AuthState.CurrentUser?.Email
+                                    </MudText>
+                                </MudStack>
+                                <div class="role-pill @(AuthState.IsGlobalAdmin ? "role-pill-admin" : "role-pill-member")">
+                                    <span class="role-dot"></span>
+                                    @(AuthState.IsGlobalAdmin ? "Administrator" : "Member")
+                                </div>
+                            </MudStack>
+
+                            <MudDivider Class="my-4" />
+
+                            <div class="profile-stats">
+                                <div class="profile-stat">
+                                    <span class="profile-stat-label">Member since</span>
+                                    <span class="profile-stat-value">@FormatMemberSince()</span>
+                                </div>
+                                <div class="profile-stat">
+                                    <span class="profile-stat-label">Sensors followed</span>
+                                    <span class="profile-stat-value">@_sensorCount</span>
+                                </div>
+                            </div>
+                        </MudPaper>
+
+                        <MudPaper Elevation="0" Class="quick-links-card">
+                            <div class="section-heading">
+                                <MudText Typo="Typo.h6">Quick Links</MudText>
+                            </div>
+                            <MudList T="string" Class="py-0">
+                                <MudListItem Href="/getting-started" Class="quick-link-item">
+                                    <div class="quick-link">
+                                        <MudIcon Icon="@Icons.Material.Outlined.HelpOutline" Class="quick-link-icon" />
+                                        <div class="quick-link-text">
+                                            <span class="quick-link-title">Getting Started</span>
+                                            <span class="quick-link-subtitle">Learn how to use EcoData</span>
+                                        </div>
+                                    </div>
+                                </MudListItem>
+                                <MudDivider />
+                                <MudListItem Href="/organizations/my" Class="quick-link-item">
+                                    <div class="quick-link">
+                                        <MudIcon Icon="@Icons.Material.Outlined.Business" Class="quick-link-icon" />
+                                        <div class="quick-link-text">
+                                            <span class="quick-link-title">My Organizations</span>
+                                            <span class="quick-link-subtitle">View memberships</span>
+                                        </div>
+                                    </div>
+                                </MudListItem>
+                                <MudDivider />
+                                <MudListItem Href="/notifications/history" Class="quick-link-item">
+                                    <div class="quick-link">
+                                        <MudIcon Icon="@Icons.Material.Outlined.NotificationsNone" Class="quick-link-icon" />
+                                        <div class="quick-link-text">
+                                            <span class="quick-link-title">Notifications</span>
+                                            <span class="quick-link-subtitle">Recent alerts &amp; history</span>
+                                        </div>
+                                    </div>
+                                </MudListItem>
+                            </MudList>
+                        </MudPaper>
                     </MudStack>
-                </MudCardContent>
-            </MudCard>
+                </MudItem>
 
-            @* Account Settings Section *@
-            <AccountSettingsSection />
+                @* Right main column *@
+                <MudItem xs="12" md="8">
+                    <MudStack Spacing="4">
+                        <AccountSettingsSection />
+                        <SubscribedSensorsSection OnCountChanged="OnSensorCountChanged" />
 
-            @* Subscribed Sensors Section *@
-            <SubscribedSensorsSection />
-
-            @* Quick Links *@
-            <MudCard Elevation="0" Outlined="true">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">Quick Links</MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent Class="pa-0">
-                    <MudList T="string" Dense="false">
-                        <MudListItem Icon="@Icons.Material.Outlined.Help" Href="/getting-started">
-                            Getting Started
-                        </MudListItem>
-                        <MudDivider />
-                        <MudListItem Icon="@Icons.Material.Outlined.Business" Href="/organizations/my">
-                            My Organizations
-                        </MudListItem>
-                        <MudDivider />
-                        <MudListItem Icon="@Icons.Material.Outlined.Notifications" Href="/notifications/history">
-                            Notifications
-                        </MudListItem>
-                    </MudList>
-                </MudCardContent>
-            </MudCard>
-
-            @* Sign Out Button *@
-            <MudButton Variant="Variant.Outlined"
-                       Color="Color.Error"
-                       FullWidth="true"
-                       StartIcon="@Icons.Material.Outlined.Logout"
-                       OnClick="LogoutAsync"
-                       Disabled="LogoutCommand.IsLoading">
-                @if (LogoutCommand.IsLoading)
-                {
-                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                    <span>Signing out...</span>
-                }
-                else
-                {
-                    <span>Sign Out</span>
-                }
-            </MudButton>
-        }
-        else
-        {
-            <MudCard Elevation="0" Outlined="true">
-                <MudCardContent>
-                    <MudStack AlignItems="AlignItems.Center" Spacing="4" Class="py-6">
-                        <MudAvatar Color="Color.Default" Size="Size.Large" Style="width: 80px; height: 80px;">
-                            <MudIcon Icon="@Icons.Material.Filled.Person" Style="font-size: 2.5rem;" />
-                        </MudAvatar>
-                        <MudStack Spacing="1" AlignItems="AlignItems.Center">
-                            <MudText Typo="Typo.h6">Welcome to EcoData</MudText>
-                            <MudText Typo="Typo.body2" Color="Color.Secondary">Sign in to access your account</MudText>
-                        </MudStack>
-                        <MudStack Row="true" Spacing="2">
-                            <MudButton Variant="Variant.Filled"
-                                       Color="Color.Primary"
-                                       Href="/login">
-                                Sign In
-                            </MudButton>
-                            <MudButton Variant="Variant.Outlined"
-                                       Color="Color.Primary"
-                                       Href="/register">
-                                Register
-                            </MudButton>
-                        </MudStack>
+                        @* Sign out panel *@
+                        <MudPaper Elevation="0" Class="signout-card pa-4">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="3">
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                                    <MudIcon Icon="@Icons.Material.Outlined.Logout" Color="Color.Error" />
+                                    <MudStack Spacing="0">
+                                        <MudText Typo="Typo.subtitle1" Class="signout-title">
+                                            Sign out of EcoData
+                                        </MudText>
+                                        <MudText Typo="Typo.body2" Class="signout-description">
+                                            You'll be returned to the home page. Your sensors keep collecting
+                                            data &mdash; they don't need you logged in.
+                                        </MudText>
+                                    </MudStack>
+                                </MudStack>
+                                <MudButton Variant="Variant.Outlined"
+                                           Color="Color.Error"
+                                           StartIcon="@Icons.Material.Outlined.Logout"
+                                           OnClick="LogoutAsync"
+                                           Disabled="LogoutCommand.IsLoading"
+                                           Class="signout-btn">
+                                    @if (LogoutCommand.IsLoading)
+                                    {
+                                        <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                                        <span>Signing out...</span>
+                                    }
+                                    else
+                                    {
+                                        <span>Sign Out</span>
+                                    }
+                                </MudButton>
+                            </MudStack>
+                        </MudPaper>
                     </MudStack>
-                </MudCardContent>
-            </MudCard>
-
-            <MudCard Elevation="0" Outlined="true">
-                <MudList T="string" Dense="false">
-                    <MudListItem Icon="@Icons.Material.Outlined.Help" Href="/getting-started">
-                        Getting Started
-                    </MudListItem>
-                </MudList>
-            </MudCard>
-        }
-    </MudStack>
-</div>
+                </MudItem>
+            </MudGrid>
+        </MudContainer>
+    </div>
+}
+else
+{
+    <div class="account-page page-enter">
+        <MudContainer MaxWidth="MaxWidth.Small" Class="py-8">
+            <MudStack Spacing="4" AlignItems="AlignItems.Center">
+                <MudAvatar Color="Color.Default" Size="Size.Large" Style="width: 80px; height: 80px;">
+                    <MudIcon Icon="@Icons.Material.Filled.Person" Style="font-size: 2.5rem;" />
+                </MudAvatar>
+                <MudStack Spacing="1" AlignItems="AlignItems.Center">
+                    <h1 class="account-title">Welcome to <em>EcoData</em></h1>
+                    <MudText Typo="Typo.body1" Color="Color.Secondary" Align="Align.Center">
+                        Sign in to manage your profile and followed sensors.
+                    </MudText>
+                </MudStack>
+                <MudStack Row="true" Spacing="2">
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/login">
+                        Sign In
+                    </MudButton>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Href="/register">
+                        Register
+                    </MudButton>
+                </MudStack>
+            </MudStack>
+        </MudContainer>
+    </div>
+}
 
 @code {
+    private int _sensorCount;
+
     protected override void OnInitialized()
     {
         Navbar.SetTitle("Account");
@@ -131,6 +189,18 @@
     {
         var name = AuthState.CurrentUser?.DisplayName;
         return string.IsNullOrEmpty(name) ? "?" : name[0].ToString().ToUpper();
+    }
+
+    private string FormatMemberSince()
+    {
+        var createdAt = AuthState.CurrentUser?.CreatedAt;
+        return createdAt is null ? "—" : createdAt.Value.ToString("MMM yyyy");
+    }
+
+    private void OnSensorCountChanged(int count)
+    {
+        _sensorCount = count;
+        StateHasChanged();
     }
 
     [RelayCommand]

--- a/src/Apps/EcoPortal/EcoPortal.Client/Pages/AccountPage.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Pages/AccountPage.razor.css
@@ -1,0 +1,237 @@
+/* ==========================================================================
+   Account Page Container
+   ========================================================================== */
+.account-page {
+    background: var(--mud-palette-background);
+    min-height: 100%;
+}
+
+.page-enter {
+    animation: pageEnter 0.4s ease-out forwards;
+}
+
+@keyframes pageEnter {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* ==========================================================================
+   Editorial Header
+   ========================================================================== */
+.account-header {
+    margin-bottom: 2.5rem;
+    max-width: 640px;
+}
+
+.account-eyebrow {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--mud-palette-secondary);
+    margin-bottom: 0.75rem;
+}
+
+.account-title {
+    font-family: 'Newsreader', serif;
+    font-size: clamp(2rem, 4vw, 3rem);
+    font-weight: 700;
+    line-height: 1.1;
+    color: var(--mud-palette-primary);
+    margin: 0 0 1rem;
+    letter-spacing: -0.02em;
+}
+
+.account-title em {
+    font-style: italic;
+    font-weight: 400;
+    color: var(--mud-palette-primary);
+    opacity: 0.85;
+}
+
+.account-subtitle {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--mud-palette-text-secondary);
+    margin: 0;
+    max-width: 560px;
+}
+
+/* ==========================================================================
+   Profile Card (left sidebar)
+   ========================================================================== */
+::deep .profile-card {
+    background: var(--mud-palette-surface) !important;
+    border: 1px solid var(--mud-palette-lines-default) !important;
+    border-radius: 12px !important;
+}
+
+::deep .profile-avatar {
+    width: 72px !important;
+    height: 72px !important;
+    font-size: 1.75rem !important;
+    font-weight: 600 !important;
+}
+
+::deep .profile-name {
+    font-family: 'Newsreader', serif !important;
+    font-weight: 600 !important;
+    color: var(--mud-palette-primary) !important;
+}
+
+::deep .profile-email {
+    color: var(--mud-palette-text-secondary) !important;
+}
+
+.role-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    border: 1px solid transparent;
+}
+
+.role-pill-admin {
+    background: rgba(38, 176, 80, 0.1);
+    color: #1e8c3e;
+    border-color: rgba(38, 176, 80, 0.25);
+}
+
+.role-pill-member {
+    background: var(--mud-palette-background-gray);
+    color: var(--mud-palette-text-secondary);
+    border-color: var(--mud-palette-lines-default);
+}
+
+.role-dot {
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.profile-stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+
+.profile-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.profile-stat-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--mud-palette-secondary);
+}
+
+.profile-stat-value {
+    font-family: 'Newsreader', serif;
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--mud-palette-primary);
+}
+
+/* ==========================================================================
+   Quick Links Card
+   ========================================================================== */
+::deep .quick-links-card {
+    background: var(--mud-palette-surface) !important;
+    border: 1px solid var(--mud-palette-lines-default) !important;
+    border-radius: 12px !important;
+    overflow: hidden;
+}
+
+.section-heading {
+    padding: 1rem 1.25rem 0.5rem;
+}
+
+::deep .section-heading .mud-typography-h6 {
+    font-family: 'Newsreader', serif;
+    font-weight: 600;
+    color: var(--mud-palette-primary);
+}
+
+::deep .quick-link-item {
+    padding: 0.5rem 0.75rem;
+}
+
+.quick-link {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+}
+
+::deep .quick-link-icon {
+    color: var(--mud-palette-primary) !important;
+}
+
+.quick-link-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+
+.quick-link-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--mud-palette-text-primary);
+}
+
+.quick-link-subtitle {
+    font-size: 0.75rem;
+    color: var(--mud-palette-text-secondary);
+}
+
+/* ==========================================================================
+   Sign Out Card
+   ========================================================================== */
+::deep .signout-card {
+    background: rgba(235, 83, 83, 0.04) !important;
+    border: 1px solid rgba(235, 83, 83, 0.25) !important;
+    border-radius: 12px !important;
+}
+
+.signout-title {
+    font-weight: 600;
+    color: var(--mud-palette-error);
+}
+
+.signout-description {
+    color: var(--mud-palette-text-secondary);
+    max-width: 480px;
+}
+
+::deep .signout-btn {
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+@media (max-width: 960px) {
+    .account-header {
+        margin-bottom: 1.5rem;
+    }
+
+    ::deep .signout-card .mud-stack-row {
+        flex-direction: column;
+        align-items: flex-start !important;
+    }
+
+    ::deep .signout-btn {
+        align-self: stretch;
+    }
+}


### PR DESCRIPTION
## Summary
- Two-column editorial layout for the Account page: profile sidebar (avatar, role pill, member-since/sensor-count stats, quick links) + main content with settings and subscribed sensors
- Restyled `AccountSettingsSection` and `SubscribedSensorsSection` as scoped-CSS `MudPaper` cards instead of bordered `MudCard`s
- `SubscribedSensorsSection` switched to the `IFetch<>` pattern (drops the `_isLoading` bool + try/finally wrapper) and now renders `SensorListItem`s
- Adds scoped CSS files for `AccountPage`, `AccountSettingsSection`, `SubscribedSensorsSection`
- Adds `docs/bioacoustics.md` overview (what bioacoustics is, why it matters, how it fits a low-budget research program)

## Test plan
- [ ] Run EcoPortal locally and visit `/account` while signed in
- [ ] Verify profile sidebar renders avatar, role pill (Administrator vs Member), member-since, and live sensor count
- [ ] Edit display name and email — flows still work, snackbars fire
- [ ] Subscribed Sensors section: empty state, loading skeleton, populated list, "View all subscriptions" footer
- [ ] Check responsive behavior at md/sm breakpoints (sidebar collapses below content)