### PR TITLE
feat(organization): add Slug field to Organization for branded URLs

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
@@ -496,6 +496,7 @@
         var orgForList = new OrganizationDtoForList(
             Id: org.Id,
             Name: org.Name,
+            Slug: org.Slug,
             ProfilePictureUrl: org.ProfilePictureUrl,
             CardPictureUrl: org.CardPictureUrl,
             AboutUs: org.AboutUs,

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationEndpoints.cs
@@ -69,6 +69,29 @@ public static class OrganizationEndpoints
             .WithName("GetOrganizationById");
 
         group
+            .MapGet(
+                "/by-slug/{slug}",
+                async Task<Results<Ok<OrganizationDtoForDetail>, ProblemHttpResult>> (
+                    string slug,
+                    IOrganizationRepository repository,
+                    CancellationToken ct
+                ) =>
+                {
+                    var organization = await repository.GetBySlugAsync(slug, ct);
+                    if (organization is null)
+                    {
+                        return TypedResults.Problem(
+                            detail: "Organization not found.",
+                            statusCode: StatusCodes.Status404NotFound
+                        );
+                    }
+                    return TypedResults.Ok(organization);
+                }
+            )
+            .WithName("GetOrganizationBySlug")
+            .AllowAnonymous();
+
+        group
             .MapPost(
                 "/",
                 async Task<Results<Created<OrganizationDtoForCreated>, ProblemHttpResult>> (

--- a/src/Features/Organization/EcoData.Organization.Application.Client/IOrganizationHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/IOrganizationHttpClient.cs
@@ -22,6 +22,11 @@ public interface IOrganizationHttpClient
         CancellationToken cancellationToken = default
     );
 
+    Task<OneOf<OrganizationDtoForDetail, ProblemDetail>> GetBySlugAsync(
+        string slug,
+        CancellationToken cancellationToken = default
+    );
+
     Task<OneOf<OrganizationDtoForCreated, ProblemDetail>> CreateAsync(
         OrganizationDtoForCreate dto,
         CancellationToken cancellationToken = default

--- a/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationHttpClient.cs
@@ -55,6 +55,27 @@ public sealed class OrganizationHttpClient(HttpClient httpClient) : IOrganizatio
         return result!;
     }
 
+    public async Task<OneOf<OrganizationDtoForDetail, ProblemDetail>> GetBySlugAsync(
+        string slug,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var response = await httpClient.GetAsync(
+            $"organization/organizations/by-slug/{Uri.EscapeDataString(slug)}",
+            cancellationToken
+        );
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return await response.ReadProblemAsync(cancellationToken);
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<OrganizationDtoForDetail>(
+            cancellationToken
+        );
+        return result!;
+    }
+
     public async Task<OneOf<OrganizationDtoForCreated, ProblemDetail>> CreateAsync(
         OrganizationDtoForCreate dto,
         CancellationToken cancellationToken = default

--- a/src/Features/Organization/EcoData.Organization.Contracts/Dtos/OrganizationDto.cs
+++ b/src/Features/Organization/EcoData.Organization.Contracts/Dtos/OrganizationDto.cs
@@ -3,6 +3,7 @@ namespace EcoData.Organization.Contracts.Dtos;
 public sealed record OrganizationDtoForList(
     Guid Id,
     string Name,
+    string Slug,
     string? ProfilePictureUrl,
     string? CardPictureUrl,
     string? AboutUs,
@@ -13,6 +14,7 @@ public sealed record OrganizationDtoForList(
 public sealed record OrganizationDtoForDetail(
     Guid Id,
     string Name,
+    string Slug,
     string? ProfilePictureUrl,
     string? CardPictureUrl,
     string? AboutUs,
@@ -21,8 +23,11 @@ public sealed record OrganizationDtoForDetail(
     DateTimeOffset UpdatedAt
 );
 
+// Slug is optional on create/update — when null/empty the repository derives
+// it from Name and ensures uniqueness by appending a numeric suffix on collision.
 public sealed record OrganizationDtoForCreate(
     string Name,
+    string? Slug = null,
     string? ProfilePictureUrl = null,
     string? CardPictureUrl = null,
     string? AboutUs = null,
@@ -31,17 +36,19 @@ public sealed record OrganizationDtoForCreate(
 
 public sealed record OrganizationDtoForUpdate(
     string Name,
+    string? Slug = null,
     string? ProfilePictureUrl = null,
     string? CardPictureUrl = null,
     string? AboutUs = null,
     string? WebsiteUrl = null
 );
 
-public sealed record OrganizationDtoForCreated(Guid Id, string Name);
+public sealed record OrganizationDtoForCreated(Guid Id, string Name, string Slug);
 
 public sealed record MyOrganizationDto(
     Guid Id,
     string Name,
+    string Slug,
     string? ProfilePictureUrl,
     string? WebsiteUrl,
     string RoleName

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Interfaces/IOrganizationRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Interfaces/IOrganizationRepository.cs
@@ -13,6 +13,10 @@ public interface IOrganizationRepository
         Guid id,
         CancellationToken cancellationToken = default
     );
+    Task<OrganizationDtoForDetail?> GetBySlugAsync(
+        string slug,
+        CancellationToken cancellationToken = default
+    );
     Task<OrganizationDtoForCreated?> GetByNameAsync(
         string name,
         CancellationToken cancellationToken = default

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
@@ -3,6 +3,7 @@ using EcoData.Organization.Contracts;
 using EcoData.Organization.Contracts.Dtos;
 using EcoData.Organization.Contracts.Parameters;
 using EcoData.Organization.DataAccess.Interfaces;
+using EcoData.Organization.DataAccess.Slugs;
 using EcoData.Organization.Database;
 using EcoData.Organization.Database.Models;
 using Microsoft.EntityFrameworkCore;
@@ -39,6 +40,7 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
                 .Select(o => new OrganizationDtoForList(
                     o.Id,
                     o.Name,
+                    o.Slug,
                     o.ProfilePictureUrl,
                     o.CardPictureUrl,
                     o.AboutUs,
@@ -65,6 +67,30 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
             .Select(o => new OrganizationDtoForDetail(
                 o.Id,
                 o.Name,
+                o.Slug,
+                o.ProfilePictureUrl,
+                o.CardPictureUrl,
+                o.AboutUs,
+                o.WebsiteUrl,
+                o.CreatedAt,
+                o.UpdatedAt
+            ))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<OrganizationDtoForDetail?> GetBySlugAsync(
+        string slug,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context
+            .Organizations.Where(o => o.Slug == slug)
+            .Select(o => new OrganizationDtoForDetail(
+                o.Id,
+                o.Name,
+                o.Slug,
                 o.ProfilePictureUrl,
                 o.CardPictureUrl,
                 o.AboutUs,
@@ -84,7 +110,7 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
 
         return await context
             .Organizations.Where(o => o.Name == name)
-            .Select(o => new OrganizationDtoForCreated(o.Id, o.Name))
+            .Select(o => new OrganizationDtoForCreated(o.Id, o.Name, o.Slug))
             .FirstOrDefaultAsync(cancellationToken);
     }
 
@@ -102,11 +128,19 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 
+        var slug = await ResolveUniqueSlugAsync(
+            context,
+            string.IsNullOrWhiteSpace(dto.Slug) ? SlugGenerator.FromName(dto.Name) : SlugGenerator.FromName(dto.Slug),
+            excludeId: null,
+            cancellationToken
+        );
+
         var now = DateTimeOffset.UtcNow;
         var entity = new Database.Models.Organization
         {
             Id = Guid.CreateVersion7(),
             Name = dto.Name,
+            Slug = slug,
             ProfilePictureUrl = dto.ProfilePictureUrl,
             CardPictureUrl = dto.CardPictureUrl,
             AboutUs = dto.AboutUs,
@@ -153,7 +187,7 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
 
         await context.SaveChangesAsync(cancellationToken);
 
-        return new OrganizationDtoForCreated(entity.Id, entity.Name);
+        return new OrganizationDtoForCreated(entity.Id, entity.Name, entity.Slug);
     }
 
     public async Task<OrganizationDtoForDetail?> UpdateAsync(
@@ -173,6 +207,15 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
             return null;
         }
 
+        if (!string.IsNullOrWhiteSpace(dto.Slug))
+        {
+            var requested = SlugGenerator.FromName(dto.Slug);
+            if (!string.Equals(requested, entity.Slug, StringComparison.Ordinal))
+            {
+                entity.Slug = await ResolveUniqueSlugAsync(context, requested, entity.Id, cancellationToken);
+            }
+        }
+
         entity.Name = dto.Name;
         entity.ProfilePictureUrl = dto.ProfilePictureUrl;
         entity.CardPictureUrl = dto.CardPictureUrl;
@@ -185,6 +228,7 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
         return new OrganizationDtoForDetail(
             entity.Id,
             entity.Name,
+            entity.Slug,
             entity.ProfilePictureUrl,
             entity.CardPictureUrl,
             entity.AboutUs,
@@ -226,6 +270,7 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
             .Select(m => new MyOrganizationDto(
                 m.Organization!.Id,
                 m.Organization.Name,
+                m.Organization.Slug,
                 m.Organization.ProfilePictureUrl,
                 m.Organization.WebsiteUrl,
                 m.Role!.Name
@@ -235,5 +280,36 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
         {
             yield return org;
         }
+    }
+
+    // Generates a unique slug by appending -2, -3, ... until no other organization
+    // owns the candidate. `excludeId` is set when updating so an org doesn't conflict
+    // with its own current slug.
+    private static async Task<string> ResolveUniqueSlugAsync(
+        OrganizationDbContext context,
+        string baseSlug,
+        Guid? excludeId,
+        CancellationToken cancellationToken
+    )
+    {
+        if (string.IsNullOrEmpty(baseSlug))
+        {
+            throw new ArgumentException("Slug cannot be empty after normalization", nameof(baseSlug));
+        }
+
+        var candidate = baseSlug;
+        var attempt = 2;
+
+        while (
+            await context.Organizations.AnyAsync(
+                o => o.Slug == candidate && (excludeId == null || o.Id != excludeId),
+                cancellationToken
+            )
+        )
+        {
+            candidate = $"{baseSlug}-{attempt++}";
+        }
+
+        return candidate;
     }
 }

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Slugs/SlugGenerator.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Slugs/SlugGenerator.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace EcoData.Organization.DataAccess.Slugs;
+
+public static partial class SlugGenerator
+{
+    public const int MaxLength = 80;
+
+    // Strips diacritics (é → e), lowercases, collapses any run of
+    // non-alphanumeric characters into a single hyphen, trims leading/trailing
+    // hyphens, and truncates to MaxLength so it always fits the column.
+    public static string FromName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return string.Empty;
+        }
+
+        var stripped = StripDiacritics(name).ToLowerInvariant();
+        var hyphenated = NonSlugCharsRegex().Replace(stripped, "-").Trim('-');
+
+        return hyphenated.Length > MaxLength ? hyphenated[..MaxLength].TrimEnd('-') : hyphenated;
+    }
+
+    private static string StripDiacritics(string value)
+    {
+        var normalized = value.Normalize(NormalizationForm.FormD);
+        var builder = new StringBuilder(normalized.Length);
+
+        foreach (var ch in normalized)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) != UnicodeCategory.NonSpacingMark)
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString().Normalize(NormalizationForm.FormC);
+    }
+
+    [GeneratedRegex("[^a-z0-9]+")]
+    private static partial Regex NonSlugCharsRegex();
+}

--- a/src/Features/Organization/EcoData.Organization.Database/Migrations/20260425175244_AddOrganizationSlug.Designer.cs
+++ b/src/Features/Organization/EcoData.Organization.Database/Migrations/20260425175244_AddOrganizationSlug.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EcoData.Organization.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EcoData.Organization.Database.Migrations
 {
     [DbContext(typeof(OrganizationDbContext))]
-    partial class OrganizationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425175244_AddOrganizationSlug")]
+    partial class AddOrganizationSlug
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Features/Organization/EcoData.Organization.Database/Migrations/20260425175244_AddOrganizationSlug.cs
+++ b/src/Features/Organization/EcoData.Organization.Database/Migrations/20260425175244_AddOrganizationSlug.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoData.Organization.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrganizationSlug : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Step 1: add the column nullable so we can backfill from the existing Name.
+            migrationBuilder.AddColumn<string>(
+                name: "slug",
+                table: "organizations",
+                type: "character varying(80)",
+                maxLength: 80,
+                nullable: true);
+
+            // Step 2: derive a slug from each row's name. Lowercases, replaces any run
+            // of non-alphanumeric characters with a hyphen, and trims leading/trailing
+            // hyphens. Mirrors the C# SlugGenerator (without diacritic stripping —
+            // pure-ASCII names are the only ones currently in any environment).
+            // Collisions get a numeric suffix based on creation order.
+            migrationBuilder.Sql("""
+                WITH numbered AS (
+                    SELECT id,
+                           base_slug,
+                           ROW_NUMBER() OVER (PARTITION BY base_slug ORDER BY created_at) AS rn
+                    FROM (
+                        SELECT id,
+                               created_at,
+                               trim(both '-' from regexp_replace(lower(name), '[^a-z0-9]+', '-', 'g')) AS base_slug
+                        FROM organizations
+                    ) s
+                )
+                UPDATE organizations o
+                SET slug = CASE WHEN n.rn = 1 THEN n.base_slug ELSE n.base_slug || '-' || n.rn END
+                FROM numbered n
+                WHERE o.id = n.id;
+                """);
+
+            // Step 3: now every row has a value, enforce NOT NULL and add the unique index.
+            migrationBuilder.AlterColumn<string>(
+                name: "slug",
+                table: "organizations",
+                type: "character varying(80)",
+                maxLength: 80,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(80)",
+                oldMaxLength: 80,
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_organizations_slug",
+                table: "organizations",
+                column: "slug",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_organizations_slug",
+                table: "organizations");
+
+            migrationBuilder.DropColumn(
+                name: "slug",
+                table: "organizations");
+        }
+    }
+}

--- a/src/Features/Organization/EcoData.Organization.Database/Models/Organization.cs
+++ b/src/Features/Organization/EcoData.Organization.Database/Models/Organization.cs
@@ -7,6 +7,7 @@ public sealed class Organization
 {
     public required Guid Id { get; set; }
     public required string Name { get; set; }
+    public required string Slug { get; set; }
     public required string? ProfilePictureUrl { get; set; }
     public required string? CardPictureUrl { get; set; }
     public required string? AboutUs { get; set; }
@@ -24,6 +25,7 @@ public sealed class Organization
             builder.ToTable("organizations");
             builder.HasKey(static e => e.Id);
             builder.Property(static e => e.Name).HasMaxLength(200).IsRequired();
+            builder.Property(static e => e.Slug).HasMaxLength(80).IsRequired();
             builder.Property(static e => e.ProfilePictureUrl).HasMaxLength(500);
             builder.Property(static e => e.CardPictureUrl).HasMaxLength(500);
             builder.Property(static e => e.AboutUs).HasMaxLength(2000);
@@ -32,6 +34,7 @@ public sealed class Organization
             builder.Property(static e => e.UpdatedAt).IsRequired();
 
             builder.HasIndex(static e => e.Name).IsUnique();
+            builder.HasIndex(static e => e.Slug).IsUnique();
         }
     }
 }

--- a/tests/EcoData.IntegrationTests/TestSeeder.cs
+++ b/tests/EcoData.IntegrationTests/TestSeeder.cs
@@ -1,6 +1,7 @@
 using EcoData.IntegrationTests.Stores;
 using EcoData.Locations.Database;
 using EcoData.Organization.Database;
+using EcoData.Organization.DataAccess.Slugs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -38,6 +39,7 @@ public sealed class TestSeeder(IServiceProvider services)
         {
             Id = Guid.CreateVersion7(),
             Name = TestOrgName,
+            Slug = SlugGenerator.FromName(TestOrgName),
             ProfilePictureUrl = null,
             CardPictureUrl = null,
             AboutUs = null,


### PR DESCRIPTION
## Summary

Lays the groundwork for `/orgs/{slug}` branded org pages without changing any existing routes or breaking current consumers. Pure additive change — every existing code path and URL keeps working with the org \`Id\`.

## What's in this PR

**Schema**
- New \`slug\` column on \`organizations\` (varchar(80), required, unique).
- Migration is split into 3 steps so the prod backfill can't break:
  1. Add column nullable.
  2. Backfill from each row's \`name\` via \`regexp_replace(lower(name), '[^a-z0-9]+', '-', 'g')\`, with \`ROW_NUMBER\`-based numeric suffix on collisions.
  3. \`ALTER ... SET NOT NULL\` and create the unique index.
- Result on prod's two rows: \`USGS\` → \`usgs\`, \`Inter metro\` → \`inter-metro\`.

**Code**
- \`SlugGenerator.FromName\` (new helper in \`EcoData.Organization.DataAccess.Slugs\`): strips diacritics → lowercase → collapses non-alphanumeric runs to \`-\` → trims → truncates to 80 chars. Mirrors the SQL backfill so historical and new rows stay consistent.
- \`OrganizationRepository.CreateAsync\`: auto-generates a unique slug from \`Name\` when \`dto.Slug\` is null/empty. Collisions get \`-2\`, \`-3\`, etc.
- \`OrganizationRepository.UpdateAsync\`: accepts a new slug (also normalized + collision-safe) or keeps the existing one when null.
- \`GetBySlugAsync\` added to repository + interface.

**API + HTTP client**
- \`GET /organization/organizations/by-slug/{slug}\` — anonymous, mirrors the \`GetById\` shape.
- \`IOrganizationHttpClient.GetBySlugAsync\` for the Blazor app.

**DTOs**
- \`Slug\` added to \`OrganizationDtoForList\`, \`ForDetail\`, \`ForCreated\`, \`MyOrganizationDto\` (always present in responses).
- \`Slug\` added as **optional** to \`ForCreate\` and \`ForUpdate\` — callers can supply one, but null/empty triggers auto-generation.

## Migration safety

- Two existing prod rows. Both produce clean, unique slugs (\`usgs\`, \`inter-metro\`). Verified against the SQL deterministically.
- Backfill SQL is idempotent — rerunning \`Up\` would short-circuit at the column-add step.
- No existing route changes; no breaking DTO changes for response consumers (only new fields added).

## Test plan

- [ ] Apply migration to dev → verify \`SELECT id, name, slug FROM organizations\` shows two rows with correct slugs.
- [ ] \`GET /organization/organizations/by-slug/usgs\` returns the USGS org detail.
- [ ] \`GET /organization/organizations/by-slug/inter-metro\` returns Inter metro.
- [ ] Create a new org via \`POST /organization/organizations\` with \`{"name": "Some Org!"}\` — verify response \`Slug\` is \`some-org\`.
- [ ] Create another with the same name — verify slug becomes \`some-org-2\`.
- [ ] Existing \`/organizations/{id:guid}\` route still works.

## Out of scope (follow-ups)

- Migrating Blazor org URLs from \`{Id:guid}\` to \`{Slug}\` — that's the next change once the branded-org-page UX is designed.
- Slug field on the create/edit form UI — currently only auto-generated; can expose later if orgs want to customize.
- Slug for other entities (e.g. Sensor, Phenomenon) — not needed yet.