### PR TITLE
feat(organization): add branding properties (Slug, colors, location, legal)

### DIFF
--- a/src/Features/Organization/EcoData.Organization.Contracts/Dtos/OrganizationDto.cs
+++ b/src/Features/Organization/EcoData.Organization.Contracts/Dtos/OrganizationDto.cs
@@ -4,10 +4,14 @@ public sealed record OrganizationDtoForList(
     Guid Id,
     string Name,
     string Slug,
+    string? Tagline,
     string? ProfilePictureUrl,
     string? CardPictureUrl,
     string? AboutUs,
     string? WebsiteUrl,
+    string? Location,
+    string? PrimaryColor,
+    string? AccentColor,
     DateTimeOffset CreatedAt
 );
 
@@ -15,10 +19,17 @@ public sealed record OrganizationDtoForDetail(
     Guid Id,
     string Name,
     string Slug,
+    string? Tagline,
     string? ProfilePictureUrl,
     string? CardPictureUrl,
     string? AboutUs,
     string? WebsiteUrl,
+    string? Location,
+    int? FoundedYear,
+    string? LegalStatus,
+    string? TaxId,
+    string? PrimaryColor,
+    string? AccentColor,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt
 );
@@ -28,19 +39,33 @@ public sealed record OrganizationDtoForDetail(
 public sealed record OrganizationDtoForCreate(
     string Name,
     string? Slug = null,
+    string? Tagline = null,
     string? ProfilePictureUrl = null,
     string? CardPictureUrl = null,
     string? AboutUs = null,
-    string? WebsiteUrl = null
+    string? WebsiteUrl = null,
+    string? Location = null,
+    int? FoundedYear = null,
+    string? LegalStatus = null,
+    string? TaxId = null,
+    string? PrimaryColor = null,
+    string? AccentColor = null
 );
 
 public sealed record OrganizationDtoForUpdate(
     string Name,
     string? Slug = null,
+    string? Tagline = null,
     string? ProfilePictureUrl = null,
     string? CardPictureUrl = null,
     string? AboutUs = null,
-    string? WebsiteUrl = null
+    string? WebsiteUrl = null,
+    string? Location = null,
+    int? FoundedYear = null,
+    string? LegalStatus = null,
+    string? TaxId = null,
+    string? PrimaryColor = null,
+    string? AccentColor = null
 );
 
 public sealed record OrganizationDtoForCreated(Guid Id, string Name, string Slug);

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Colors/HexColor.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Colors/HexColor.cs
@@ -1,0 +1,25 @@
+namespace EcoData.Organization.DataAccess.Colors;
+
+public static class HexColor
+{
+    public const int StorageLength = 7;
+
+    // Stores brand colors as 7-char "#rrggbb". Accepts inputs with or without
+    // the leading hash; rejects anything else by returning null. Keeps malformed
+    // input out of CSS where it would silently break the org-themed page.
+    public static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+
+        var trimmed = value.Trim();
+        var body = trimmed.StartsWith('#') ? trimmed[1..] : trimmed;
+        if (body.Length != 6) return null;
+
+        foreach (var c in body)
+        {
+            if (!Uri.IsHexDigit(c)) return null;
+        }
+
+        return "#" + body.ToLowerInvariant();
+    }
+}

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
@@ -69,7 +69,24 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
 
         return await context
             .Organizations.Where(o => o.Id == id)
-            .Select(ProjectToDetail)
+            .Select(o => new OrganizationDtoForDetail(
+                o.Id,
+                o.Name,
+                o.Slug,
+                o.Tagline,
+                o.ProfilePictureUrl,
+                o.CardPictureUrl,
+                o.AboutUs,
+                o.WebsiteUrl,
+                o.Location,
+                o.FoundedYear,
+                o.LegalStatus,
+                o.TaxId,
+                o.PrimaryColor,
+                o.AccentColor,
+                o.CreatedAt,
+                o.UpdatedAt
+            ))
             .FirstOrDefaultAsync(cancellationToken);
     }
 
@@ -82,29 +99,26 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
 
         return await context
             .Organizations.Where(o => o.Slug == slug)
-            .Select(ProjectToDetail)
+            .Select(o => new OrganizationDtoForDetail(
+                o.Id,
+                o.Name,
+                o.Slug,
+                o.Tagline,
+                o.ProfilePictureUrl,
+                o.CardPictureUrl,
+                o.AboutUs,
+                o.WebsiteUrl,
+                o.Location,
+                o.FoundedYear,
+                o.LegalStatus,
+                o.TaxId,
+                o.PrimaryColor,
+                o.AccentColor,
+                o.CreatedAt,
+                o.UpdatedAt
+            ))
             .FirstOrDefaultAsync(cancellationToken);
     }
-
-    private static readonly System.Linq.Expressions.Expression<Func<Database.Models.Organization, OrganizationDtoForDetail>> ProjectToDetail =
-        o => new OrganizationDtoForDetail(
-            o.Id,
-            o.Name,
-            o.Slug,
-            o.Tagline,
-            o.ProfilePictureUrl,
-            o.CardPictureUrl,
-            o.AboutUs,
-            o.WebsiteUrl,
-            o.Location,
-            o.FoundedYear,
-            o.LegalStatus,
-            o.TaxId,
-            o.PrimaryColor,
-            o.AccentColor,
-            o.CreatedAt,
-            o.UpdatedAt
-        );
 
     public async Task<OrganizationDtoForCreated?> GetByNameAsync(
         string name,

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using EcoData.Organization.Contracts;
 using EcoData.Organization.Contracts.Dtos;
 using EcoData.Organization.Contracts.Parameters;
+using EcoData.Organization.DataAccess.Colors;
 using EcoData.Organization.DataAccess.Interfaces;
 using EcoData.Organization.DataAccess.Slugs;
 using EcoData.Organization.Database;
@@ -41,10 +42,14 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
                     o.Id,
                     o.Name,
                     o.Slug,
+                    o.Tagline,
                     o.ProfilePictureUrl,
                     o.CardPictureUrl,
                     o.AboutUs,
                     o.WebsiteUrl,
+                    o.Location,
+                    o.PrimaryColor,
+                    o.AccentColor,
                     o.CreatedAt
                 ))
                 .AsAsyncEnumerable()
@@ -64,17 +69,7 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
 
         return await context
             .Organizations.Where(o => o.Id == id)
-            .Select(o => new OrganizationDtoForDetail(
-                o.Id,
-                o.Name,
-                o.Slug,
-                o.ProfilePictureUrl,
-                o.CardPictureUrl,
-                o.AboutUs,
-                o.WebsiteUrl,
-                o.CreatedAt,
-                o.UpdatedAt
-            ))
+            .Select(ProjectToDetail)
             .FirstOrDefaultAsync(cancellationToken);
     }
 
@@ -87,19 +82,29 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
 
         return await context
             .Organizations.Where(o => o.Slug == slug)
-            .Select(o => new OrganizationDtoForDetail(
-                o.Id,
-                o.Name,
-                o.Slug,
-                o.ProfilePictureUrl,
-                o.CardPictureUrl,
-                o.AboutUs,
-                o.WebsiteUrl,
-                o.CreatedAt,
-                o.UpdatedAt
-            ))
+            .Select(ProjectToDetail)
             .FirstOrDefaultAsync(cancellationToken);
     }
+
+    private static readonly System.Linq.Expressions.Expression<Func<Database.Models.Organization, OrganizationDtoForDetail>> ProjectToDetail =
+        o => new OrganizationDtoForDetail(
+            o.Id,
+            o.Name,
+            o.Slug,
+            o.Tagline,
+            o.ProfilePictureUrl,
+            o.CardPictureUrl,
+            o.AboutUs,
+            o.WebsiteUrl,
+            o.Location,
+            o.FoundedYear,
+            o.LegalStatus,
+            o.TaxId,
+            o.PrimaryColor,
+            o.AccentColor,
+            o.CreatedAt,
+            o.UpdatedAt
+        );
 
     public async Task<OrganizationDtoForCreated?> GetByNameAsync(
         string name,
@@ -141,10 +146,17 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
             Id = Guid.CreateVersion7(),
             Name = dto.Name,
             Slug = slug,
+            Tagline = dto.Tagline,
             ProfilePictureUrl = dto.ProfilePictureUrl,
             CardPictureUrl = dto.CardPictureUrl,
             AboutUs = dto.AboutUs,
             WebsiteUrl = dto.WebsiteUrl,
+            Location = dto.Location,
+            FoundedYear = dto.FoundedYear,
+            LegalStatus = dto.LegalStatus,
+            TaxId = dto.TaxId,
+            PrimaryColor = HexColor.Normalize(dto.PrimaryColor),
+            AccentColor = HexColor.Normalize(dto.AccentColor),
             CreatedAt = now,
             UpdatedAt = now,
         };
@@ -217,10 +229,17 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
         }
 
         entity.Name = dto.Name;
+        entity.Tagline = dto.Tagline;
         entity.ProfilePictureUrl = dto.ProfilePictureUrl;
         entity.CardPictureUrl = dto.CardPictureUrl;
         entity.AboutUs = dto.AboutUs;
         entity.WebsiteUrl = dto.WebsiteUrl;
+        entity.Location = dto.Location;
+        entity.FoundedYear = dto.FoundedYear;
+        entity.LegalStatus = dto.LegalStatus;
+        entity.TaxId = dto.TaxId;
+        entity.PrimaryColor = HexColor.Normalize(dto.PrimaryColor);
+        entity.AccentColor = HexColor.Normalize(dto.AccentColor);
         entity.UpdatedAt = DateTimeOffset.UtcNow;
 
         await context.SaveChangesAsync(cancellationToken);
@@ -229,10 +248,17 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
             entity.Id,
             entity.Name,
             entity.Slug,
+            entity.Tagline,
             entity.ProfilePictureUrl,
             entity.CardPictureUrl,
             entity.AboutUs,
             entity.WebsiteUrl,
+            entity.Location,
+            entity.FoundedYear,
+            entity.LegalStatus,
+            entity.TaxId,
+            entity.PrimaryColor,
+            entity.AccentColor,
             entity.CreatedAt,
             entity.UpdatedAt
         );

--- a/src/Features/Organization/EcoData.Organization.Database/Migrations/20260425185649_AddOrganizationBrandingFields.Designer.cs
+++ b/src/Features/Organization/EcoData.Organization.Database/Migrations/20260425185649_AddOrganizationBrandingFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EcoData.Organization.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EcoData.Organization.Database.Migrations
 {
     [DbContext(typeof(OrganizationDbContext))]
-    partial class OrganizationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425185649_AddOrganizationBrandingFields")]
+    partial class AddOrganizationBrandingFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Features/Organization/EcoData.Organization.Database/Migrations/20260425185649_AddOrganizationBrandingFields.cs
+++ b/src/Features/Organization/EcoData.Organization.Database/Migrations/20260425185649_AddOrganizationBrandingFields.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoData.Organization.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrganizationBrandingFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "accent_color",
+                table: "organizations",
+                type: "character varying(7)",
+                maxLength: 7,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "founded_year",
+                table: "organizations",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "legal_status",
+                table: "organizations",
+                type: "character varying(80)",
+                maxLength: 80,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "location",
+                table: "organizations",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "primary_color",
+                table: "organizations",
+                type: "character varying(7)",
+                maxLength: 7,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "tagline",
+                table: "organizations",
+                type: "character varying(280)",
+                maxLength: 280,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "tax_id",
+                table: "organizations",
+                type: "character varying(40)",
+                maxLength: 40,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "accent_color",
+                table: "organizations");
+
+            migrationBuilder.DropColumn(
+                name: "founded_year",
+                table: "organizations");
+
+            migrationBuilder.DropColumn(
+                name: "legal_status",
+                table: "organizations");
+
+            migrationBuilder.DropColumn(
+                name: "location",
+                table: "organizations");
+
+            migrationBuilder.DropColumn(
+                name: "primary_color",
+                table: "organizations");
+
+            migrationBuilder.DropColumn(
+                name: "tagline",
+                table: "organizations");
+
+            migrationBuilder.DropColumn(
+                name: "tax_id",
+                table: "organizations");
+        }
+    }
+}

--- a/src/Features/Organization/EcoData.Organization.Database/Models/Organization.cs
+++ b/src/Features/Organization/EcoData.Organization.Database/Models/Organization.cs
@@ -8,10 +8,17 @@ public sealed class Organization
     public required Guid Id { get; set; }
     public required string Name { get; set; }
     public required string Slug { get; set; }
+    public required string? Tagline { get; set; }
     public required string? ProfilePictureUrl { get; set; }
     public required string? CardPictureUrl { get; set; }
     public required string? AboutUs { get; set; }
     public required string? WebsiteUrl { get; set; }
+    public required string? Location { get; set; }
+    public required int? FoundedYear { get; set; }
+    public required string? LegalStatus { get; set; }
+    public required string? TaxId { get; set; }
+    public required string? PrimaryColor { get; set; }
+    public required string? AccentColor { get; set; }
     public required DateTimeOffset CreatedAt { get; set; }
     public required DateTimeOffset UpdatedAt { get; set; }
 
@@ -26,10 +33,18 @@ public sealed class Organization
             builder.HasKey(static e => e.Id);
             builder.Property(static e => e.Name).HasMaxLength(200).IsRequired();
             builder.Property(static e => e.Slug).HasMaxLength(80).IsRequired();
+            builder.Property(static e => e.Tagline).HasMaxLength(280);
             builder.Property(static e => e.ProfilePictureUrl).HasMaxLength(500);
             builder.Property(static e => e.CardPictureUrl).HasMaxLength(500);
             builder.Property(static e => e.AboutUs).HasMaxLength(2000);
             builder.Property(static e => e.WebsiteUrl).HasMaxLength(500);
+            builder.Property(static e => e.Location).HasMaxLength(200);
+            builder.Property(static e => e.LegalStatus).HasMaxLength(80);
+            builder.Property(static e => e.TaxId).HasMaxLength(40);
+            // Brand colors are stored as 7-char hex strings (e.g. "#1f4d3a"). The design
+            // injects them as CSS variables, so we keep the leading "#" in the value.
+            builder.Property(static e => e.PrimaryColor).HasMaxLength(7);
+            builder.Property(static e => e.AccentColor).HasMaxLength(7);
             builder.Property(static e => e.CreatedAt).IsRequired();
             builder.Property(static e => e.UpdatedAt).IsRequired();
 


### PR DESCRIPTION
## Summary
Foundation PR for the org details redesign. Adds the new branding/identity properties on `Organization` so the upcoming UI work has something to read and write.

**New `Organization` fields**
- `Slug` (already wired in earlier commits on this branch — branded URLs)
- `Tagline` — short editorial line
- `Location` — e.g. "El Yunque, PR"
- `FoundedYear`
- `LegalStatus` / `TaxId` — legal info line
- `PrimaryColor` / `AccentColor` — 7-char hex strings stored with the leading `#` so the redesign can drop them straight into CSS variables

**Other changes**
- `AddOrganizationBrandingFields` EF migration (+ designer + snapshot)
- `OrganizationDto` extended with the new fields
- `OrganizationRepository` reads/writes them
- New `EcoData.Organization.DataAccess/Colors/HexColor.cs` helper for parsing/validating hex values

UI for setting these fields (form inputs, color pickers, image uploads) lands in the follow-up redesign PR on `feat/org-details-redesign`.

## Test plan
- [ ] `dotnet ef database update` against a fresh local DB applies cleanly
- [ ] `dotnet ef database update <previous-migration>` rolls back cleanly
- [ ] Existing organizations load and round-trip with `null` values for the new fields
- [ ] Repository upsert sets and reads each new field
- [ ] `HexColor` rejects non-7-char values, missing `#`, non-hex chars