### PR TITLE
fix(eco-portal): pass new branding fields when constructing OrganizationDtoForList

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
@@ -497,10 +497,14 @@
             Id: org.Id,
             Name: org.Name,
             Slug: org.Slug,
+            Tagline: org.Tagline,
             ProfilePictureUrl: org.ProfilePictureUrl,
             CardPictureUrl: org.CardPictureUrl,
             AboutUs: org.AboutUs,
             WebsiteUrl: org.WebsiteUrl,
+            Location: org.Location,
+            PrimaryColor: org.PrimaryColor,
+            AccentColor: org.AccentColor,
             CreatedAt: org.CreatedAt
         );
 


### PR DESCRIPTION
## Summary
PR #210 added `Tagline`, `Location`, `PrimaryColor`, and `AccentColor` as required parameters on `OrganizationDtoForList`. The repository's `Select` projection was updated, but the only other construction site — `OpenRequestAccessDialog` in `OrganizationDetailsPage.razor` — was not, breaking the build on master after merge.

This fix passes the four new fields from `_organizationFetch.Data` (which is `OrganizationDtoForDetail` and already has them all) through to the `OrganizationDtoForList` constructor.

## Test plan
- [x] `dotnet build src/Apps/EcoPortal/EcoPortal.Client/EcoPortal.Client.csproj` — 0 errors
- [ ] Click "Request access" on an org details page where the user is unauthenticated/non-member; dialog opens with the org preselected and shows the right tagline/colors