### PR TITLE
feat(eco-portal): wire branding fields into Organization create/edit form

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Components/OrganizationForm.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Components/OrganizationForm.razor
@@ -8,6 +8,8 @@
         </MudAlert>
     }
 
+    <MudText Typo="Typo.subtitle1">Identity</MudText>
+
     <MudTextField @bind-Value="Model.Name"
                   Label="Name"
                   Required="true"
@@ -16,6 +18,23 @@
                   Counter="200"
                   Immediate="true"
                   Disabled="IsLoading" />
+
+    <MudTextField @bind-Value="Model.Slug"
+                  Label="Slug"
+                  Placeholder="my-organization"
+                  MaxLength="80"
+                  HelperText="URL-friendly identifier. Leave blank to derive from Name."
+                  Disabled="IsLoading" />
+
+    <MudTextField @bind-Value="Model.Tagline"
+                  Label="Tagline"
+                  MaxLength="280"
+                  Counter="280"
+                  HelperText="Short editorial line shown on the organization page"
+                  Disabled="IsLoading" />
+
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1">Branding</MudText>
 
     <MudTextField @bind-Value="Model.ProfilePictureUrl"
                   Label="Profile Picture URL"
@@ -49,12 +68,22 @@
         </MudStack>
     }
 
-    <MudTextField @bind-Value="Model.WebsiteUrl"
-                  Label="Website URL"
-                  Placeholder="https://example.com"
-                  MaxLength="500"
-                  HelperText="Organization's website (optional)"
+    <MudTextField @bind-Value="Model.PrimaryColor"
+                  Label="Primary Color"
+                  InputType="InputType.Color"
+                  Class="color-field"
+                  HelperText="Used for organization-themed UI accents"
                   Disabled="IsLoading" />
+
+    <MudTextField @bind-Value="Model.AccentColor"
+                  Label="Accent Color"
+                  InputType="InputType.Color"
+                  Class="color-field"
+                  HelperText="Highlights and call-to-action color"
+                  Disabled="IsLoading" />
+
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1">About</MudText>
 
     <MudTextField @bind-Value="Model.AboutUs"
                   Label="About Us"
@@ -63,6 +92,45 @@
                   Counter="2000"
                   HelperText="Description of the organization"
                   Disabled="IsLoading" />
+
+    <MudTextField @bind-Value="Model.WebsiteUrl"
+                  Label="Website URL"
+                  Placeholder="https://example.com"
+                  MaxLength="500"
+                  HelperText="Organization's website"
+                  Disabled="IsLoading" />
+
+    <MudTextField @bind-Value="Model.Location"
+                  Label="Location"
+                  Placeholder="El Yunque, PR"
+                  MaxLength="200"
+                  Disabled="IsLoading" />
+
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.subtitle1">Legal</MudText>
+
+    <MudGrid Spacing="2">
+        <MudItem xs="12" sm="4">
+            <MudNumericField @bind-Value="Model.FoundedYear"
+                             Label="Founded Year"
+                             Min="1800"
+                             Max="2100"
+                             Disabled="IsLoading" />
+        </MudItem>
+        <MudItem xs="12" sm="4">
+            <MudTextField @bind-Value="Model.LegalStatus"
+                          Label="Legal Status"
+                          Placeholder="501(c)(3)"
+                          MaxLength="80"
+                          Disabled="IsLoading" />
+        </MudItem>
+        <MudItem xs="12" sm="4">
+            <MudTextField @bind-Value="Model.TaxId"
+                          Label="Tax ID"
+                          MaxLength="40"
+                          Disabled="IsLoading" />
+        </MudItem>
+    </MudGrid>
 
     <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2" Class="mt-4">
         <MudButton Variant="Variant.Text"
@@ -122,6 +190,12 @@
         [MaxLength(200)]
         public string Name { get; set; } = string.Empty;
 
+        [MaxLength(80)]
+        public string? Slug { get; set; }
+
+        [MaxLength(280)]
+        public string? Tagline { get; set; }
+
         [MaxLength(500)]
         public string? ProfilePictureUrl { get; set; }
 
@@ -133,5 +207,23 @@
 
         [MaxLength(2000)]
         public string? AboutUs { get; set; }
+
+        [MaxLength(200)]
+        public string? Location { get; set; }
+
+        [Range(1800, 2100)]
+        public int? FoundedYear { get; set; }
+
+        [MaxLength(80)]
+        public string? LegalStatus { get; set; }
+
+        [MaxLength(40)]
+        public string? TaxId { get; set; }
+
+        [MaxLength(7)]
+        public string? PrimaryColor { get; set; }
+
+        [MaxLength(7)]
+        public string? AccentColor { get; set; }
     }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Components/OrganizationForm.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Components/OrganizationForm.razor.css
@@ -4,3 +4,26 @@
     object-fit: cover;
     border-radius: 8px;
 }
+
+::deep .color-field input[type="color"] {
+    width: 100%;
+    height: 48px;
+    padding: 4px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+}
+
+::deep .color-field input[type="color"]::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+::deep .color-field input[type="color"]::-webkit-color-swatch {
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 4px;
+}
+
+::deep .color-field input[type="color"]::-moz-color-swatch {
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 4px;
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationCreatePage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationCreatePage.razor
@@ -38,11 +38,19 @@
         }
 
         var dto = new OrganizationDtoForCreate(
-            _model.Name,
-            _model.ProfilePictureUrl,
-            _model.CardPictureUrl,
-            _model.AboutUs,
-            _model.WebsiteUrl
+            Name: _model.Name,
+            Slug: _model.Slug,
+            Tagline: _model.Tagline,
+            ProfilePictureUrl: _model.ProfilePictureUrl,
+            CardPictureUrl: _model.CardPictureUrl,
+            AboutUs: _model.AboutUs,
+            WebsiteUrl: _model.WebsiteUrl,
+            Location: _model.Location,
+            FoundedYear: _model.FoundedYear,
+            LegalStatus: _model.LegalStatus,
+            TaxId: _model.TaxId,
+            PrimaryColor: _model.PrimaryColor,
+            AccentColor: _model.AccentColor
         );
 
         var result = await OrganizationClient.CreateAsync(dto);

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationEditPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationEditPage.razor
@@ -66,10 +66,18 @@
             {
                 _organization = organization;
                 _model.Name = organization.Name;
+                _model.Slug = organization.Slug;
+                _model.Tagline = organization.Tagline;
                 _model.ProfilePictureUrl = organization.ProfilePictureUrl;
                 _model.CardPictureUrl = organization.CardPictureUrl;
                 _model.AboutUs = organization.AboutUs;
                 _model.WebsiteUrl = organization.WebsiteUrl;
+                _model.Location = organization.Location;
+                _model.FoundedYear = organization.FoundedYear;
+                _model.LegalStatus = organization.LegalStatus;
+                _model.TaxId = organization.TaxId;
+                _model.PrimaryColor = organization.PrimaryColor;
+                _model.AccentColor = organization.AccentColor;
             },
             _ => _organization = null
         );
@@ -92,11 +100,19 @@
         }
 
         var dto = new OrganizationDtoForUpdate(
-            _model.Name,
-            _model.ProfilePictureUrl,
-            _model.CardPictureUrl,
-            _model.AboutUs,
-            _model.WebsiteUrl
+            Name: _model.Name,
+            Slug: _model.Slug,
+            Tagline: _model.Tagline,
+            ProfilePictureUrl: _model.ProfilePictureUrl,
+            CardPictureUrl: _model.CardPictureUrl,
+            AboutUs: _model.AboutUs,
+            WebsiteUrl: _model.WebsiteUrl,
+            Location: _model.Location,
+            FoundedYear: _model.FoundedYear,
+            LegalStatus: _model.LegalStatus,
+            TaxId: _model.TaxId,
+            PrimaryColor: _model.PrimaryColor,
+            AccentColor: _model.AccentColor
         );
 
         var result = await OrganizationClient.UpdateAsync(Id, dto);


### PR DESCRIPTION
## Summary
PR #210 added the branding properties to `Organization` (Slug, Tagline, Location, FoundedYear, LegalStatus, TaxId, PrimaryColor, AccentColor) but left the create/edit forms with no UI for them. This PR wires them up.

**Form inputs**
- Grouped into four sections under subtitle headers: **Identity** (Name, Slug, Tagline), **Branding** (Profile/Card URLs, Primary/Accent colors), **About** (About us, Website, Location), **Legal** (FoundedYear, LegalStatus, TaxId).
- `Slug` has a helper note that it's optional and derives from Name when blank.
- Color inputs use `InputType.Color` with scoped CSS so each swatch fills the input width at ~48px tall (stacked, full-width — not the cramped side-by-side from the first pass).
- `FoundedYear` is a `MudNumericField` clamped to 1800–2100.

**Bug fix included**
`OrganizationCreatePage` and `OrganizationEditPage` were calling `new OrganizationDtoForCreate(...)` / `new OrganizationDtoForUpdate(...)` positionally. After PR #210 inserted `Slug` as the second positional parameter, those calls silently shifted: `ProfilePictureUrl` was being sent as `Slug`, `CardPictureUrl` as `Tagline`, etc. Switched both call sites to **named arguments** so this can't drift again.

## Test plan
- [ ] Create a new organization filling every field; verify the org details page shows the right tagline, location, colors
- [ ] Edit an existing org, change colors and tagline, save; confirm the values round-trip
- [ ] Leave Slug blank on create; confirm the API derives it from the Name
- [ ] Provide a Slug that already exists; confirm the repo appends `-2` (existing behavior, just exercised through the form now)
- [ ] Color picker swatch fills the input width and is roughly 48px tall