### PR TITLE
feat(eco-portal): editorial redesign of Organization details page

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
@@ -79,11 +79,11 @@
                     <div class="org-hero-left">
                         <div class="org-hero-eyebrow">
                             <span class="v-line"></span>
-                            <span>@_viewModel.Slug</span>
+                            <MudText Inline="true" Style="color: white;">@_viewModel.Slug</MudText>
                             @if (_viewModel.HasLocation)
                             {
-                                <span class="dot-sep">·</span>
-                                <span>@_viewModel.Location</span>
+                                <MudText Inline="true" Class="dot-sep">·</MudText>
+                                <MudText Inline="true" Style="color: white;">@_viewModel.Location</MudText>
                             }
                         </div>
 
@@ -121,26 +121,26 @@
                             @if (_viewModel.HasWebsite)
                             {
                                 <span class="hmr-item">
-                                    <MudIcon Icon="@Icons.Material.Outlined.Link" Size="Size.Small" />
-                                    <a href="@_viewModel.WebsiteUrl" target="_blank" rel="noopener">@_viewModel.DisplayWebsiteUrl</a>
+                                    <MudIcon Icon="@Icons.Material.Outlined.Link" Size="Size.Small" Style="color: white !important;" />
+                                    <MudLink Href="@_viewModel.WebsiteUrl" Target="_blank" Style="color: white;">@_viewModel.DisplayWebsiteUrl</MudLink>
                                 </span>
                             }
                             @if (_viewModel.HasLocation)
                             {
                                 <span class="hmr-item">
-                                    <MudIcon Icon="@Icons.Material.Outlined.LocationOn" Size="Size.Small" />
-                                    @_viewModel.Location
+                                    <MudIcon Icon="@Icons.Material.Outlined.LocationOn" Size="Size.Small" Style="color: white !important;" />
+                                    <MudText Inline="true" Style="color: white;">@_viewModel.Location</MudText>
                                 </span>
                             }
                             <span class="hmr-item">
-                                <MudIcon Icon="@Icons.Material.Outlined.CalendarMonth" Size="Size.Small" />
-                                Joined @_viewModel.FormattedCreatedDate
+                                <MudIcon Icon="@Icons.Material.Outlined.CalendarMonth" Size="Size.Small" Style="color: white !important;" />
+                                <MudText Inline="true" Style="color: white;">Joined @_viewModel.FormattedCreatedDate</MudText>
                             </span>
                             @if (_viewModel.HasLegalInfo)
                             {
                                 <span class="hmr-item">
-                                    <MudIcon Icon="@Icons.Material.Outlined.Shield" Size="Size.Small" />
-                                    @_viewModel.LegalLine
+                                    <MudIcon Icon="@Icons.Material.Outlined.Shield" Size="Size.Small" Style="color: white !important;" />
+                                    <MudText Inline="true" Style="color: white;">@_viewModel.LegalLine</MudText>
                                 </span>
                             }
                         </div>
@@ -180,6 +180,7 @@
                             <RequireOrganizationPermission Permission="@OrgPermissions.Organization.Update" OrganizationId="Id">
                                 <Authorized>
                                     <MudButton Variant="Variant.Filled" Class="btn-pri-org" StartIcon="@Icons.Material.Outlined.Edit"
+                                               Style="color: white !important;"
                                                OnClick="NavigateToEdit">
                                         Edit organization
                                     </MudButton>
@@ -188,6 +189,7 @@
                                     @if (AuthState.IsAuthenticated)
                                     {
                                         <MudButton Variant="Variant.Filled" Class="btn-pri-org" StartIcon="@Icons.Material.Outlined.PersonAdd"
+                                                   Style="color: white !important;"
                                                    OnClick="OpenRequestAccessDialog">
                                             Request access
                                         </MudButton>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor
@@ -31,18 +31,19 @@
 <PageTitle>Organization Details - EcoData</PageTitle>
 
 <NuiPageLayout Title="Organization Details" ParentPath="/organizations/discover">
+    <div class="org-page page-enter" style="@(_viewModel?.ThemeStyle ?? string.Empty)">
         @if (_viewModel is null && _organizationFetch.IsLoading)
         {
-            <MudPaper Elevation="1" Class="pa-6 rounded-lg mb-6">
+            <MudPaper Elevation="0" Class="org-hero-skeleton pa-6 rounded-lg mb-6">
                 <MudStack Row AlignItems="AlignItems.Center" Spacing="4">
-                    <MudSkeleton SkeletonType="SkeletonType.Circle" Width="64px" Height="64px" />
+                    <MudSkeleton SkeletonType="SkeletonType.Circle" Width="72px" Height="72px" />
                     <MudStack Spacing="2">
-                        <MudSkeleton Width="250px" Height="32px" />
-                        <MudSkeleton Width="150px" Height="20px" />
+                        <MudSkeleton Width="320px" Height="40px" />
+                        <MudSkeleton Width="220px" Height="20px" />
                     </MudStack>
                 </MudStack>
             </MudPaper>
-            <MudPaper Elevation="1" Class="rounded-lg pa-6">
+            <MudPaper Elevation="0" Class="rounded-lg pa-6">
                 <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="48px" Class="mb-4" />
                 <MudGrid Spacing="4">
                     @for (var i = 0; i < 3; i++)
@@ -56,7 +57,7 @@
         }
         else if (_organizationFetch.Data is null && !_organizationFetch.IsLoading)
         {
-            <MudPaper Elevation="1" Class="pa-8 rounded-lg d-flex flex-column align-center justify-center">
+            <MudPaper Elevation="0" Class="pa-8 rounded-lg d-flex flex-column align-center justify-center org-not-found">
                 <MudIcon Icon="@Icons.Material.Filled.DomainDisabled" Size="Size.Large" Color="Color.Error" Class="mb-4" />
                 <MudText Typo="Typo.h5" Color="Color.Error">Organization not found</MudText>
                 <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mt-2 text-center">
@@ -71,159 +72,245 @@
         else if (_viewModel is not null)
         {
 
-            <!-- Header Card with Banner Image -->
-            <MudPaper Elevation="1" Class="mb-6 rounded-lg overflow-hidden">
-                @if (_viewModel.HasCardPicture)
-                {
-                    <div class="org-banner">
-                        <MudImage Src="@_viewModel.CardPictureUrl" Alt="@_viewModel.Name" ObjectFit="ObjectFit.Cover"
-                                  Class="org-banner-img" />
-                        <div class="org-banner-overlay"></div>
-                    </div>
-                }
-                <div class="pa-6">
-                    <MudGrid>
-                        <MudItem xs="12" md="8">
-                            <MudStack Row AlignItems="AlignItems.Center" Spacing="4">
-                                @if (_viewModel.HasProfilePicture)
-                                {
-                                    <MudAvatar Size="Size.Large">
-                                        <MudImage Src="@_viewModel.ProfilePictureUrl" Alt="@_viewModel.Name"
-                                                  ObjectFit="ObjectFit.Cover" />
-                                    </MudAvatar>
-                                }
-                                else
-                                {
-                                    <MudAvatar Size="Size.Large" Color="Color.Primary" Variant="Variant.Filled">
-                                        <MudIcon Icon="@Icons.Material.Filled.Business" />
-                                    </MudAvatar>
-                                }
+            @* ============================ HERO ============================ *@
+            <section class="org-hero @(_viewModel.HasCardPicture ? "has-banner" : "no-banner")"
+                     style="@(_viewModel.HasCardPicture ? $"background-image: linear-gradient(180deg, rgba(20,28,24,0.55) 0%, rgba(20,28,24,0.85) 100%), url('{_viewModel.CardPictureUrl}');" : null)">
+                <div class="org-hero-grid">
+                    <div class="org-hero-left">
+                        <div class="org-hero-eyebrow">
+                            <span class="v-line"></span>
+                            <span>@_viewModel.Slug</span>
+                            @if (_viewModel.HasLocation)
+                            {
+                                <span class="dot-sep">·</span>
+                                <span>@_viewModel.Location</span>
+                            }
+                        </div>
 
-                                <MudStack Spacing="1">
-                                    <MudText Typo="Typo.h4">@_viewModel.Name</MudText>
-                                    @if (_viewModel.HasWebsite)
+                        <div class="org-hero-orgline">
+                            @if (_viewModel.HasProfilePicture)
+                            {
+                                <div class="hero-mark hero-mark-img">
+                                    <MudImage Src="@_viewModel.ProfilePictureUrl" Alt="@_viewModel.Name" ObjectFit="ObjectFit.Cover" />
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="hero-mark">@_viewModel.Initials</div>
+                            }
+                            <div>
+                                <div class="org-hero-orgmeta"><strong>@_viewModel.Name</strong></div>
+                                <div class="org-hero-orgmeta">
+                                    Org · joined @_viewModel.FormattedCreatedDate
+                                    @if (_viewModel.HasFoundedYear)
                                     {
-                                        <MudLink Href="@_viewModel.WebsiteUrl" Target="_blank" Color="Color.Primary"
-                                                 Typo="Typo.body2" Class="d-flex align-center">
-                                            <MudIcon Icon="@Icons.Material.Outlined.Link" Size="Size.Small" Class="mr-1" />
-                                            @_viewModel.DisplayWebsiteUrl
-                                        </MudLink>
+                                        <span> · active since @_viewModel.FoundedYear</span>
                                     }
-                                    <MudText Typo="Typo.caption" Class="d-flex align-center">
-                                        <MudIcon Icon="@Icons.Material.Outlined.CalendarMonth" Size="Size.Small"
-                                                 Class="mr-1" />
-                                        Joined @_viewModel.FormattedCreatedDate
-                                    </MudText>
-                                </MudStack>
-                            </MudStack>
-                        </MudItem>
+                                </div>
+                            </div>
+                        </div>
 
-                        <MudItem xs="12" md="4" Class="d-flex justify-md-end align-start">
-                            <MudStack Row Spacing="1">
-                                <MudTooltip Text="Sensor Map">
-                                    <MudIconButton Icon="@Icons.Material.Outlined.Map" Color="Color.Primary"
-                                                   Variant="Variant.Outlined" Size="Size.Medium" OnClick="NavigateToMap" />
-                                </MudTooltip>
-                                <RequireOrganizationPermission Permission="@OrgPermissions.Organization.Update"
-                                                               OrganizationId="Id">
-                                    <Authorized>
-                                        <MudTooltip Text="Edit Organization">
-                                            <MudIconButton Icon="@Icons.Material.Outlined.Edit" Color="Color.Primary"
-                                                           Variant="Variant.Filled" Size="Size.Medium" OnClick="NavigateToEdit" />
-                                        </MudTooltip>
-                                    </Authorized>
-                                    <NotAuthorized>
-                                        @if (AuthState.IsAuthenticated)
-                                        {
-                                            <MudTooltip Text="Request to join this organization">
-                                                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
-                                                           StartIcon="@Icons.Material.Outlined.PersonAdd" OnClick="OpenRequestAccessDialog">
-                                                    Request Access
-                                                </MudButton>
-                                            </MudTooltip>
-                                        }
-                                    </NotAuthorized>
-                                </RequireOrganizationPermission>
-                                <RequireOrganizationPermission Permission="@OrgPermissions.Organization.Delete"
-                                                               OrganizationId="Id">
-                                    <MudTooltip Text="Delete Organization">
-                                        <MudIconButton Icon="@Icons.Material.Outlined.Delete" Color="Color.Error"
-                                                       Variant="Variant.Outlined" Size="Size.Medium" OnClick="ConfirmDelete" />
-                                    </MudTooltip>
-                                </RequireOrganizationPermission>
-                            </MudStack>
-                        </MudItem>
-                    </MudGrid>
+                        <h1 class="org-hero-title">@_viewModel.Name</h1>
+
+                        @if (_viewModel.HasTagline)
+                        {
+                            <p class="org-hero-tagline">@_viewModel.Tagline</p>
+                        }
+
+                        <div class="org-hero-meta-row">
+                            @if (_viewModel.HasWebsite)
+                            {
+                                <span class="hmr-item">
+                                    <MudIcon Icon="@Icons.Material.Outlined.Link" Size="Size.Small" />
+                                    <a href="@_viewModel.WebsiteUrl" target="_blank" rel="noopener">@_viewModel.DisplayWebsiteUrl</a>
+                                </span>
+                            }
+                            @if (_viewModel.HasLocation)
+                            {
+                                <span class="hmr-item">
+                                    <MudIcon Icon="@Icons.Material.Outlined.LocationOn" Size="Size.Small" />
+                                    @_viewModel.Location
+                                </span>
+                            }
+                            <span class="hmr-item">
+                                <MudIcon Icon="@Icons.Material.Outlined.CalendarMonth" Size="Size.Small" />
+                                Joined @_viewModel.FormattedCreatedDate
+                            </span>
+                            @if (_viewModel.HasLegalInfo)
+                            {
+                                <span class="hmr-item">
+                                    <MudIcon Icon="@Icons.Material.Outlined.Shield" Size="Size.Small" />
+                                    @_viewModel.LegalLine
+                                </span>
+                            }
+                        </div>
+                    </div>
+
+                    <aside class="org-hero-card">
+                        <div class="hero-card-k">At a glance</div>
+                        <div class="hero-card-stats">
+                            <div class="hcs">
+                                <div class="hcs-v">
+                                    @if (_sensorCountFetch.IsLoading)
+                                    {
+                                        <span class="hcs-v-dim">—</span>
+                                    }
+                                    else
+                                    {
+                                        @_sensorCountFetch.Data
+                                    }
+                                </div>
+                                <div class="hcs-k">Sensors live</div>
+                            </div>
+                            <div class="hcs">
+                                <div class="hcs-v">
+                                    @if (_membersFetch.IsLoading)
+                                    {
+                                        <span class="hcs-v-dim">—</span>
+                                    }
+                                    else
+                                    {
+                                        @(_membersFetch.Data?.Count ?? 0)
+                                    }
+                                </div>
+                                <div class="hcs-k">Members</div>
+                            </div>
+                        </div>
+                        <div class="hero-card-actions">
+                            <RequireOrganizationPermission Permission="@OrgPermissions.Organization.Update" OrganizationId="Id">
+                                <Authorized>
+                                    <MudButton Variant="Variant.Filled" Class="btn-pri-org" StartIcon="@Icons.Material.Outlined.Edit"
+                                               OnClick="NavigateToEdit">
+                                        Edit organization
+                                    </MudButton>
+                                </Authorized>
+                                <NotAuthorized>
+                                    @if (AuthState.IsAuthenticated)
+                                    {
+                                        <MudButton Variant="Variant.Filled" Class="btn-pri-org" StartIcon="@Icons.Material.Outlined.PersonAdd"
+                                                   OnClick="OpenRequestAccessDialog">
+                                            Request access
+                                        </MudButton>
+                                    }
+                                </NotAuthorized>
+                            </RequireOrganizationPermission>
+                            <MudButton Variant="Variant.Outlined" Class="btn-ghost-light" StartIcon="@Icons.Material.Outlined.Map"
+                                       OnClick="NavigateToMap">
+                                View sensor map
+                            </MudButton>
+                            <RequireOrganizationPermission Permission="@OrgPermissions.Organization.Delete" OrganizationId="Id">
+                                <MudButton Variant="Variant.Text" Class="btn-danger-light" StartIcon="@Icons.Material.Outlined.Delete"
+                                           OnClick="ConfirmDelete">
+                                    Delete
+                                </MudButton>
+                            </RequireOrganizationPermission>
+                        </div>
+                    </aside>
                 </div>
-            </MudPaper>
+            </section>
 
-            <!-- Tabs Section -->
-            <MudPaper Elevation="1" Class="rounded-lg">
+            @* ============================ TABS ============================ *@
+            <MudPaper Elevation="0" Class="org-tabs-paper rounded-lg mt-6">
                 <Tabs>
                     <Tab Title="Overview" Icon="@Icons.Material.Outlined.Dashboard">
-                        <div class="pa-6">
-                            <MudGrid Spacing="4">
-                                @if (_viewModel.HasAbout)
-                                {
-                                    <MudItem xs="12">
-                                        <MudText Typo="Typo.h6" Class="mb-2">About Us</MudText>
-                                        <MudText Typo="Typo.body1">@_viewModel.AboutUs</MudText>
-                                    </MudItem>
-                                }
+                        <div class="org-tab-body">
+                            @if (_viewModel.HasAbout)
+                            {
+                                <section class="about-card">
+                                    <div class="about-eyebrow">Mission</div>
+                                    <p class="about-text">@_viewModel.AboutUs</p>
+                                </section>
+                            }
 
-                                <MudItem xs="12" sm="4">
-                                    <MudPaper Elevation="0" Outlined="true" Class="pa-4 rounded-lg d-flex align-center">
-                                        <MudIcon Icon="@Icons.Material.Outlined.Sensors" Color="Color.Primary"
-                                                 Size="Size.Large" Class="mr-4" />
+                            <section class="impact-grid">
+                                <div class="impact-card primary">
+                                    <div class="impact-card-k">
+                                        <MudIcon Icon="@Icons.Material.Outlined.SettingsInputAntenna" Size="Size.Small" />
+                                        Network
+                                    </div>
+                                    <div class="impact-card-v">
+                                        @if (_sensorCountFetch.IsLoading)
+                                        {
+                                            <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+                                        }
+                                        else
+                                        {
+                                            @_sensorCountFetch.Data
+                                        }
+                                    </div>
+                                    <div class="impact-card-l">Sensors deployed by this organization</div>
+                                </div>
+                                <div class="impact-card light">
+                                    <div class="impact-card-k">
+                                        <MudIcon Icon="@Icons.Material.Outlined.Group" Size="Size.Small" />
+                                        Team
+                                    </div>
+                                    <div class="impact-card-v">
+                                        @if (_membersFetch.IsLoading)
+                                        {
+                                            <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+                                        }
+                                        else
+                                        {
+                                            @(_membersFetch.Data?.Count ?? 0)
+                                        }
+                                    </div>
+                                    <div class="impact-card-l">Active members</div>
+                                </div>
+                                <div class="impact-card light">
+                                    <div class="impact-card-k">
+                                        <MudIcon Icon="@Icons.Material.Outlined.CalendarMonth" Size="Size.Small" />
+                                        With us since
+                                    </div>
+                                    <div class="impact-card-v impact-card-v-text">
+                                        @_viewModel.JoinedYear
+                                    </div>
+                                    <div class="impact-card-l">Joined @_viewModel.FormattedCreatedDate</div>
+                                </div>
+                            </section>
+
+                            <section class="overview-row">
+                                <div class="map-card">
+                                    <div class="map-card-vis">
+                                        <MudIcon Icon="@Icons.Material.Outlined.Map" Class="map-card-bg-icon" />
+                                    </div>
+                                    <div class="map-card-foot">
                                         <div>
-                                            @if (_sensorCountFetch.IsLoading)
-                                            {
-                                                <MudProgressCircular Size="Size.Small" Indeterminate="true" />
-                                            }
-                                            else
-                                            {
-                                                <MudText Typo="Typo.h5">@_sensorCountFetch.Data</MudText>
-                                            }
-                                            <MudText Typo="Typo.body2" Color="Color.Secondary">Total Sensors</MudText>
+                                            <div class="map-card-title">Sensor map</div>
+                                            <div class="map-card-sub">See every deployment on the reserve</div>
                                         </div>
-                                    </MudPaper>
-                                </MudItem>
-                                <MudItem xs="12" sm="4">
-                                    <MudPaper Elevation="0" Outlined="true" Class="pa-4 rounded-lg d-flex align-center">
-                                        <MudIcon Icon="@Icons.Material.Outlined.Group" Color="Color.Secondary"
-                                                 Size="Size.Large" Class="mr-4" />
-                                        <div>
-                                            @if (_membersFetch.IsLoading)
-                                            {
-                                                <MudProgressCircular Size="Size.Small" Indeterminate="true" />
-                                            }
-                                            else
-                                            {
-                                                <MudText Typo="Typo.h5">@(_membersFetch.Data?.Count ?? 0)</MudText>
-                                            }
-                                            <MudText Typo="Typo.body2" Color="Color.Secondary">Team Members</MudText>
+                                        <MudButton Variant="Variant.Text" EndIcon="@Icons.Material.Filled.ArrowForward"
+                                                   OnClick="NavigateToMap" Class="map-card-link">
+                                            Open map
+                                        </MudButton>
+                                    </div>
+                                </div>
+
+                                @if (_viewModel.HasWebsite)
+                                {
+                                    <div class="partner-card">
+                                        <MudIcon Icon="@Icons.Material.Outlined.Handshake" Class="partner-card-icon" />
+                                        <div class="partner-card-title">Partner with us</div>
+                                        <div class="partner-card-desc">
+                                            Pitch a project, request data, or get in touch with the team.
                                         </div>
-                                    </MudPaper>
-                                </MudItem>
-                                <MudItem xs="12" sm="4">
-                                    <MudPaper Elevation="0" Outlined="true" Class="pa-4 rounded-lg d-flex align-center">
-                                        <MudIcon Icon="@Icons.Material.Outlined.Science" Color="Color.Tertiary"
-                                                 Size="Size.Large" Class="mr-4" />
-                                        <div>
-                                            <MudText Typo="Typo.h5">0</MudText>
-                                            <MudText Typo="Typo.body2" Color="Color.Secondary">Publications</MudText>
-                                        </div>
-                                    </MudPaper>
-                                </MudItem>
-                            </MudGrid>
+                                        <MudLink Href="@_viewModel.WebsiteUrl" Target="_blank" Class="partner-card-link">
+                                            Visit @_viewModel.DisplayWebsiteUrl
+                                        </MudLink>
+                                    </div>
+                                }
+                            </section>
                         </div>
                     </Tab>
 
                     <Tab Title="Sensors" Icon="@Icons.Material.Outlined.Sensors"
                          Badge="@(_sensorCountFetch.IsLoading ? "..." : _sensorCountFetch.Data.ToString())">
-                        <div class="pa-6">
-                            <MudStack Row Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-4">
-                                <MudText Typo="Typo.h6">Sensor Fleet</MudText>
+                        <div class="org-tab-body">
+                            <div class="section-head">
+                                <div>
+                                    <div class="section-eyebrow">Sensor fleet · live</div>
+                                    <h2 class="section-title">What's online</h2>
+                                </div>
                                 <MudStack Row Spacing="2">
                                     <RequireOrganizationPermission Permission="@SensorPermissions.Sensor.Update"
                                                                    OrganizationId="Id">
@@ -240,7 +327,7 @@
                                         </MudButton>
                                     </RequireOrganizationPermission>
                                 </MudStack>
-                            </MudStack>
+                            </div>
 
                             @if (_sensorsFetch.IsLoading)
                             {
@@ -279,15 +366,7 @@
                                     <div class="d-flex justify-center mt-4">
                                         <MudButton Variant="Variant.Text" Color="Color.Primary"
                                                    EndIcon="@Icons.Material.Filled.ArrowForward" OnClick="NavigateToSensors">
-                                            @if (_sensorCountFetch.IsLoading)
-                                            {
-                                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                                                <span>View all sensors</span>
-                                            }
-                                            else
-                                            {
-                                                <span>View all @_sensorCountFetch.Data sensors</span>
-                                            }
+                                            View all @_sensorCountFetch.Data sensors
                                         </MudButton>
                                     </div>
                                 }
@@ -297,9 +376,12 @@
 
                     <Tab Title="Team" Icon="@Icons.Material.Outlined.Group"
                          Badge="@(_membersFetch.IsLoading ? "..." : (_membersFetch.Data?.Count ?? 0).ToString())">
-                        <div class="pa-6">
-                            <MudStack Row Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-4">
-                                <MudText Typo="Typo.h6">Members</MudText>
+                        <div class="org-tab-body">
+                            <div class="section-head">
+                                <div>
+                                    <div class="section-eyebrow">Leadership</div>
+                                    <h2 class="section-title">The team</h2>
+                                </div>
                                 <RequireOrganizationPermission Permission="@OrgPermissions.Organization.ManageMembers"
                                                                OrganizationId="Id">
                                     <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
@@ -307,7 +389,7 @@
                                         Manage
                                     </MudButton>
                                 </RequireOrganizationPermission>
-                            </MudStack>
+                            </div>
 
                             @if (_membersFetch.IsLoading)
                             {
@@ -335,27 +417,20 @@
                             }
                             else
                             {
-                                <MudGrid Spacing="3">
-                                    @foreach (var member in (_membersFetch.Data ??
-                                                                []).Take(OrganizationDetailsViewModel.MaxDisplayedMembers))
+                                <div class="team-grid">
+                                    @foreach (var member in (_membersFetch.Data ?? []).Take(OrganizationDetailsViewModel.MaxDisplayedMembers))
                                     {
-                                        <MudItem xs="12" sm="6" md="4" lg="3">
-                                            <MudPaper Elevation="0" Outlined="true" Class="pa-4 text-center rounded-lg">
-                                                <MudAvatar Size="Size.Large"
-                                                           Color="@OrganizationDetailsViewModel.GetMemberAvatarColor(member.DisplayName)"
-                                                           Class="mb-3">
-                                                    @OrganizationDetailsViewModel.GetMemberInitial(member.DisplayName)
-                                                </MudAvatar>
-                                                <MudText Typo="Typo.subtitle1" Class="mud-text-truncate">
-                                                    @member.DisplayName
-                                                </MudText>
-                                                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mud-text-truncate">
-                                                    @member.RoleName
-                                                </MudText>
-                                            </MudPaper>
-                                        </MudItem>
+                                        <div class="team-cell">
+                                            <MudAvatar Size="Size.Medium" Color="@OrganizationDetailsViewModel.GetMemberAvatarColor(member.DisplayName)" Class="team-av">
+                                                @OrganizationDetailsViewModel.GetMemberInitial(member.DisplayName)
+                                            </MudAvatar>
+                                            <div class="team-text">
+                                                <div class="team-name">@member.DisplayName</div>
+                                                <div class="team-role">@member.RoleName</div>
+                                            </div>
+                                        </div>
                                     }
-                                </MudGrid>
+                                </div>
                                 @if ((_membersFetch.Data?.Count ?? 0) > OrganizationDetailsViewModel.MaxDisplayedMembers)
                                 {
                                     <div class="d-flex justify-center mt-4">
@@ -370,33 +445,34 @@
                     </Tab>
 
                     <Tab Title="Projects" Icon="@Icons.Material.Outlined.AccountTree">
-                        <div class="pa-6">
-                            <MudPaper Elevation="0" Outlined="true" Class="pa-8 text-center rounded-lg empty-state">
-                                <MudIcon Icon="@Icons.Material.Outlined.Construction" Size="Size.Large"
-                                         Color="Color.Secondary" Class="mb-2" />
-                                <MudText Typo="Typo.h6" Color="Color.Secondary">Projects Coming Soon</MudText>
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                    Track field operations and data initiatives here.
-                                </MudText>
-                            </MudPaper>
+                        <div class="org-tab-body">
+                            <div class="coming-soon">
+                                <div class="coming-soon-eyebrow">Coming soon</div>
+                                <h2 class="coming-soon-title">Field projects</h2>
+                                <p class="coming-soon-body">
+                                    Track active field operations, completion dates, and the sensors scoped to each project.
+                                    Tracked in <a href="https://github.com/andres-m-rodriguez/EcoData/issues/209" target="_blank" rel="noopener">issue #209</a>.
+                                </p>
+                            </div>
                         </div>
                     </Tab>
 
                     <Tab Title="Research" Icon="@Icons.Material.Outlined.Science">
-                        <div class="pa-6">
-                            <MudPaper Elevation="0" Outlined="true" Class="pa-8 text-center rounded-lg empty-state">
-                                <MudIcon Icon="@Icons.Material.Outlined.Article" Size="Size.Large" Color="Color.Secondary"
-                                         Class="mb-2" />
-                                <MudText Typo="Typo.h6" Color="Color.Secondary">Publications Coming Soon</MudText>
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                    A centralized hub for ecological research and data reports.
-                                </MudText>
-                            </MudPaper>
+                        <div class="org-tab-body">
+                            <div class="coming-soon">
+                                <div class="coming-soon-eyebrow">Coming soon</div>
+                                <h2 class="coming-soon-title">Publications</h2>
+                                <p class="coming-soon-body">
+                                    Latest papers, dataset DOIs, and citations referencing this organization's data.
+                                    Tracked in <a href="https://github.com/andres-m-rodriguez/EcoData/issues/209" target="_blank" rel="noopener">issue #209</a>.
+                                </p>
+                            </div>
                         </div>
                     </Tab>
                 </Tabs>
             </MudPaper>
         }
+    </div>
 </NuiPageLayout>
 
 @code {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor.css
@@ -25,17 +25,14 @@
    ========================================================================== */
 .org-hero {
     position: relative;
-    /* Full-bleed: break out of the constrained page container and span the
-       viewport width regardless of where the hero is rendered in the tree. */
-    width: 100vw;
-    margin-left: calc(50% - 50vw);
-    margin-right: calc(50% - 50vw);
+    border-radius: 14px;
     overflow: hidden;
     color: #fff;
     background: linear-gradient(135deg, var(--org-primary, var(--mud-palette-primary)) 0%,
                                 rgba(20, 28, 24, 0.95) 100%);
     background-size: cover;
     background-position: center 40%;
+    border: 1px solid var(--mud-palette-lines-default);
 }
 
 .org-hero.no-banner {
@@ -49,11 +46,7 @@
     grid-template-columns: 1fr 320px;
     gap: 2.5rem;
     align-items: end;
-    padding: 4rem 2.5rem 3rem;
-    /* Constrain the inner content even though the hero is full-bleed,
-       so on wide monitors the grid stays readable and centered. */
-    max-width: 1280px;
-    margin: 0 auto;
+    padding: 3.5rem 2.5rem 2.5rem;
 }
 
 .org-hero-left {
@@ -68,14 +61,14 @@
     text-transform: uppercase;
     letter-spacing: 0.18em;
     font-weight: 700;
-    color: #fff;
+    color: var(--org-accent, var(--mud-palette-secondary));
     margin-bottom: 1.25rem;
 }
 
 .org-hero-eyebrow .v-line {
     width: 28px;
     height: 1px;
-    background: rgba(255, 255, 255, 0.5);
+    background: var(--org-accent, var(--mud-palette-secondary));
     display: inline-block;
 }
 
@@ -169,21 +162,21 @@
 }
 
 ::deep .hmr-item .mud-icon-root {
-    color: #fff !important;
+    color: var(--org-accent, var(--mud-palette-secondary)) !important;
     width: 1rem !important;
     height: 1rem !important;
     font-size: 1rem !important;
 }
 
 .hmr-item a {
-    color: #fff;
+    color: rgba(255, 255, 255, 0.95);
     border-bottom: 1px dotted rgba(255, 255, 255, 0.4);
     padding-bottom: 1px;
     text-decoration: none;
 }
 
 .hmr-item a:hover {
-    border-bottom-color: #fff;
+    border-bottom-color: var(--org-accent, var(--mud-palette-secondary));
 }
 
 /* Hero glass card */

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor.css
@@ -25,14 +25,17 @@
    ========================================================================== */
 .org-hero {
     position: relative;
-    border-radius: 14px;
+    /* Full-bleed: break out of the constrained page container and span the
+       viewport width regardless of where the hero is rendered in the tree. */
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
     overflow: hidden;
     color: #fff;
     background: linear-gradient(135deg, var(--org-primary, var(--mud-palette-primary)) 0%,
                                 rgba(20, 28, 24, 0.95) 100%);
     background-size: cover;
     background-position: center 40%;
-    border: 1px solid var(--mud-palette-lines-default);
 }
 
 .org-hero.no-banner {
@@ -46,7 +49,11 @@
     grid-template-columns: 1fr 320px;
     gap: 2.5rem;
     align-items: end;
-    padding: 3.5rem 2.5rem 2.5rem;
+    padding: 4rem 2.5rem 3rem;
+    /* Constrain the inner content even though the hero is full-bleed,
+       so on wide monitors the grid stays readable and centered. */
+    max-width: 1280px;
+    margin: 0 auto;
 }
 
 .org-hero-left {
@@ -61,14 +68,14 @@
     text-transform: uppercase;
     letter-spacing: 0.18em;
     font-weight: 700;
-    color: var(--org-accent, var(--mud-palette-secondary));
+    color: #fff;
     margin-bottom: 1.25rem;
 }
 
 .org-hero-eyebrow .v-line {
     width: 28px;
     height: 1px;
-    background: var(--org-accent, var(--mud-palette-secondary));
+    background: rgba(255, 255, 255, 0.5);
     display: inline-block;
 }
 
@@ -162,21 +169,21 @@
 }
 
 ::deep .hmr-item .mud-icon-root {
-    color: var(--org-accent, var(--mud-palette-secondary)) !important;
+    color: #fff !important;
     width: 1rem !important;
     height: 1rem !important;
     font-size: 1rem !important;
 }
 
 .hmr-item a {
-    color: rgba(255, 255, 255, 0.95);
+    color: #fff;
     border-bottom: 1px dotted rgba(255, 255, 255, 0.4);
     padding-bottom: 1px;
     text-decoration: none;
 }
 
 .hmr-item a:hover {
-    border-bottom-color: var(--org-accent, var(--mud-palette-secondary));
+    border-bottom-color: #fff;
 }
 
 /* Hero glass card */

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/OrganizationDetailsPage.razor.css
@@ -1,31 +1,704 @@
-/* Organization Banner */
-.org-banner {
+/* ==========================================================================
+   Page container
+   ========================================================================== */
+.org-page {
+    background: var(--mud-palette-background);
+    min-height: 100%;
+}
+
+.page-enter {
+    animation: pageEnter 0.4s ease-out forwards;
+}
+
+@keyframes pageEnter {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.org-not-found {
+    background: var(--mud-palette-surface);
+    border: 1px solid var(--mud-palette-lines-default);
+}
+
+/* ==========================================================================
+   HERO
+   ========================================================================== */
+.org-hero {
     position: relative;
-    height: 180px;
+    border-radius: 14px;
     overflow: hidden;
-    width: 100%;
+    color: #fff;
+    background: linear-gradient(135deg, var(--org-primary, var(--mud-palette-primary)) 0%,
+                                rgba(20, 28, 24, 0.95) 100%);
+    background-size: cover;
+    background-position: center 40%;
+    border: 1px solid var(--mud-palette-lines-default);
 }
 
-::deep .org-banner-img {
-    width: 100%;
-    height: 100%;
-    display: block;
+.org-hero.no-banner {
+    background: linear-gradient(135deg,
+                color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 92%, black) 0%,
+                color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 70%, black) 100%);
 }
 
-::deep .org-banner-img img {
+.org-hero-grid {
+    display: grid;
+    grid-template-columns: 1fr 320px;
+    gap: 2.5rem;
+    align-items: end;
+    padding: 3.5rem 2.5rem 2.5rem;
+}
+
+.org-hero-left {
+    max-width: 720px;
+}
+
+.org-hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-weight: 700;
+    color: var(--org-accent, var(--mud-palette-secondary));
+    margin-bottom: 1.25rem;
+}
+
+.org-hero-eyebrow .v-line {
+    width: 28px;
+    height: 1px;
+    background: var(--org-accent, var(--mud-palette-secondary));
+    display: inline-block;
+}
+
+.org-hero-eyebrow .dot-sep {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.org-hero-orgline {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.hero-mark {
+    width: 56px;
+    height: 56px;
+    border-radius: 12px;
+    background: var(--org-accent, var(--mud-palette-secondary));
+    color: var(--org-primary, var(--mud-palette-primary));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Newsreader', serif;
+    font-weight: 700;
+    font-size: 1.6rem;
+    letter-spacing: -0.02em;
+    flex-shrink: 0;
+    box-shadow: 0 8px 24px -8px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
+}
+
+.hero-mark-img {
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0;
+}
+
+::deep .hero-mark-img img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    display: block;
 }
 
-.org-banner-overlay {
+.org-hero-orgmeta {
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.7);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    line-height: 1.4;
+}
+
+.org-hero-orgmeta strong {
+    color: #fff;
+    font-weight: 600;
+}
+
+.org-hero-title {
+    font-family: 'Newsreader', serif;
+    font-weight: 600;
+    font-size: clamp(2.25rem, 4.5vw, 3.5rem);
+    line-height: 1.1;
+    letter-spacing: -0.025em;
+    margin: 0 0 1.25rem;
+    color: #fff;
+}
+
+.org-hero-tagline {
+    font-family: 'Newsreader', serif;
+    font-size: 1.1rem;
+    line-height: 1.55;
+    color: rgba(255, 255, 255, 0.88);
+    max-width: 580px;
+    font-style: italic;
+    margin: 0 0 1.5rem;
+}
+
+.org-hero-meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem 1.75rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.hmr-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+::deep .hmr-item .mud-icon-root {
+    color: var(--org-accent, var(--mud-palette-secondary)) !important;
+    width: 1rem !important;
+    height: 1rem !important;
+    font-size: 1rem !important;
+}
+
+.hmr-item a {
+    color: rgba(255, 255, 255, 0.95);
+    border-bottom: 1px dotted rgba(255, 255, 255, 0.4);
+    padding-bottom: 1px;
+    text-decoration: none;
+}
+
+.hmr-item a:hover {
+    border-bottom-color: var(--org-accent, var(--mud-palette-secondary));
+}
+
+/* Hero glass card */
+.org-hero-card {
+    background: rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 14px;
+    padding: 1.5rem;
+    color: #fff;
+    align-self: stretch;
+}
+
+.hero-card-k {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: rgba(255, 255, 255, 0.55);
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.hero-card-stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0;
+    margin-bottom: 1.25rem;
+}
+
+.hcs {
+    padding: 0.5rem 0;
+}
+
+.hcs:nth-child(odd) {
+    border-right: 1px solid rgba(255, 255, 255, 0.12);
+    padding-right: 0.875rem;
+}
+
+.hcs:nth-child(even) {
+    padding-left: 0.875rem;
+}
+
+.hcs-v {
+    font-family: 'Newsreader', serif;
+    font-weight: 600;
+    font-size: 1.75rem;
+    letter-spacing: -0.02em;
+    line-height: 1;
+}
+
+.hcs-v-dim {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.hcs-k {
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin-top: 0.4rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.hero-card-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+}
+
+::deep .btn-pri-org {
+    background: var(--org-accent, var(--mud-palette-secondary)) !important;
+    color: color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 80%, black) !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.1em !important;
+    font-size: 0.75rem !important;
+    font-weight: 600 !important;
+}
+
+::deep .btn-ghost-light {
+    background: rgba(255, 255, 255, 0.1) !important;
+    color: #fff !important;
+    border: 1px solid rgba(255, 255, 255, 0.25) !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.1em !important;
+    font-size: 0.75rem !important;
+    font-weight: 600 !important;
+}
+
+::deep .btn-ghost-light:hover {
+    background: rgba(255, 255, 255, 0.16) !important;
+}
+
+::deep .btn-danger-light {
+    color: rgba(255, 255, 255, 0.7) !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.1em !important;
+    font-size: 0.7rem !important;
+    font-weight: 600 !important;
+}
+
+::deep .btn-danger-light:hover {
+    background: rgba(220, 38, 38, 0.12) !important;
+    color: #fff !important;
+}
+
+/* ==========================================================================
+   TABS section
+   ========================================================================== */
+::deep .org-tabs-paper {
+    background: var(--mud-palette-surface) !important;
+    border: 1px solid var(--mud-palette-lines-default) !important;
+    overflow: hidden;
+}
+
+.org-tab-body {
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+/* ==========================================================================
+   About card (Mission)
+   ========================================================================== */
+.about-card {
+    background:
+        radial-gradient(circle at 0% 0%,
+            color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 6%, transparent),
+            transparent 60%),
+        var(--mud-palette-surface);
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 14px;
+    padding: 2.25rem 2.5rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.about-card::before {
+    content: '"';
     position: absolute;
-    inset: 0;
-    background: linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 0.3) 100%);
+    top: -1.875rem;
+    right: 1.5rem;
+    font-family: 'Newsreader', serif;
+    font-size: 13rem;
+    color: color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 8%, transparent);
+    line-height: 1;
+    font-weight: 600;
 }
 
-/* Empty State */
+.about-eyebrow {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 80%, var(--mud-palette-secondary));
+    font-weight: 700;
+    margin-bottom: 0.875rem;
+    position: relative;
+}
+
+.about-text {
+    font-family: 'Newsreader', serif;
+    font-size: 1.15rem;
+    line-height: 1.55;
+    color: var(--mud-palette-text-primary);
+    max-width: 760px;
+    margin: 0;
+    position: relative;
+    white-space: pre-wrap;
+}
+
+/* ==========================================================================
+   Impact stats grid
+   ========================================================================== */
+.impact-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.25rem;
+}
+
+.impact-card {
+    border-radius: 14px;
+    padding: 1.75rem 1.5rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.impact-card.primary {
+    background: linear-gradient(135deg,
+        var(--org-primary, var(--mud-palette-primary)) 0%,
+        color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 70%, black) 100%);
+    color: #fff;
+}
+
+.impact-card.light {
+    background: var(--mud-palette-surface);
+    border: 1px solid var(--mud-palette-lines-default);
+    color: var(--mud-palette-text-primary);
+}
+
+.impact-card-k {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.impact-card.primary .impact-card-k {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.impact-card.light .impact-card-k {
+    color: var(--mud-palette-text-secondary);
+}
+
+::deep .impact-card.primary .impact-card-k .mud-icon-root {
+    color: var(--org-accent, var(--mud-palette-secondary)) !important;
+}
+
+::deep .impact-card.light .impact-card-k .mud-icon-root {
+    color: var(--org-primary, var(--mud-palette-primary)) !important;
+}
+
+.impact-card-v {
+    font-family: 'Newsreader', serif;
+    font-weight: 600;
+    font-size: 3.25rem;
+    letter-spacing: -0.03em;
+    line-height: 0.95;
+    margin-bottom: 0.5rem;
+}
+
+.impact-card-v-text {
+    font-size: 2.25rem;
+}
+
+.impact-card.light .impact-card-v {
+    color: var(--mud-palette-primary);
+}
+
+.impact-card-l {
+    font-size: 0.85rem;
+}
+
+.impact-card.primary .impact-card-l {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.impact-card.light .impact-card-l {
+    color: var(--mud-palette-text-secondary);
+}
+
+/* ==========================================================================
+   Overview row: map teaser + partner CTA
+   ========================================================================== */
+.overview-row {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 1.25rem;
+}
+
+.map-card,
+.partner-card {
+    background: var(--mud-palette-surface);
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 14px;
+    overflow: hidden;
+}
+
+.map-card-vis {
+    height: 180px;
+    background:
+        radial-gradient(circle at 30% 60%,
+            color-mix(in srgb, var(--org-accent, var(--mud-palette-secondary)) 12%, transparent), transparent 50%),
+        linear-gradient(180deg,
+            color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 6%, var(--mud-palette-background)),
+            color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 14%, var(--mud-palette-background)));
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+::deep .map-card-bg-icon {
+    font-size: 5rem !important;
+    color: color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 30%, transparent) !important;
+}
+
+.map-card-foot {
+    padding: 1rem 1.25rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.map-card-title {
+    font-family: 'Newsreader', serif;
+    font-weight: 600;
+    font-size: 1rem;
+    color: var(--mud-palette-primary);
+    letter-spacing: -0.01em;
+}
+
+.map-card-sub {
+    font-size: 0.75rem;
+    color: var(--mud-palette-text-secondary);
+    margin-top: 0.15rem;
+}
+
+::deep .map-card-link {
+    color: var(--mud-palette-primary) !important;
+    font-weight: 600 !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.1em !important;
+    font-size: 0.7rem !important;
+}
+
+.partner-card {
+    padding: 2rem 1.5rem;
+    text-align: center;
+    background: linear-gradient(135deg,
+        var(--mud-palette-background) 0%,
+        color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 5%, var(--mud-palette-surface)) 100%);
+    border-style: dashed;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+::deep .partner-card-icon {
+    font-size: 2rem !important;
+    color: var(--org-primary, var(--mud-palette-primary)) !important;
+    margin-bottom: 0.75rem;
+}
+
+.partner-card-title {
+    font-family: 'Newsreader', serif;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--mud-palette-primary);
+    margin-bottom: 0.4rem;
+}
+
+.partner-card-desc {
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: var(--mud-palette-text-secondary);
+    max-width: 240px;
+    margin: 0 auto 0.875rem;
+}
+
+::deep .partner-card-link {
+    font-weight: 600;
+    color: var(--mud-palette-primary) !important;
+    border-bottom: 1px solid currentColor;
+    padding-bottom: 1px;
+    font-size: 0.8rem;
+}
+
+/* ==========================================================================
+   Section heads, team grid, coming-soon
+   ========================================================================== */
+.section-head {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.section-eyebrow {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 80%, var(--mud-palette-secondary));
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+
+.section-title {
+    font-family: 'Newsreader', serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    color: var(--mud-palette-primary);
+    margin: 0;
+}
+
+.team-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.75rem;
+}
+
+.team-cell {
+    display: flex;
+    align-items: center;
+    gap: 0.875rem;
+    padding: 0.75rem;
+    border-radius: 10px;
+    border: 1px solid transparent;
+    transition: background .15s, border-color .15s;
+    cursor: default;
+}
+
+.team-cell:hover {
+    background: color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 5%, transparent);
+    border-color: var(--mud-palette-lines-default);
+}
+
+::deep .team-av {
+    width: 38px !important;
+    height: 38px !important;
+    font-size: 0.875rem !important;
+    font-weight: 600 !important;
+    flex-shrink: 0;
+}
+
+.team-text {
+    min-width: 0;
+}
+
+.team-name {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--mud-palette-text-primary);
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.team-role {
+    font-size: 0.7rem;
+    color: var(--mud-palette-text-secondary);
+    margin-top: 0.15rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.coming-soon {
+    text-align: center;
+    padding: 3rem 1.5rem;
+    border: 1px dashed var(--mud-palette-lines-default);
+    border-radius: 14px;
+    background: color-mix(in srgb, var(--org-primary, var(--mud-palette-primary)) 3%, var(--mud-palette-background));
+}
+
+.coming-soon-eyebrow {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--mud-palette-text-secondary);
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+}
+
+.coming-soon-title {
+    font-family: 'Newsreader', serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--mud-palette-primary);
+    margin: 0 0 0.625rem;
+}
+
+.coming-soon-body {
+    font-size: 0.875rem;
+    color: var(--mud-palette-text-secondary);
+    max-width: 460px;
+    margin: 0 auto;
+    line-height: 1.55;
+}
+
+.coming-soon-body a {
+    color: var(--mud-palette-primary);
+    font-weight: 600;
+}
+
 .empty-state {
     border-style: dashed;
+}
+
+/* ==========================================================================
+   Skeleton hero placeholder
+   ========================================================================== */
+.org-hero-skeleton {
+    background: var(--mud-palette-surface);
+    border: 1px solid var(--mud-palette-lines-default);
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+@media (max-width: 1100px) {
+    .org-hero-grid {
+        grid-template-columns: 1fr;
+        gap: 1.75rem;
+        padding: 2.25rem 1.5rem 1.75rem;
+    }
+
+    .impact-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .overview-row {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 700px) {
+    .org-tab-body {
+        padding: 1.25rem;
+    }
+
+    .about-card {
+        padding: 1.5rem 1.25rem;
+    }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/ViewModels/OrganizationDetailsViewModel.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/ViewModels/OrganizationDetailsViewModel.cs
@@ -8,16 +8,28 @@ public class OrganizationDetailsViewModel(OrganizationDtoForDetail organization)
     // Organization Info
     public Guid Id => organization.Id;
     public string Name => organization.Name;
+    public string Slug => organization.Slug;
+    public string? Tagline => organization.Tagline;
     public string? ProfilePictureUrl => organization.ProfilePictureUrl;
     public string? CardPictureUrl => organization.CardPictureUrl;
     public string? AboutUs => organization.AboutUs;
     public string? WebsiteUrl => organization.WebsiteUrl;
+    public string? Location => organization.Location;
+    public int? FoundedYear => organization.FoundedYear;
+    public string? LegalStatus => organization.LegalStatus;
+    public string? TaxId => organization.TaxId;
+    public string? PrimaryColor => organization.PrimaryColor;
+    public string? AccentColor => organization.AccentColor;
 
     // Display Properties
     public bool HasProfilePicture => !string.IsNullOrWhiteSpace(ProfilePictureUrl);
     public bool HasCardPicture => !string.IsNullOrWhiteSpace(CardPictureUrl);
     public bool HasWebsite => !string.IsNullOrWhiteSpace(WebsiteUrl);
     public bool HasAbout => !string.IsNullOrWhiteSpace(AboutUs);
+    public bool HasTagline => !string.IsNullOrWhiteSpace(Tagline);
+    public bool HasLocation => !string.IsNullOrWhiteSpace(Location);
+    public bool HasFoundedYear => FoundedYear.HasValue;
+    public bool HasLegalInfo => !string.IsNullOrWhiteSpace(LegalStatus) || !string.IsNullOrWhiteSpace(TaxId);
 
     public string DisplayWebsiteUrl =>
         Uri.TryCreate(WebsiteUrl, UriKind.Absolute, out var uri)
@@ -25,6 +37,41 @@ public class OrganizationDetailsViewModel(OrganizationDtoForDetail organization)
             : WebsiteUrl ?? string.Empty;
 
     public string FormattedCreatedDate => organization.CreatedAt.ToString("MMM d, yyyy");
+    public int JoinedYear => organization.CreatedAt.Year;
+
+    public string Initials
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(Name)) return "?";
+            var parts = Name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 1) return parts[0][..Math.Min(2, parts[0].Length)].ToUpperInvariant();
+            return string.Concat(parts[0][0], parts[1][0]).ToUpperInvariant();
+        }
+    }
+
+    // Inline CSS variables that scope per-org branding to the page. Falls back
+    // to MudBlazor palette tokens when the org hasn't picked colors yet, so
+    // the layout reads correctly either way.
+    public string ThemeStyle =>
+        $"--org-primary: {PrimaryColor ?? "var(--mud-palette-primary)"}; " +
+        $"--org-accent: {AccentColor ?? "var(--mud-palette-secondary)"};";
+
+    public string LegalLine
+    {
+        get
+        {
+            var hasStatus = !string.IsNullOrWhiteSpace(LegalStatus);
+            var hasTaxId = !string.IsNullOrWhiteSpace(TaxId);
+            return (hasStatus, hasTaxId) switch
+            {
+                (true, true) => $"{LegalStatus} · {TaxId}",
+                (true, false) => LegalStatus!,
+                (false, true) => TaxId!,
+                _ => string.Empty
+            };
+        }
+    }
 
     public string PageTitle => $"{Name} - EcoData";
 


### PR DESCRIPTION
## Summary
Magazine-style redesign of `/organizations/{id}`. Hero pulls per-org branding (`PrimaryColor` / `AccentColor`) into CSS variables via `ViewModel.ThemeStyle`, so every accent on the page picks up the org's palette without re-templating components.

**Layout**
- **Hero** — optional banner image (`CardPicture`), eyebrow line (Slug + Location), profile mark (avatar or initials), Name, Tagline, meta row (website / location / joined / legal info), plus a glassmorphism "At a glance" stats card (sensor + member counts) and primary actions (Edit / Request access / View map / Delete).
- **Tabbed body**:
  - **Overview** — Mission card with editorial pull-quote, impact-stat grid (Network / Team / With us since), map teaser, partner CTA.
  - **Sensors** — existing fleet list reused via `SensorListItem`.
  - **Team** — member grid.
  - **Projects** + **Research** — coming-soon placeholders linking issue #209.

**ViewModel additions**
- Passthroughs: Slug, Tagline, Location, FoundedYear, LegalStatus, TaxId, PrimaryColor, AccentColor.
- Flags: `HasTagline`, `HasLocation`, `HasFoundedYear`, `HasLegalInfo`.
- Computed: `Initials`, `JoinedYear`, `LegalLine`, `ThemeStyle`.

**Drive-by fix**
`OpenRequestAccessDialog` now passes `Type` when constructing `OrganizationDtoForList` (added in PR #213).

## Notes
- The form, create page, and edit page are intentionally **not** changed in this PR — the in-flight work for those was made stale by PRs #212 and #213, which already wired all the new branding fields cleanly.
- If/when you decide to drop `LegalStatus` / `TaxId` (per the earlier conversation), the `LegalLine` / `HasLegalInfo` ViewModel properties and the meta-row line in the hero need to come out too.

## Test plan
- [ ] Visit `/organizations/{id}` for an org that has primary/accent colors set; verify hero, tabs, "At a glance" card, and impact grid all use those colors.
- [ ] Visit an org with **no** branding colors; verify it falls back to MudBlazor palette tokens cleanly.
- [ ] Hero variants: with/without banner image, with/without profile picture, with/without tagline / location / website / legal line.
- [ ] Click Edit (as authorized user), Request access (as unauthenticated), View map, Delete — all navigate / open dialogs correctly.
- [ ] Switch tabs — Sensors loads via existing list; Team grid renders; Projects + Research show coming-soon.
- [ ] Responsive: at <1100px the hero collapses to a single column, impact grid stacks.