### PR TITLE
feat(eco-portal): add Data tab to mobile bottom navigation

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -171,6 +171,13 @@
                 <MudText Typo="Typo.caption">Home</MudText>
             </MudStack>
         </MudButton>
+        <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Data)" Class="bottom-nav-item"
+                   OnClick="@(() => NavigateToBottomNav(NavigationTab.Data))">
+            <MudStack AlignItems="AlignItems.Center" Spacing="0">
+                <MudIcon Icon="@Icons.Material.Filled.QueryStats" Size="Size.Medium" />
+                <MudText Typo="Typo.caption">Data</MudText>
+            </MudStack>
+        </MudButton>
         <MudButton Variant="Variant.Text" Color="@GetBottomNavColor(NavigationTab.Monitor)" Class="bottom-nav-item"
                    OnClick="@(() => NavigateToBottomNav(NavigationTab.Monitor))">
             <MudStack AlignItems="AlignItems.Center" Spacing="0">

--- a/src/Apps/EcoPortal/EcoPortal.Client/Services/TabNavigationService.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Services/TabNavigationService.cs
@@ -8,6 +8,7 @@ namespace EcoPortal.Client.Services;
 public enum NavigationTab
 {
     Home,
+    Data,
     Monitor,
     Orgs,
     Account
@@ -45,6 +46,7 @@ public sealed class TabNavigationService : ITabNavigationService
     private static string GetTabRoot(NavigationTab tab) => tab switch
     {
         NavigationTab.Home => "/",
+        NavigationTab.Data => "/data",
         NavigationTab.Monitor => "/monitor",
         NavigationTab.Orgs => "/orgs",
         NavigationTab.Account => "/account",
@@ -54,6 +56,7 @@ public sealed class TabNavigationService : ITabNavigationService
     private static NavigationTab GetTabFromPath(string path) => path switch
     {
         "/" or "" => NavigationTab.Home,
+        _ when path.StartsWith("/data") => NavigationTab.Data,
         _ when path.StartsWith("/monitor") || path.StartsWith("/sensor") || path.StartsWith("/alerts")
             => NavigationTab.Monitor,
         _ when path.StartsWith("/orgs") || path.StartsWith("/organizations") || path.StartsWith("/access-requests")


### PR DESCRIPTION
## Summary
- Adds a `Data` tab to the mobile bottom navigation between `Home` and `Monitor`, mirroring the desktop top-bar order, so mobile users can reach `/data` (and `/data/surface-water`).
- Extends `NavigationTab` with `Data` and updates `TabNavigationService` so any path under `/data*` activates the new tab and `Tabs.NavigateToTab(NavigationTab.Data)` routes to `/data`.

## Why
Desktop top-bar has `Data` link, but it's hidden on mobile via `MudHidden`. The mobile bottom nav was a fixed list of four tabs (Home / Monitor / Orgs / Account) with no entry for Data — there was literally no way for a mobile user to reach the data portal added in #217.

## Test plan
- [ ] Open the app on a narrow viewport (<MdAndUp). Bottom nav now shows five tabs: Home · Data · Monitor · Orgs · Account.
- [ ] Tap `Data` → routes to `/data`.
- [ ] On `/data` and `/data/surface-water`, the `Data` tab is highlighted as active.
- [ ] On `/sensors`, the `Monitor` tab is still highlighted (regression check).
- [ ] Five tabs still fit without overflow on the smallest target widths.