### PR TITLE
feat(eco-portal): give /sensor-dashboard the data-portal hero treatment

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorsPage.razor
@@ -1,21 +1,130 @@
 @page "/sensor-dashboard"
+@using BlazingSingularity.Fetch
+@using EcoData.Sensors.Application.Client
 @using EcoData.Sensors.Contracts.Dtos
+@using EcoData.Sensors.Contracts.Parameters
 @using EcoPortal.Client.Features.Sensors.Components
 @inject INativeNavigationManager Navigation
 @inject INativeNavbarManager Navbar
+@inject ISensorHttpClient SensorClient
+@inject ISensorReadingHttpClient ReadingClient
+@inject ISnackbar Snackbar
 
 <PageTitle>Sensors - EcoData</PageTitle>
 
 <div class="sensors-page">
-    <section class="sensors-content">
-        <SensorList OnSensorClick="NavigateToDetail" />
+
+    <section class="hero">
+        <div class="hero-in">
+            <div>
+                <div class="hero-eyebrow"><span class="v-line"></span>Live Network · Puerto Rico</div>
+                <h1>Every sensor, <em>visible</em>.</h1>
+                <p>
+                    Real-time and recent readings from every monitoring station registered to the EcoData network —
+                    USGS Caribbean stations, partner organizations, and individual researchers. Browse by status,
+                    organization, or municipality.
+                </p>
+            </div>
+
+            <aside class="hero-stats">
+                <div class="hero-stats-k"><span class="pulse"></span>Updated · just now</div>
+                <div class="hs-item">
+                    <span class="hs-label">Total sensors</span>
+                    @if (_totalSensorsFetch.IsLoading)
+                    {
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="120px" Height="32px" />
+                    }
+                    else
+                    {
+                        <span class="hs-val">@_totalSensorsFetch.Data.ToString("N0")</span>
+                    }
+                </div>
+                <div class="hs-item">
+                    <span class="hs-label">Active sensors</span>
+                    @if (_activeSensorsFetch.IsLoading || _totalSensorsFetch.IsLoading)
+                    {
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="120px" Height="32px" />
+                    }
+                    else
+                    {
+                        <span class="hs-val">@_activeSensorsFetch.Data.ToString("N0")<span class="u">/@_totalSensorsFetch.Data.ToString("N0")</span></span>
+                    }
+                </div>
+                <div class="hs-item">
+                    <span class="hs-label">Total readings</span>
+                    @if (_totalReadingsFetch.IsLoading)
+                    {
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="120px" Height="32px" />
+                    }
+                    else
+                    {
+                        <span class="hs-val">@_totalReadingsFetch.Data.ToString("N0")</span>
+                    }
+                </div>
+                <div class="hs-item"><span class="hs-label">Updated every</span><span class="hs-val">15<span class="u">min</span></span></div>
+            </aside>
+        </div>
     </section>
+
+    <main class="body-in">
+
+        <div class="section-h">
+            <div class="section-h-l">
+                <div class="eyebrow">Browse stations</div>
+                <h2>Find a <em>station</em></h2>
+                <p>Search by river, municipality, or station ID. Click any sensor to drill into its live readings, recent history, and configuration.</p>
+            </div>
+        </div>
+
+        <div class="list-card">
+            <SensorList OnSensorClick="NavigateToDetail" />
+        </div>
+
+    </main>
 </div>
 
 @code {
+    private IFetch<int> _totalSensorsFetch = default!;
+    private IFetch<int> _activeSensorsFetch = default!;
+    private IFetch<long> _totalReadingsFetch = default!;
+
     protected override void OnInitialized()
     {
         Navbar.SetTitle("Sensors");
+
+        _totalSensorsFetch = new Fetch<int>(
+            ct => SensorClient.GetSensorCountAsync(new SensorParameters(), ct),
+            () => InvokeAsync(StateHasChanged)
+        );
+        _totalSensorsFetch.OnChange(() =>
+        {
+            if (_totalSensorsFetch.IsError)
+                Snackbar.Add("Couldn't load total sensor count.", Severity.Error);
+        });
+
+        _activeSensorsFetch = new Fetch<int>(
+            ct => SensorClient.GetSensorCountAsync(new SensorParameters(IsActive: true), ct),
+            () => InvokeAsync(StateHasChanged)
+        );
+        _activeSensorsFetch.OnChange(() =>
+        {
+            if (_activeSensorsFetch.IsError)
+                Snackbar.Add("Couldn't load active sensor count.", Severity.Error);
+        });
+
+        _totalReadingsFetch = new Fetch<long>(
+            ct => ReadingClient.GetTotalCountAsync(ct),
+            () => InvokeAsync(StateHasChanged)
+        );
+        _totalReadingsFetch.OnChange(() =>
+        {
+            if (_totalReadingsFetch.IsError)
+                Snackbar.Add("Couldn't load reading count.", Severity.Error);
+        });
+
+        _ = _totalSensorsFetch.FetchAsync();
+        _ = _activeSensorsFetch.FetchAsync();
+        _ = _totalReadingsFetch.FetchAsync();
     }
 
     private void NavigateToDetail(SensorDtoForList sensor)

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorsPage.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Sensors/Pages/SensorsPage.razor.css
@@ -1,47 +1,241 @@
 .sensors-page {
-    max-width: 100%;
+    --eco-primary: #003452;
+    --eco-primary-500: #0a6ba0;
+    --eco-fg: #1f2937;
+    --eco-fg-2: #4b5563;
+    --eco-fg-3: #6b7280;
+    --eco-fg-4: #9ca3af;
+    --eco-line: #e5e7eb;
+    --eco-bg-alt: #f3f4f6;
+    --eco-font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --eco-font-serif: 'Newsreader', 'Georgia', serif;
+
+    background: #f7f7f5;
+    color: var(--eco-fg);
+    font-family: var(--eco-font-sans);
+    -webkit-font-smoothing: antialiased;
 }
 
-.sensors-header {
-    margin-bottom: 1rem;
+/* ===== Hero ===== */
+.hero {
+    background: linear-gradient(180deg, #003452 0%, #002940 100%);
+    color: #fff;
+    border-bottom: 1px solid var(--eco-line);
+    position: relative;
+    overflow: hidden;
+}
+
+    .hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Cg fill='none' stroke='%23ffffff' stroke-opacity='0.03' stroke-width='1'%3E%3Cpath d='M0 40 Q 20 20, 40 40 T 80 40'/%3E%3Cpath d='M0 60 Q 20 40, 40 60 T 80 60'/%3E%3Cpath d='M0 20 Q 20 0, 40 20 T 80 20'/%3E%3C/g%3E%3C/svg%3E");
+        opacity: 0.5;
+        pointer-events: none;
+    }
+
+.hero-in {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 56px 40px 44px;
+    display: grid;
+    grid-template-columns: 1fr 360px;
+    gap: 48px;
+    align-items: center;
+    position: relative;
+}
+
+.hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: #93c5fd;
+    margin-bottom: 18px;
+}
+
+    .hero-eyebrow .v-line {
+        width: 32px;
+        height: 1px;
+        background: #93c5fd;
+    }
+
+.hero h1 {
+    font-family: var(--eco-font-serif);
+    font-weight: 600;
+    font-size: clamp(38px, 4.6vw, 56px);
+    letter-spacing: -0.025em;
+    line-height: 1.05;
+    margin: 0 0 18px;
+}
+
+    .hero h1 em {
+        font-style: italic;
+        font-weight: 500;
+        color: #c4a455;
+    }
+
+.hero p {
+    font-family: var(--eco-font-serif);
+    font-size: 18px;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.78);
+    max-width: 620px;
+    margin: 0;
+}
+
+.hero-stats {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 14px;
+    padding: 24px;
+}
+
+.hero-stats-k {
     display: flex;
-    flex-direction: column;
-    gap: 1rem;
+    align-items: center;
+    gap: 8px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: rgba(255, 255, 255, 0.55);
+    font-weight: 700;
+    margin-bottom: 18px;
 }
 
-@media (min-width: 960px) {
-    .sensors-header {
-        flex-direction: row;
-        align-items: flex-end;
-        justify-content: space-between;
+    .hero-stats-k .pulse {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: #34d399;
+        box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.7);
+        animation: sensors-pulse 2s infinite;
+    }
+
+@keyframes sensors-pulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.7);
+    }
+
+    70% {
+        box-shadow: 0 0 0 8px rgba(52, 211, 153, 0);
+    }
+
+    100% {
+        box-shadow: 0 0 0 0 rgba(52, 211, 153, 0);
     }
 }
 
-.header-title-section {
+.hs-item {
+    padding: 12px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
     display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+    justify-content: space-between;
+    align-items: baseline;
 }
 
-.header-label {
-    font-size: 0.75rem;
+    .hs-item:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+    }
+
+    .hs-item:first-child {
+        padding-top: 0;
+    }
+
+.hs-label {
+    font-size: 12.5px;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.hs-val {
+    font-family: var(--eco-font-serif);
+    font-size: 22px;
+    font-weight: 600;
+    color: #fff;
+    letter-spacing: -0.018em;
+}
+
+    .hs-val .u {
+        font-family: var(--eco-font-sans);
+        font-size: 11px;
+        color: rgba(255, 255, 255, 0.55);
+        font-weight: 400;
+        margin-left: 3px;
+    }
+
+/* ===== Body ===== */
+.body-in {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 56px 40px 80px;
+}
+
+.section-h {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    margin-bottom: 24px;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.section-h-l .eyebrow {
+    font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.15em;
-    color: var(--mud-palette-text-secondary);
+    letter-spacing: 0.18em;
+    color: var(--eco-primary-500);
+    margin-bottom: 10px;
 }
 
-.header-heading {
-    font-family: 'Newsreader', serif;
-    font-size: clamp(2.5rem, 5vw, 3.5rem);
-    font-weight: 500;
-    color: var(--mud-palette-primary);
+.section-h-l h2 {
+    font-family: var(--eco-font-serif);
+    font-size: 32px;
+    font-weight: 600;
+    letter-spacing: -0.022em;
+    color: var(--eco-primary);
     margin: 0;
-    letter-spacing: -0.02em;
-    line-height: 1.1;
 }
 
-.sensors-content {
-    display: flex;
-    flex-direction: column;
+    .section-h-l h2 em {
+        font-style: italic;
+        font-weight: 500;
+        color: var(--eco-primary-500);
+    }
+
+.section-h-l p {
+    font-size: 14px;
+    color: var(--eco-fg-3);
+    max-width: 560px;
+    margin: 6px 0 0;
+    line-height: 1.55;
+}
+
+/* ===== List card ===== */
+.list-card {
+    background: #fff;
+    border: 1px solid var(--eco-line);
+    border-radius: 14px;
+    padding: 18px 18px 4px;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 1100px) {
+    .hero-in {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 700px) {
+    .hero-in {
+        padding: 40px 20px 32px;
+    }
+
+    .body-in {
+        padding: 40px 20px 60px;
+    }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -222,7 +222,8 @@
 
     private bool IsFullWidthPage =>
         Navigation.State.Path.StartsWith("/data", StringComparison.OrdinalIgnoreCase)
-        || Navigation.State.Path.Equals("/organizations/discover", StringComparison.OrdinalIgnoreCase);
+        || Navigation.State.Path.Equals("/organizations/discover", StringComparison.OrdinalIgnoreCase)
+        || Navigation.State.Path.Equals("/sensor-dashboard", StringComparison.OrdinalIgnoreCase);
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
## Summary
- Replaces the bare `<SensorList>` page with the same blue-hero + body layout used by `/data`. Hero stats are live (total sensors, active/total, total readings) with `MudSkeleton` while loading; errors surface via `IFetch.OnChange` + Snackbar.
- The existing virtualized `<SensorList>` still owns search/filter/list rendering — it's just now wrapped in a `.list-card` under a "Find a station" section header.
- Adds `/sensor-dashboard` to `MainLayout.IsFullWidthPage` so the hero extends edge-to-edge (mirrors how `/data` already escapes the `MudContainer`).

## Why
We agreed offline (Option B): copy the hero into the sensors page first, defer the `EcoDataLayout` extraction until a third page wants the same shell. Hero markup + CSS in this PR is intentionally a copy of `DataHubPage`'s — small blast radius, no risk to the live `/data` page, and cleanly extractable later.

## Out of scope (follow-up)
- Extracting a shared `EcoDataLayout` component once Reservoirs / Precipitation / etc. want the same shell.

## Test plan
- [ ] `/sensor-dashboard` shows the blue hero with four live stats; "Total sensors", "Active sensors", and "Total readings" populate from the existing endpoints; "Updated every 15min" is static.
- [ ] During load, each populated stat shows a `MudSkeleton`.
- [ ] If any of the three fetches fails, a Snackbar surfaces an error toast (per the IFetch + OnChange pattern).
- [ ] The hero spans edge-to-edge of the viewport (no `MudContainer` clipping), matching `/data`.
- [ ] Below the hero, the `<SensorList>` still renders correctly with search, filter, virtualized scroll, and click-to-detail.
- [ ] `/data` and `/data/surface-water` are unaffected.
- [ ] Mobile bottom nav `Monitor` tab still highlights when on `/sensor-dashboard`.