### PR TITLE
feat(eco-portal): give /organizations/discover the data-portal hero treatment

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/DiscoverOrganizationsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/DiscoverOrganizationsPage.razor
@@ -1,78 +1,153 @@
 @page "/organizations/discover"
+@using BlazingSingularity.Fetch
+@using BlazingSingularity.Signals
+@using EcoData.Common.Pagination.Blazor
+@using EcoData.Organization.Application.Client
 @using EcoData.Organization.Contracts.Dtos
 @using EcoData.Organization.Contracts.Parameters
-@using EcoData.Organization.Application.Client
-@using EcoData.Common.Pagination.Blazor
+@using EcoData.Sensors.Application.Client
+@using EcoData.Sensors.Contracts.Parameters
 @using EcoPortal.Client.Features.Organizations.Components
-@using BlazingSingularity.Signals
 @using EcoPortal.Client.Services
 @inject IOrganizationHttpClient OrganizationClient
+@inject ISensorHttpClient SensorClient
+@inject ISensorReadingHttpClient ReadingClient
 @inject INativeNavigationManager Navigation
 @inject INativeNavbarManager Navbar
 @inject AuthStateService AuthState
+@inject ISnackbar Snackbar
 
 <PageTitle>Discover Organizations - EcoData</PageTitle>
 
-<div class="organizations-page">
-    <section class="organizations-content">
-        <SearchHeader SearchSignal="SearchTextSignal" Placeholder="Search organizations..." />
+<div class="orgs-discover-page">
 
-        <div class="organizations-list">
-            <EcoDataVirtualizedList @ref="_virtualizedList" TItem="OrganizationDtoForList" TParams="OrganizationParameters"
-                                    ItemsProvider="GetItemsAsync" ParametersBuilder="BuildParameters" CursorSelector="org => org.Id" ItemSize="200"
-                                    OverscanCount="3">
-                <LoadingTemplate>
-                    @for (var i = 0; i < 4; i++)
+    <section class="hero">
+        <div class="hero-in">
+            <div>
+                <div class="hero-eyebrow"><span class="v-line"></span>Network Partners · Puerto Rico</div>
+                <h1>The teams behind the <em>data</em>.</h1>
+                <p>
+                    Universities, government agencies, and conservation groups deploying sensors and contributing
+                    datasets across Puerto Rico. Browse profiles, see who's monitoring what, and request access
+                    to private datasets.
+                </p>
+            </div>
+
+            <aside class="hero-stats">
+                <div class="hero-stats-k"><span class="pulse"></span>Updated · just now</div>
+                <div class="hs-item">
+                    <span class="hs-label">Organizations</span>
+                    @if (_orgCountFetch.IsLoading)
                     {
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="120px" Height="32px" />
+                    }
+                    else
+                    {
+                        <span class="hs-val">@_orgCountFetch.Data.ToString("N0")</span>
+                    }
+                </div>
+                <div class="hs-item">
+                    <span class="hs-label">Sensors deployed</span>
+                    @if (_sensorCountFetch.IsLoading)
+                    {
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="120px" Height="32px" />
+                    }
+                    else
+                    {
+                        <span class="hs-val">@_sensorCountFetch.Data.ToString("N0")</span>
+                    }
+                </div>
+                <div class="hs-item">
+                    <span class="hs-label">Total readings</span>
+                    @if (_readingCountFetch.IsLoading)
+                    {
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="120px" Height="32px" />
+                    }
+                    else
+                    {
+                        <span class="hs-val">@_readingCountFetch.Data.ToString("N0")</span>
+                    }
+                </div>
+                <div class="hs-item"><span class="hs-label">Updated every</span><span class="hs-val">15<span class="u">min</span></span></div>
+            </aside>
+        </div>
+    </section>
+
+    <main class="body-in">
+
+        <div class="section-h">
+            <div class="section-h-l">
+                <div class="eyebrow">Browse organizations</div>
+                <h2>Find a <em>partner</em></h2>
+                <p>Search by name to find an organization. Click any card to see their profile, sensors, and contact information.</p>
+            </div>
+        </div>
+
+        <div class="list-card">
+            <SearchHeader SearchSignal="SearchTextSignal" Placeholder="Search organizations..." />
+
+            <div class="organizations-list">
+                <EcoDataVirtualizedList @ref="_virtualizedList" TItem="OrganizationDtoForList" TParams="OrganizationParameters"
+                                        ItemsProvider="GetItemsAsync" ParametersBuilder="BuildParameters" CursorSelector="org => org.Id" ItemSize="200"
+                                        OverscanCount="3">
+                    <LoadingTemplate>
+                        @for (var i = 0; i < 4; i++)
+                        {
+                            <div class="organization-skeleton">
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100px" Class="rounded mb-3" />
+                                <MudSkeleton Width="60%" Height="20px" />
+                                <MudSkeleton Width="80%" Height="14px" Class="mt-2" />
+                            </div>
+                        }
+                    </LoadingTemplate>
+                    <EmptyTemplate>
+                        @if (!string.IsNullOrWhiteSpace(SearchText))
+                        {
+                            <div class="organizations-empty-state">
+                                <div class="empty-icon">
+                                    <MudIcon Icon="@Icons.Material.Filled.SearchOff" Size="Size.Large" />
+                                </div>
+                                <h4 class="empty-title">No organizations found</h4>
+                                <p class="empty-description">No organizations match "@SearchText"</p>
+                                <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ClearSearch" Class="mt-4">
+                                    Clear Search
+                                </MudButton>
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="organizations-empty-state">
+                                <div class="empty-icon">
+                                    <MudIcon Icon="@Icons.Material.Filled.Business" Size="Size.Large" />
+                                </div>
+                                <h4 class="empty-title">No organizations yet</h4>
+                                <p class="empty-description">Organizations will appear here once they are created.</p>
+                            </div>
+                        }
+                    </EmptyTemplate>
+                    <PlaceholderTemplate>
                         <div class="organization-skeleton">
                             <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100px" Class="rounded mb-3" />
                             <MudSkeleton Width="60%" Height="20px" />
                             <MudSkeleton Width="80%" Height="14px" Class="mt-2" />
                         </div>
-                    }
-                </LoadingTemplate>
-                <EmptyTemplate>
-                    @if (!string.IsNullOrWhiteSpace(SearchText))
-                    {
-                        <div class="organizations-empty-state">
-                            <div class="empty-icon">
-                                <MudIcon Icon="@Icons.Material.Filled.SearchOff" Size="Size.Large" />
-                            </div>
-                            <h4 class="empty-title">No organizations found</h4>
-                            <p class="empty-description">No organizations match "@SearchText"</p>
-                            <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ClearSearch" Class="mt-4">
-                                Clear Search
-                            </MudButton>
-                        </div>
-                    }
-                    else
-                    {
-                        <div class="organizations-empty-state">
-                            <div class="empty-icon">
-                                <MudIcon Icon="@Icons.Material.Filled.Business" Size="Size.Large" />
-                            </div>
-                            <h4 class="empty-title">No organizations yet</h4>
-                            <p class="empty-description">Organizations will appear here once they are created.</p>
-                        </div>
-                    }
-                </EmptyTemplate>
-                <PlaceholderTemplate>
-                    <div class="organization-skeleton">
-                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100px" Class="rounded mb-3" />
-                        <MudSkeleton Width="60%" Height="20px" />
-                        <MudSkeleton Width="80%" Height="14px" Class="mt-2" />
-                    </div>
-                </PlaceholderTemplate>
-                <ItemTemplate Context="organization">
-                    <OrganizationListItem Organization="organization" OnClick="NavigateToDetails" />
-                </ItemTemplate>
-            </EcoDataVirtualizedList>
+                    </PlaceholderTemplate>
+                    <ItemTemplate Context="organization">
+                        <OrganizationListItem Organization="organization" OnClick="NavigateToDetails" />
+                    </ItemTemplate>
+                </EcoDataVirtualizedList>
+            </div>
         </div>
-    </section>
+
+    </main>
 </div>
 
 @code {
     private EcoDataVirtualizedList<OrganizationDtoForList, OrganizationParameters>? _virtualizedList;
+
+    private IFetch<int> _orgCountFetch = default!;
+    private IFetch<int> _sensorCountFetch = default!;
+    private IFetch<long> _readingCountFetch = default!;
 
     [Signal]
     private string? _searchText;
@@ -81,6 +156,40 @@
     {
         Navbar.SetTitle("Organizations");
         SearchTextSignal.OnChange(_ => _virtualizedList?.Refresh());
+
+        _orgCountFetch = new Fetch<int>(
+            ct => OrganizationClient.GetOrganizationCountAsync(new OrganizationParameters(), ct),
+            () => InvokeAsync(StateHasChanged)
+        );
+        _orgCountFetch.OnChange(() =>
+        {
+            if (_orgCountFetch.IsError)
+                Snackbar.Add("Couldn't load organization count.", Severity.Error);
+        });
+
+        _sensorCountFetch = new Fetch<int>(
+            ct => SensorClient.GetSensorCountAsync(new SensorParameters(), ct),
+            () => InvokeAsync(StateHasChanged)
+        );
+        _sensorCountFetch.OnChange(() =>
+        {
+            if (_sensorCountFetch.IsError)
+                Snackbar.Add("Couldn't load sensor count.", Severity.Error);
+        });
+
+        _readingCountFetch = new Fetch<long>(
+            ct => ReadingClient.GetTotalCountAsync(ct),
+            () => InvokeAsync(StateHasChanged)
+        );
+        _readingCountFetch.OnChange(() =>
+        {
+            if (_readingCountFetch.IsError)
+                Snackbar.Add("Couldn't load reading count.", Severity.Error);
+        });
+
+        _ = _orgCountFetch.FetchAsync();
+        _ = _sensorCountFetch.FetchAsync();
+        _ = _readingCountFetch.FetchAsync();
     }
 
     private OrganizationParameters BuildParameters(Guid? cursor)

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/DiscoverOrganizationsPage.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Organizations/Pages/DiscoverOrganizationsPage.razor.css
@@ -1,45 +1,229 @@
-.organizations-page {
-    max-width: 100%;
+.orgs-discover-page {
+    --eco-primary: #003452;
+    --eco-primary-500: #0a6ba0;
+    --eco-fg: #1f2937;
+    --eco-fg-2: #4b5563;
+    --eco-fg-3: #6b7280;
+    --eco-fg-4: #9ca3af;
+    --eco-line: #e5e7eb;
+    --eco-bg-alt: #f3f4f6;
+    --eco-font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --eco-font-serif: 'Newsreader', 'Georgia', serif;
+
+    background: #f7f7f5;
+    color: var(--eco-fg);
+    font-family: var(--eco-font-sans);
+    -webkit-font-smoothing: antialiased;
 }
 
-.organizations-header {
-    margin-bottom: 1rem;
-    display: flex;
-    flex-direction: row;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 1rem;
+/* ===== Hero ===== */
+.hero {
+    background: linear-gradient(180deg, #003452 0%, #002940 100%);
+    color: #fff;
+    border-bottom: 1px solid var(--eco-line);
+    position: relative;
+    overflow: hidden;
 }
 
-.header-title-section {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+    .hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Cg fill='none' stroke='%23ffffff' stroke-opacity='0.03' stroke-width='1'%3E%3Cpath d='M0 40 Q 20 20, 40 40 T 80 40'/%3E%3Cpath d='M0 60 Q 20 40, 40 60 T 80 60'/%3E%3Cpath d='M0 20 Q 20 0, 40 20 T 80 20'/%3E%3C/g%3E%3C/svg%3E");
+        opacity: 0.5;
+        pointer-events: none;
+    }
+
+.hero-in {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 56px 40px 44px;
+    display: grid;
+    grid-template-columns: 1fr 360px;
+    gap: 48px;
+    align-items: center;
+    position: relative;
 }
 
-.header-label {
-    font-size: 0.75rem;
+.hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.15em;
-    color: var(--mud-palette-text-secondary);
+    letter-spacing: 0.18em;
+    color: #93c5fd;
+    margin-bottom: 18px;
 }
 
-.header-heading {
-    font-family: 'Newsreader', serif;
-    font-size: clamp(2.5rem, 5vw, 3.5rem);
-    font-weight: 500;
-    color: var(--mud-palette-primary);
+    .hero-eyebrow .v-line {
+        width: 32px;
+        height: 1px;
+        background: #93c5fd;
+    }
+
+.hero h1 {
+    font-family: var(--eco-font-serif);
+    font-weight: 600;
+    font-size: clamp(38px, 4.6vw, 56px);
+    letter-spacing: -0.025em;
+    line-height: 1.05;
+    margin: 0 0 18px;
+}
+
+    .hero h1 em {
+        font-style: italic;
+        font-weight: 500;
+        color: #c4a455;
+    }
+
+.hero p {
+    font-family: var(--eco-font-serif);
+    font-size: 18px;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.78);
+    max-width: 620px;
     margin: 0;
-    letter-spacing: -0.02em;
-    line-height: 1.1;
 }
 
-.organizations-content {
+.hero-stats {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 14px;
+    padding: 24px;
+}
+
+.hero-stats-k {
     display: flex;
-    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: rgba(255, 255, 255, 0.55);
+    font-weight: 700;
+    margin-bottom: 18px;
 }
 
+    .hero-stats-k .pulse {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: #34d399;
+        box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.7);
+        animation: orgs-pulse 2s infinite;
+    }
+
+@keyframes orgs-pulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.7);
+    }
+
+    70% {
+        box-shadow: 0 0 0 8px rgba(52, 211, 153, 0);
+    }
+
+    100% {
+        box-shadow: 0 0 0 0 rgba(52, 211, 153, 0);
+    }
+}
+
+.hs-item {
+    padding: 12px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+    .hs-item:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+    }
+
+    .hs-item:first-child {
+        padding-top: 0;
+    }
+
+.hs-label {
+    font-size: 12.5px;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.hs-val {
+    font-family: var(--eco-font-serif);
+    font-size: 22px;
+    font-weight: 600;
+    color: #fff;
+    letter-spacing: -0.018em;
+}
+
+    .hs-val .u {
+        font-family: var(--eco-font-sans);
+        font-size: 11px;
+        color: rgba(255, 255, 255, 0.55);
+        font-weight: 400;
+        margin-left: 3px;
+    }
+
+/* ===== Body ===== */
+.body-in {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 56px 40px 80px;
+}
+
+.section-h {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    margin-bottom: 24px;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.section-h-l .eyebrow {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--eco-primary-500);
+    margin-bottom: 10px;
+}
+
+.section-h-l h2 {
+    font-family: var(--eco-font-serif);
+    font-size: 32px;
+    font-weight: 600;
+    letter-spacing: -0.022em;
+    color: var(--eco-primary);
+    margin: 0;
+}
+
+    .section-h-l h2 em {
+        font-style: italic;
+        font-weight: 500;
+        color: var(--eco-primary-500);
+    }
+
+.section-h-l p {
+    font-size: 14px;
+    color: var(--eco-fg-3);
+    max-width: 560px;
+    margin: 6px 0 0;
+    line-height: 1.55;
+}
+
+/* ===== List card ===== */
+.list-card {
+    background: #fff;
+    border: 1px solid var(--eco-line);
+    border-radius: 14px;
+    padding: 18px 18px 4px;
+}
+
+/* ===== List items / empty / skeleton (preserved from previous design) ===== */
 .organizations-list {
     display: flex;
     flex-direction: column;
@@ -52,7 +236,6 @@
     border-radius: 0.75rem;
 }
 
-/* Empty state styles */
 .organizations-empty-state {
     display: flex;
     flex-direction: column;
@@ -91,4 +274,21 @@
     color: var(--mud-palette-text-secondary);
     margin: 0;
     max-width: 300px;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 1100px) {
+    .hero-in {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 700px) {
+    .hero-in {
+        padding: 40px 20px 32px;
+    }
+
+    .body-in {
+        padding: 40px 20px 60px;
+    }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -221,7 +221,8 @@
     }
 
     private bool IsFullWidthPage =>
-        Navigation.State.Path.StartsWith("/data", StringComparison.OrdinalIgnoreCase);
+        Navigation.State.Path.StartsWith("/data", StringComparison.OrdinalIgnoreCase)
+        || Navigation.State.Path.Equals("/organizations/discover", StringComparison.OrdinalIgnoreCase);
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationEndpoints.cs
@@ -34,6 +34,18 @@ public static class OrganizationEndpoints
 
         group
             .MapGet(
+                "/count",
+                (
+                    [AsParameters] OrganizationParameters parameters,
+                    IOrganizationRepository repository,
+                    CancellationToken ct
+                ) => repository.GetOrganizationCountAsync(parameters, ct)
+            )
+            .WithName("GetOrganizationCount")
+            .AllowAnonymous();
+
+        group
+            .MapGet(
                 "/my",
                 (ClaimsPrincipal user, IOrganizationRepository repository, CancellationToken ct) =>
                 {

--- a/src/Features/Organization/EcoData.Organization.Application.Client/IOrganizationHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/IOrganizationHttpClient.cs
@@ -13,6 +13,11 @@ public interface IOrganizationHttpClient
         CancellationToken cancellationToken = default
     );
 
+    Task<int> GetOrganizationCountAsync(
+        OrganizationParameters parameters,
+        CancellationToken cancellationToken = default
+    );
+
     IAsyncEnumerable<MyOrganizationDto> GetMyOrganizationsAsync(
         CancellationToken cancellationToken = default
     );

--- a/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationHttpClient.cs
@@ -27,6 +27,21 @@ public sealed class OrganizationHttpClient(HttpClient httpClient) : IOrganizatio
         )!;
     }
 
+    public Task<int> GetOrganizationCountAsync(
+        OrganizationParameters parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var queryString = new QueryStringBuilder()
+            .Add("search", parameters.Search)
+            .Build();
+
+        return httpClient.GetFromJsonAsync<int>(
+            $"organization/organizations/count{queryString}",
+            cancellationToken
+        )!;
+    }
+
     public IAsyncEnumerable<MyOrganizationDto> GetMyOrganizationsAsync(
         CancellationToken cancellationToken = default
     )

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Interfaces/IOrganizationRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Interfaces/IOrganizationRepository.cs
@@ -9,6 +9,11 @@ public interface IOrganizationRepository
         OrganizationParameters parameters,
         CancellationToken cancellationToken = default
     );
+
+    Task<int> GetOrganizationCountAsync(
+        OrganizationParameters parameters,
+        CancellationToken cancellationToken = default
+    );
     Task<OrganizationDtoForDetail?> GetByIdAsync(
         Guid id,
         CancellationToken cancellationToken = default

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRepository.cs
@@ -61,6 +61,24 @@ public sealed class OrganizationRepository(IDbContextFactory<OrganizationDbConte
         }
     }
 
+    public async Task<int> GetOrganizationCountAsync(
+        OrganizationParameters parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.Organizations.AsNoTracking().AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(parameters.Search))
+        {
+            var search = parameters.Search.ToLower();
+            query = query.Where(o => o.Name.ToLower().Contains(search));
+        }
+
+        return await query.CountAsync(cancellationToken);
+    }
+
     public async Task<OrganizationDtoForDetail?> GetByIdAsync(
         Guid id,
         CancellationToken cancellationToken = default


### PR DESCRIPTION
## Summary
- Migrates `/organizations/discover` from a bare list to the same blue-hero + body layout as `/data` and `/sensor-dashboard` (#220).
- Hero shows four live stats: Organizations, Sensors deployed, Total readings, Updated every 15min — `MudSkeleton` during load, `IFetch.OnChange` + `Snackbar` on error.
- Existing search header + `EcoDataVirtualizedList` move into a white `.list-card` under a "Find a partner" section header. List behavior is unchanged.
- Adds a new public `GET /organization/organizations/count` endpoint (with `?search=` filter for parity with the list endpoint) to power the organization count.
- Adds `/organizations/discover` to `MainLayout.IsFullWidthPage` so the hero spans edge-to-edge.

## Why
Option B (copy hero, defer extraction) per the offline conversation. With this PR, three pages now use the same hero (`/data`, `/sensor-dashboard`, `/organizations/discover`), so extracting a shared `EcoDataLayout` next is grounded in three real call sites instead of speculation.

## Conflict to be aware of
This and #220 both add to `MainLayout.IsFullWidthPage`. Tiny conflict, mechanical to resolve at merge time.

## Visual note for desktop
On `/organizations/discover` while authenticated, the existing contextual nav strip (Discover / My Organizations / Access Requests) still wraps in `MudContainer.MaxWidth.Large`, so it's a centered narrow strip above an edge-to-edge hero. Acceptable for now; if you want it to also span full-width, that's a follow-up.

## Test plan
- [ ] Visit `/organizations/discover`. Blue hero appears with live counts; skeletons show while loading; counts populate from `/organization/organizations/count`, `/sensors/count`, `/readings/count`.
- [ ] Search box still filters the list, and the org count remains the *unfiltered* total (matches the design — count reflects the dataset, not the filter).
- [ ] If any of the three count endpoints fails, an error Snackbar appears.
- [ ] Click an org card → navigates to `/organizations/{id}` (regression check).
- [ ] On a narrow viewport, hero stacks; bottom-nav `Orgs` tab still highlights when on `/organizations/discover`.
- [ ] `/data`, `/data/surface-water`, and `/sensor-dashboard` (after #220) are unaffected.

## Out of scope (follow-up)
- Extract a shared `EcoDataLayout` component now that three pages use the hero.
- Decide whether `OrganizationParameters.Search` should also filter the count (currently it does on the backend, but the page calls it without a search arg so it always shows total).