### PR TITLE
chore(notifications): trim the top-right notification popover

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationBell.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationBell.razor
@@ -62,6 +62,13 @@
         margin-right: 8px;
     }
 
+    /* Pull the unread-count badge inward so it sits on the icon's top-right corner
+       instead of floating above the button. */
+    .notification-bell .mud-badge.mud-badge-overlap {
+        top: 25%;
+        right: 25%;
+    }
+
     .notification-popover {
         width: 340px;
         max-height: 440px;

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationBell.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationBell.razor
@@ -63,10 +63,12 @@
     }
 
     /* Pull the unread-count badge inward so it sits on the icon's top-right corner
-       instead of floating above the button. */
+       instead of floating above the button. Override MudBlazor's default
+       translate(50%, -50%) which was pulling it back up the y-axis. */
     .notification-bell .mud-badge.mud-badge-overlap {
-        top: 25%;
-        right: 25%;
+        top: 8px;
+        right: 8px;
+        transform: none;
     }
 
     .notification-popover {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationBell.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationBell.razor
@@ -63,8 +63,8 @@
     }
 
     .notification-popover {
-        width: 360px;
-        max-height: 480px;
+        width: 340px;
+        max-height: 440px;
         overflow: hidden;
     }
 </style>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationBell.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationBell.razor
@@ -62,13 +62,15 @@
         margin-right: 8px;
     }
 
-    /* Pull the unread-count badge inward so it sits on the icon's top-right corner
-       instead of floating above the button. Override MudBlazor's default
-       translate(50%, -50%) which was pulling it back up the y-axis. */
-    .notification-bell .mud-badge.mud-badge-overlap {
-        top: 8px;
-        right: 8px;
-        transform: none;
+    /* Pull the unread-count badge inward so it sits on the icon's top-right corner.
+       MudBadge's .Class lands on the .mud-badge-root wrapper; the actual bubble is
+       its child .mud-badge. We need !important to beat MudBlazor's default position
+       rules (top: 14%; right: 14%; transform: translate(50%, -50%)) which were
+       pulling the badge above the button. */
+    .notification-bell .mud-badge {
+        top: 8px !important;
+        right: 8px !important;
+        transform: none !important;
     }
 
     .notification-popover {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationPanel.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/NotificationPanel.razor
@@ -6,25 +6,23 @@
 
 <MudPaper Elevation="0" Class="notification-panel">
     <div class="notification-header">
-        <MudText Typo="Typo.h6">Notifications</MudText>
+        <MudText Typo="Typo.subtitle2">Notifications</MudText>
         <MudSpacer />
         @if (NotificationService.UnreadCount > 0)
         {
-            <MudButton Variant="Variant.Text"
-                       Color="Color.Primary"
-                       Size="Size.Small"
-                       OnClick="MarkAllAsReadAsync">
+            <MudLink Color="Color.Primary"
+                     Typo="Typo.caption"
+                     Underline="Underline.None"
+                     OnClick="MarkAllAsReadAsync">
                 Mark all read
-            </MudButton>
+            </MudLink>
         }
     </div>
-
-    <MudDivider />
 
     <div class="notification-list">
         @if (_isLoading)
         {
-            <div class="d-flex justify-center pa-4">
+            <div class="d-flex justify-center pa-3">
                 <MudProgressCircular Size="Size.Small" Indeterminate="true" />
             </div>
         }
@@ -32,9 +30,9 @@
         {
             <div class="empty-state">
                 <MudIcon Icon="@Icons.Material.Outlined.NotificationsNone"
-                         Size="Size.Large"
+                         Size="Size.Medium"
                          Color="Color.Default" />
-                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
                     No notifications yet
                 </MudText>
             </div>
@@ -54,11 +52,8 @@
                         <MudText Typo="Typo.body2" Class="notification-title">
                             @notification.Title
                         </MudText>
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">
-                            @notification.SensorName
-                        </MudText>
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">
-                            @FormatTime(notification.CreatedAt)
+                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="notification-meta">
+                            @notification.SensorName · @FormatTime(notification.CreatedAt)
                         </MudText>
                     </div>
                     @if (!notification.IsRead)
@@ -70,32 +65,29 @@
 
             @if (_hasMore)
             {
-                <div class="d-flex justify-center pa-2">
-                    <MudButton Variant="Variant.Text"
-                               Size="Size.Small"
-                               OnClick="LoadMoreAsync"
-                               Disabled="_isLoadingMore">
+                <div class="d-flex justify-center py-1">
+                    <MudLink Typo="Typo.caption"
+                             Underline="Underline.None"
+                             OnClick="LoadMoreAsync"
+                             Disabled="_isLoadingMore">
                         @if (_isLoadingMore)
                         {
                             <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
                         }
                         Load more
-                    </MudButton>
+                    </MudLink>
                 </div>
             }
         }
     </div>
 
-    <MudDivider />
-
     <div class="notification-footer">
-        <MudButton Variant="Variant.Text"
-                   Color="Color.Primary"
-                   Size="Size.Small"
-                   FullWidth="true"
-                   Href="/notifications">
-            View all notifications
-        </MudButton>
+        <MudLink Href="/notifications"
+                 Typo="Typo.caption"
+                 Underline="Underline.None"
+                 Color="Color.Primary">
+            View all
+        </MudLink>
     </div>
 </MudPaper>
 
@@ -183,11 +175,7 @@
     }
 
     private string GetNotificationClass(UserNotificationDto notification)
-    {
-        return notification.IsRead
-            ? "notification-item"
-            : "notification-item notification-unread";
-    }
+        => "notification-item";
 
     private string GetNotificationIcon(string type) => type switch
     {
@@ -237,19 +225,21 @@
     .notification-header {
         display: flex;
         align-items: center;
-        padding: 12px 16px;
+        padding: 8px 12px;
     }
 
     .notification-list {
         flex: 1;
         overflow-y: auto;
         max-height: 320px;
+        border-top: 1px solid var(--mud-palette-divider);
+        border-bottom: 1px solid var(--mud-palette-divider);
     }
 
     .notification-item {
         display: flex;
-        align-items: flex-start;
-        padding: 12px 16px;
+        align-items: center;
+        padding: 8px 12px;
         cursor: pointer;
         transition: background-color 0.15s;
         position: relative;
@@ -259,13 +249,10 @@
         background-color: var(--mud-palette-action-default-hover);
     }
 
-    .notification-unread {
-        background-color: var(--mud-palette-primary-lighten);
-    }
-
     .notification-icon {
-        margin-right: 12px;
-        padding-top: 2px;
+        margin-right: 10px;
+        display: flex;
+        align-items: center;
     }
 
     .notification-content {
@@ -275,17 +262,20 @@
 
     .notification-title {
         font-weight: 500;
-        line-height: 1.3;
+        line-height: 1.25;
+    }
+
+    .notification-meta {
+        line-height: 1.25;
     }
 
     .unread-dot {
-        width: 8px;
-        height: 8px;
+        width: 6px;
+        height: 6px;
         border-radius: 50%;
         background-color: var(--mud-palette-primary);
         margin-left: 8px;
         flex-shrink: 0;
-        align-self: center;
     }
 
     .empty-state {
@@ -293,11 +283,13 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        padding: 32px 16px;
-        gap: 8px;
+        padding: 20px 12px;
+        gap: 4px;
     }
 
     .notification-footer {
-        padding: 8px;
+        display: flex;
+        justify-content: center;
+        padding: 6px;
     }
 </style>

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/Notifications/Components/NotificationListItem.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/Notifications/Components/NotificationListItem.razor.css
@@ -12,10 +12,6 @@
     background-color: var(--mud-palette-action-default-hover);
 }
 
-.notification-item.unread {
-    background-color: var(--mud-palette-primary-lighten);
-}
-
 .notification-content {
     flex: 1;
     min-width: 0;

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -82,6 +82,10 @@
 
         @* Mobile: Action button(s) at far right *@
         <MudHidden Breakpoint="Breakpoint.MdAndUp">
+            @if (AuthState.IsAuthenticated)
+            {
+                <NotificationBell />
+            }
             @if (!IsHomePage)
             {
                 <NuiNativeNavbar ShowBackButton="false" ShowTitle="false" />


### PR DESCRIPTION
## Summary
Bulky notification popover trimmed. Each item dropped from three lines to two; dividers, full-width buttons, and the unread-row tint are gone in favor of subtle borders and a smaller dot.

## Changes
| | Before | After |
|---|---|---|
| Notification rows | icon + 3 stacked text lines | icon + title + meta row (\`sensor · 5m ago\`) |
| Item padding | 12px/16px | 8px/12px |
| Header | Typo.h6 + MudButton "Mark all read" | Typo.subtitle2 + small text link |
| Footer | Full-width MudButton "View all notifications" | Small text link "View all" |
| Dividers | Two MudDividers | 1px borders on the list region only |
| Unread state | Lighten-tinted row + 8px dot | 6px dot only |
| Popover size | 360 × 480 | 340 × 440 |

## Test plan
- [ ] Bell renders, click toggles popover.
- [ ] Header/footer compact, list scrolls within max-height.
- [ ] Empty state still shown when zero notifications.
- [ ] Unread dot visible on unread items, hidden on read.
- [ ] Click on an item still navigates to the sensor and marks-as-read.
- [ ] Mobile (the bell is desktop-only per MainLayout, but verify no overflow at 340px).