### PR TITLE
feat(sensors): publish ReadingCreatedEvent from USGS pull worker

### DIFF
--- a/src/Features/Sensors/EcoData.Sensors.Ingestion/Program.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Ingestion/Program.cs
@@ -1,3 +1,4 @@
+using EcoData.Common.Messaging;
 using EcoData.Locations.DataAccess.Extensions;
 using EcoData.Locations.Database.Extensions;
 using EcoData.Organization.DataAccess;
@@ -17,6 +18,8 @@ builder.AddSensorsDatabase();
 builder.Services.AddSensorsDataAccess();
 builder.AddLocationsDatabase();
 builder.Services.AddLocationsDataAccess();
+builder.Services.AddMessaging(messaging =>
+    messaging.UseAzureServiceBus(builder.Configuration.GetSection("Messaging:ServiceBus")));
 
 builder.Services.AddHttpClient<IUsgsApiClient, UsgsApiClient>(client =>
 {

--- a/src/Features/Sensors/EcoData.Sensors.Ingestion/Workers/UsgsIngestionWorker.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Ingestion/Workers/UsgsIngestionWorker.cs
@@ -1,7 +1,9 @@
+using EcoData.Common.Messaging.Abstractions;
 using EcoData.Locations.DataAccess.Interfaces;
 using EcoData.Organization.Contracts.Dtos;
 using EcoData.Organization.DataAccess.Interfaces;
 using EcoData.Sensors.Contracts.Dtos;
+using EcoData.Sensors.Contracts.Events;
 using EcoData.Sensors.DataAccess.Interfaces;
 using EcoData.Sensors.DataAccess.Resolvers;
 using EcoData.Sensors.Ingestion.Services;
@@ -20,6 +22,7 @@ public sealed class UsgsIngestionWorker(
     IMunicipalityRepository municipalityRepository,
     ParameterResolver parameterResolver,
     IUsgsApiClient usgsApiClient,
+    IMessageBus messageBus,
     IHostEnvironment hostEnvironment,
     ILogger<UsgsIngestionWorker> logger
 ) : BackgroundService
@@ -192,6 +195,22 @@ public sealed class UsgsIngestionWorker(
                     foreach (var (sensorId, lastReading) in sensorLastReadings)
                     {
                         await healthRepository.RecordReadingAsync(sensorId, lastReading, stoppingToken);
+                    }
+
+                    foreach (var reading in readingsToAdd)
+                    {
+                        await messageBus.PublishEventAsync(
+                            new ReadingCreatedEvent(
+                                reading.SensorId,
+                                reading.Parameter,
+                                reading.Description,
+                                reading.Value,
+                                reading.Unit,
+                                reading.RecordedAt
+                            ),
+                            topic: reading.SensorId.ToString(),
+                            cancellationToken: stoppingToken
+                        );
                     }
 
                     logger.LogInformation("Ingested {Count} readings, last recorded at {LastRecordedAt}",

--- a/src/Host/EcoData.AppHost/AppHost.cs
+++ b/src/Host/EcoData.AppHost/AppHost.cs
@@ -125,6 +125,10 @@ var sensorsIngestion = builder
     .WithReference(organizationDb)
     .WithReference(sensorsDb)
     .WithReference(locationsDb)
+    .WithReference(serviceBus)
+    .WaitFor(eventsTopic)
+    .WithEnvironment("Messaging__ServiceBus__ConnectionString", serviceBus.Resource.ConnectionStringExpression)
+    .WithEnvironment("Messaging__ServiceBus__TopicName", "ecodata-events")
     .WaitFor(seeder);
 
 // Azure resources for production


### PR DESCRIPTION
## Summary
- USGS ingestion worker now publishes one `ReadingCreatedEvent` per persisted reading, matching the push-API contract (`SensorReadingEndpoints.cs`). Push and pull paths now emit the same event so a single subscriber can react to readings regardless of source.
- `EcoData.Sensors.Ingestion` host wires the existing `IMessageBus` (`AddMessaging` + `UseAzureServiceBus`) using the same `Messaging:ServiceBus` config keys the EcoPortal server uses.
- Aspire AppHost gives the `sensors-ingestion` project a Service Bus reference, the `Messaging__ServiceBus__*` env vars, and a `WaitFor(eventsTopic)` so the worker doesn't start before the topic exists.

## Why
First step of a three-PR plan to move the Surface Water dashboard off live aggregations:
1. **(this PR)** Wire the event so both ingest paths publish it.
2. Add a `SurfaceWaterStationSnapshot` table (entity + migration).
3. Subscribe a worker to `ReadingCreatedEvent` and keep the snapshot updated, then point `SurfaceWaterRepository` at it.

Reuses the existing `ReadingCreatedEvent` rather than introducing a synonym — the contract already covers "any source" semantics.

## Test plan
- [ ] Aspire app comes up cleanly with the new Service Bus reference on the ingestion worker
- [ ] On the next USGS poll cycle, observe `ReadingCreatedEvent` messages on the `ecodata-events` topic / `readingcreatedevent` subscription
- [ ] Existing SSE subscribers (push-API consumers) keep receiving events — no regression
- [ ] Worker still records ingestion log + sensor health after the publish loop