### PR TITLE
perf(surface-water): index parameter-code queries and cache station endpoints

### DIFF
--- a/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/ReadingEndpoints.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Api/Endpoints/ReadingEndpoints.cs
@@ -11,6 +11,8 @@ public static class ReadingEndpoints
 {
     private const string TotalCountCacheKey = "readings:total-count";
     private const string SurfaceWaterSummaryCacheKey = "readings:topics:surface-water:summary";
+    private const string SurfaceWaterStationsCacheKey = "readings:topics:surface-water:stations";
+    private const string SurfaceWaterMarkersCacheKey = "readings:topics:surface-water:markers";
     private static readonly TimeSpan TotalCountCacheTtl = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan TopicCacheTtl = TimeSpan.FromMinutes(2);
 
@@ -53,19 +55,49 @@ public static class ReadingEndpoints
         topics
             .MapGet(
                 "/surface-water/stations",
-                (
+                async (
                     [AsParameters] SurfaceWaterStationParameters parameters,
                     ISurfaceWaterRepository repository,
+                    IMemoryCache cache,
                     CancellationToken ct
-                ) => repository.GetStationsAsync(parameters, ct)
+                ) =>
+                {
+                    // The sorted list is identical for every page, so it is cached
+                    // whole and sliced per request.
+                    var sorted = await cache.GetOrCreateAsync(
+                        SurfaceWaterStationsCacheKey,
+                        entry =>
+                        {
+                            entry.AbsoluteExpirationRelativeToNow = TopicCacheTtl;
+                            return repository.GetSortedStationsAsync(ct);
+                        }
+                    ) ?? [];
+
+                    var startIndex = 0;
+                    if (parameters.Cursor.HasValue)
+                    {
+                        var idx = sorted.FindIndex(s => s.SensorId == parameters.Cursor.Value);
+                        startIndex = idx >= 0 ? idx + 1 : 0;
+                    }
+
+                    var pageSize = parameters.PageSize > 0 ? parameters.PageSize : 50;
+                    return sorted.Skip(startIndex).Take(pageSize);
+                }
             )
             .WithName("GetSurfaceWaterStations");
 
         topics
             .MapGet(
                 "/surface-water/stations/markers",
-                (ISurfaceWaterRepository repository, CancellationToken ct) =>
-                    repository.GetMarkersAsync(ct)
+                (ISurfaceWaterRepository repository, IMemoryCache cache, CancellationToken ct) =>
+                    cache.GetOrCreateAsync(
+                        SurfaceWaterMarkersCacheKey,
+                        entry =>
+                        {
+                            entry.AbsoluteExpirationRelativeToNow = TopicCacheTtl;
+                            return repository.GetMarkersAsync(ct);
+                        }
+                    )
             )
             .WithName("GetSurfaceWaterStationMarkers");
 

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Interfaces/ISurfaceWaterRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Interfaces/ISurfaceWaterRepository.cs
@@ -1,5 +1,4 @@
 using EcoData.Sensors.Contracts.Dtos;
-using EcoData.Sensors.Contracts.Parameters;
 
 namespace EcoData.Sensors.DataAccess.Interfaces;
 
@@ -7,12 +6,11 @@ public interface ISurfaceWaterRepository
 {
     Task<SurfaceWaterSummaryDto> GetSummaryAsync(CancellationToken cancellationToken = default);
 
-    IAsyncEnumerable<SurfaceWaterStationDto> GetStationsAsync(
-        SurfaceWaterStationParameters parameters,
+    Task<List<SurfaceWaterStationDto>> GetSortedStationsAsync(
         CancellationToken cancellationToken = default
     );
 
-    IAsyncEnumerable<SurfaceWaterStationMarkerDto> GetMarkersAsync(
+    Task<List<SurfaceWaterStationMarkerDto>> GetMarkersAsync(
         CancellationToken cancellationToken = default
     );
 }

--- a/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/SurfaceWaterRepository.cs
+++ b/src/Features/Sensors/EcoData.Sensors.DataAccess/Repositories/SurfaceWaterRepository.cs
@@ -1,6 +1,4 @@
-using System.Runtime.CompilerServices;
 using EcoData.Sensors.Contracts.Dtos;
-using EcoData.Sensors.Contracts.Parameters;
 using EcoData.Sensors.DataAccess.Interfaces;
 using EcoData.Sensors.Database;
 using Microsoft.EntityFrameworkCore;
@@ -13,6 +11,7 @@ public sealed class SurfaceWaterRepository(IDbContextFactory<SensorsDbContext> c
     private const string StreamflowCode = "00060";
     private const string GageHeightCode = "00065";
     private const string PrecipitationCode = "00045";
+    private const int SparklineSize = 12;
 
     private static readonly string[] SurfaceWaterCodes =
         [StreamflowCode, GageHeightCode, PrecipitationCode];
@@ -76,34 +75,8 @@ public sealed class SurfaceWaterRepository(IDbContextFactory<SensorsDbContext> c
         );
     }
 
-    public async IAsyncEnumerable<SurfaceWaterStationDto> GetStationsAsync(
-        SurfaceWaterStationParameters parameters,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default
-    )
-    {
-        // The full list is materialized + sorted on every request. The slice below
-        // is what actually goes over the wire; DB cost stays the same per request.
-        // For larger station counts, swap this for a snapshot table populated by a worker.
-        var sorted = await ComputeSortedStationsAsync(sparklineSize: 12, cancellationToken);
-
-        var startIndex = 0;
-        if (parameters.Cursor.HasValue)
-        {
-            var idx = sorted.FindIndex(s => s.SensorId == parameters.Cursor.Value);
-            startIndex = idx >= 0 ? idx + 1 : 0;
-        }
-
-        var pageSize = parameters.PageSize > 0 ? parameters.PageSize : 50;
-        var end = Math.Min(sorted.Count, startIndex + pageSize);
-        for (var i = startIndex; i < end; i++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            yield return sorted[i] with { Rank = i + 1 };
-        }
-    }
-
-    public async IAsyncEnumerable<SurfaceWaterStationMarkerDto> GetMarkersAsync(
-        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    public async Task<List<SurfaceWaterStationMarkerDto>> GetMarkersAsync(
+        CancellationToken cancellationToken = default
     )
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
@@ -118,7 +91,7 @@ public sealed class SurfaceWaterRepository(IDbContextFactory<SensorsDbContext> c
 
         if (sensorIds.Count == 0)
         {
-            yield break;
+            return [];
         }
 
         var rows = await context.Sensors
@@ -154,44 +127,30 @@ public sealed class SurfaceWaterRepository(IDbContextFactory<SensorsDbContext> c
             })
             .ToListAsync(cancellationToken);
 
-        var ordered = rows
-            .Select(r => new
+        return rows
+            .Select(r =>
             {
-                r.Id,
-                r.Name,
-                r.ExternalId,
-                r.MunicipalityId,
-                r.Latitude,
-                r.Longitude,
-                r.LatestFlow,
-                r.LatestGage,
-                LatestRecordedAt = MaxNullable(r.LatestFlowAt, r.LatestGageAt),
-                Status = ResolveStatus(r.LatestFlow, MaxNullable(r.LatestFlowAt, r.LatestGageAt), dayAgo),
+                var latestRecorded = MaxNullable(r.LatestFlowAt, r.LatestGageAt);
+                return new SurfaceWaterStationMarkerDto(
+                    SensorId: r.Id,
+                    Name: r.Name,
+                    ExternalId: r.ExternalId,
+                    MunicipalityId: r.MunicipalityId,
+                    Latitude: r.Latitude,
+                    Longitude: r.Longitude,
+                    LatestStreamflowCfs: r.LatestFlow,
+                    LatestGageHeightFt: r.LatestGage,
+                    LatestRecordedAt: latestRecorded,
+                    Status: ResolveStatus(r.LatestFlow, latestRecorded, dayAgo)
+                );
             })
-            .OrderByDescending(r => r.LatestFlow ?? double.MinValue)
-            .ThenByDescending(r => r.Id);
-
-        foreach (var r in ordered)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            yield return new SurfaceWaterStationMarkerDto(
-                SensorId: r.Id,
-                Name: r.Name,
-                ExternalId: r.ExternalId,
-                MunicipalityId: r.MunicipalityId,
-                Latitude: r.Latitude,
-                Longitude: r.Longitude,
-                LatestStreamflowCfs: r.LatestFlow,
-                LatestGageHeightFt: r.LatestGage,
-                LatestRecordedAt: r.LatestRecordedAt,
-                Status: r.Status
-            );
-        }
+            .OrderByDescending(r => r.LatestStreamflowCfs ?? double.MinValue)
+            .ThenByDescending(r => r.SensorId)
+            .ToList();
     }
 
-    private async Task<List<SurfaceWaterStationDto>> ComputeSortedStationsAsync(
-        int sparklineSize,
-        CancellationToken cancellationToken
+    public async Task<List<SurfaceWaterStationDto>> GetSortedStationsAsync(
+        CancellationToken cancellationToken = default
     )
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
@@ -242,7 +201,7 @@ public sealed class SurfaceWaterRepository(IDbContextFactory<SensorsDbContext> c
                 Sparkline = context.Readings
                     .Where(r => r.SensorId == s.Id && r.Parameter == StreamflowCode)
                     .OrderByDescending(r => r.RecordedAt)
-                    .Take(sparklineSize)
+                    .Take(SparklineSize)
                     .Select(r => r.Value)
                     .ToList(),
             })
@@ -272,6 +231,7 @@ public sealed class SurfaceWaterRepository(IDbContextFactory<SensorsDbContext> c
             })
             .OrderByDescending(s => s.LatestStreamflowCfs ?? double.MinValue)
             .ThenByDescending(s => s.SensorId)
+            .Select((s, i) => s with { Rank = i + 1 })
             .ToList();
     }
 

--- a/src/Features/Sensors/EcoData.Sensors.Database/Migrations/20260805225011_AddReadingParameterRecordedAtIndex.Designer.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/Migrations/20260805225011_AddReadingParameterRecordedAtIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EcoData.Sensors.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EcoData.Sensors.Database.Migrations
 {
     [DbContext(typeof(SensorsDbContext))]
-    partial class SensorsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805225011_AddReadingParameterRecordedAtIndex")]
+    partial class AddReadingParameterRecordedAtIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Features/Sensors/EcoData.Sensors.Database/Migrations/20260805225011_AddReadingParameterRecordedAtIndex.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/Migrations/20260805225011_AddReadingParameterRecordedAtIndex.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoData.Sensors.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReadingParameterRecordedAtIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_readings_parameter_recorded_at",
+                table: "readings",
+                columns: new[] { "parameter", "recorded_at" })
+                .Annotation("Npgsql:IndexInclude", new[] { "sensor_id", "value" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_readings_parameter_recorded_at",
+                table: "readings");
+        }
+    }
+}

--- a/src/Features/Sensors/EcoData.Sensors.Database/Models/Reading.cs
+++ b/src/Features/Sensors/EcoData.Sensors.Database/Models/Reading.cs
@@ -38,6 +38,13 @@ public sealed class Reading
 
             builder.HasIndex(static e => e.RecordedAt);
 
+            // Topic queries filter by parameter code without a sensor id; the
+            // SensorId-leading indexes can't serve them. Covering SensorId/Value
+            // keeps distinct-station and latest-value scans index-only.
+            builder
+                .HasIndex(static e => new { e.Parameter, e.RecordedAt })
+                .IncludeProperties(static e => new { e.SensorId, e.Value });
+
             builder.HasIndex(static e => new { e.SensorId, e.RecordedAt });
 
             builder.HasIndex(static e => new


### PR DESCRIPTION
## Problem

The Data Hub hero stats and `/data/surface-water` are slow in prod: every surface-water query filters `readings` by parameter code with no usable index (full scans), the summary runs six sequential aggregation queries, `/stations` and `/markers` rebuilt the full sorted station list with correlated subqueries on **every** request, and `/readings/count` is a whole-table `COUNT(*)`.

## Changes

**Commit 1 — index + endpoint caching (quick wins)**
- Covering index `ix_readings_parameter_recorded_at (parameter, recorded_at) INCLUDE (sensor_id, value)` (migration `AddReadingParameterRecordedAtIndex`). All the topic queries filter by parameter code without a sensor id, which no existing index could serve.
- Interim `IMemoryCache` on the stations/markers endpoints (superseded by commit 2, kept for history).

**Commit 2 — snapshot tables recalculated every 15 min**
- New tables, rewritten in one transaction by `SurfaceWaterSnapshotRefresher` after each USGS ingestion cycle (the refresher also runs when ingestion fails, since time-windowed stats drift without new readings):
  - `surface_water_station_snapshots` — one row per station: rank, latest flow/gage, latest recorded-at, sparkline (`double precision[]`).
  - `surface_water_summary_snapshots` — single row backing the dashboard summary.
  - `reading_stats_snapshots` — single row with the portal-wide total reading count.
- `SurfaceWaterRepository` now reads the snapshots: stations page on the stored rank in SQL (`WHERE rank > cursor-rank ORDER BY rank LIMIT n`), and station **status is derived at read time** from `latest_recorded_at` so stations age into Offline between refreshes — an event/refresh path alone can never flip a station offline, because offline is defined by the absence of new data.
- `ReadingRepository.GetTotalCountAsync` reads the stats row, falling back to `COUNT(*)` only on a fresh database before the first refresh.
- All `IMemoryCache` usage removed from `ReadingEndpoints` — every dashboard read is now a select over ≤ a few hundred pre-ranked rows, and staleness no longer stacks (was up to 15 min ingestion + 2–5 min cache).

Wire format of all four endpoints is unchanged; no client changes.

## Notes

- The refresher lives in the ingestion host, so snapshot freshness tracks data arrival exactly (recompute happens seconds after each batch lands, worst case one 15-min cycle).
- Relates to #218 — this is the "recalculate on the ingestion cadence" half of that design; the Service Bus `IngestionBatchCompletedEvent` remains future work for when recompute needs to move out of the ingestion host or serve more topics.
- Builds verified per-project; full-solution build only fails on DLLs locked by locally running dev servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
