### PR TITLE
fix(layout): remove light flash during page transitions

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor.css
@@ -90,28 +90,30 @@
     }
 }
 
-/* Page transition animations */
+/* Page transition animations. Transform-only: an opacity fade lets the gray
+   .main-content background show through the incoming page, which reads as a
+   flash between pages that share the same dark hero (Data ↔ Sensors). */
 @keyframes slide-in-right {
     from {
-        opacity: 0;
+        transform: translateX(12px);
     }
     to {
-        opacity: 1;
+        transform: none;
     }
 }
 
 @keyframes slide-in-left {
     from {
-        opacity: 0;
+        transform: translateX(-12px);
     }
     to {
-        opacity: 1;
+        transform: none;
     }
 }
 
 .page-transition-forward,
 .page-transition-back {
-    will-change: opacity;
+    will-change: transform;
 }
 
 .page-transition-forward {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor.css
@@ -92,7 +92,10 @@
 
 /* Page transition animations. Transform-only: an opacity fade lets the gray
    .main-content background show through the incoming page, which reads as a
-   flash between pages that share the same dark hero (Data ↔ Sensors). */
+   flash between pages that share the same dark hero (Data ↔ Sensors).
+
+   Mobile-only: on desktop the swap is instant (one paint), so pages that open
+   with the same hero keep it visually stationary instead of re-entering. */
 @keyframes slide-in-right {
     from {
         transform: translateX(12px);
@@ -111,17 +114,19 @@
     }
 }
 
-.page-transition-forward,
-.page-transition-back {
-    will-change: transform;
-}
+@media (max-width: 959.95px) {
+    .page-transition-forward,
+    .page-transition-back {
+        will-change: transform;
+    }
 
-.page-transition-forward {
-    animation: slide-in-right 0.2s ease-out;
-}
+    .page-transition-forward {
+        animation: slide-in-right 0.2s ease-out;
+    }
 
-.page-transition-back {
-    animation: slide-in-left 0.2s ease-out;
+    .page-transition-back {
+        animation: slide-in-left 0.2s ease-out;
+    }
 }
 
 /* Ensure minimum height for content */


### PR DESCRIPTION
## Summary

Navigating between pages (most visibly Data ↔ Sensors, which share the same dark navy hero) flashed on every navigation — the hero looked like it was being torn out and replaced.

**Cause:** two things compound in `MainLayout`:
1. The page wrapper remounts on every navigation (`@key` = new GUID), which is unavoidable for the hero — it lives inside each page component, so its DOM is replaced regardless.
2. The `slide-in-right`/`slide-in-left` classes animated that remount with a pure **opacity fade from 0**, so for ~200ms the gray `.main-content` background showed through where the previous page's dark hero had been. Any animation on the swap makes an identical hero visibly "re-enter".

**Fix (CSS-only):**
- Keyframes are now transform-only (`translateX(±12px) → 0`) — the incoming page is opaque from the first frame, so the layout background can never show through.
- The animation is scoped to **mobile only** (`max-width: 959.95px`, same breakpoint the file already uses), where the directional native-feel transition was intended. On desktop the swap happens in a single paint: pages that open with the same hero keep it pixel-identical and stationary, so nothing appears replaced.

The keyed remount is kept deliberately: it's what restarts the animation on each mobile navigation (the wrapper's class doesn't change between two consecutive forward navigations).

## Testing
- Desktop: navigate Data ↔ Sensors — the blue hero should not move, fade, or flash; only the content below it changes.
- Mobile: forward/back navigation shows a subtle directional slide with no gray flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)