### PR TITLE
fix(layout): show only the Ecoportal logo in the desktop app bar

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Layout/MainLayout.razor
@@ -35,15 +35,10 @@
             </div>
         </MudHidden>
 
-        @* Desktop: Logo + Page Title *@
+        @* Desktop: Logo *@
         <MudHidden Breakpoint="Breakpoint.SmAndDown">
             <div class="d-flex align-center">
                 <span class="logo-text">Ecoportal</span>
-                @if (!IsHomePage && Navbar.State.Title is not null)
-                {
-                    <MudDivider Vertical="true" FlexItem="true" Class="mx-4 my-3" />
-                    <span class="logo-text">@Navbar.State.Title</span>
-                }
             </div>
         </MudHidden>
 


### PR DESCRIPTION
## Summary

The desktop app bar showed `Ecoportal | Data`, `Ecoportal | Sensors`, etc. — the title segment (divider + page name) swapped on every navigation, one more element visibly changing during page transitions. On desktop the active nav link already indicates the current page, so the title is redundant.

This removes the divider and page-title span from the desktop app bar, leaving just the **Ecoportal** logo.

Mobile is untouched — it has no persistent nav links, so the app-bar page title still carries the page name there.

Companion to #232 (page-transition flash fix).

## Testing
- Desktop: app bar shows only "Ecoportal" on every page; nothing in the bar changes when navigating Data ↔ Sensors.
- Mobile: back button + page title behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)