### PR TITLE
fix(deploy): stop concurrent deploy runs racing on shared Azure resources

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -11,6 +11,13 @@ permissions:
   id-token: write
   contents: read
 
+# All runs deploy into the same resource group; overlapping runs race on ARM
+# updates to shared resources (e.g. Log Analytics "Workspace cannot be updated
+# while current provisioning state is not Succeeded"), so queue them instead.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 env:
   AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
   AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}

--- a/scripts/generate-deploy-mappings.cs
+++ b/scripts/generate-deploy-mappings.cs
@@ -47,6 +47,10 @@ foreach (var (resource, project, _) in deployables)
     }
 }
 
+// The AppHost defines every resource's infrastructure; without this entry an
+// AppHost-only change (new Azure resource, env var, scaling rule) deploys nothing.
+projectToResources["EcoData.AppHost"] = [.. resources.Keys];
+
 var output = new Output(
     resources,
     projectToResources.OrderBy(x => x.Key).ToDictionary(x => x.Key, x => x.Value.Order().ToList())

--- a/src/Host/EcoData.AppHost/AppHost.cs
+++ b/src/Host/EcoData.AppHost/AppHost.cs
@@ -16,8 +16,15 @@ if (builder.ExecutionContext.IsRunMode)
         .ExcludeFromManifest();
 }
 
-// Azure Container App Environment for deployment
-builder.AddAzureContainerAppEnvironment("aca-env");
+// Azure Container App Environment for deployment. The Log Analytics workspace is
+// declared explicitly and shared with Application Insights — left implicit, each
+// provisions its own workspace, splitting telemetry in two and re-PUTting
+// workspace state on every deploy, which is what overlapping deploy runs raced on
+// ("Workspace cannot be updated while current provisioning state is not
+// Succeeded"; serialized via the concurrency group in azure-dev.yml). aca-env
+// references this workspace as 'existing', so its redeploys never touch it.
+var logAnalytics = builder.AddAzureLogAnalyticsWorkspace("law");
+builder.AddAzureContainerAppEnvironment("aca-env").WithAzureLogAnalyticsWorkspace(logAnalytics);
 
 // JWT secrets - from Key Vault in production, parameters in development
 var jwtSensorSecretKey = builder.AddParameter("jwt-sensor-secret-key", secret: true);
@@ -139,7 +146,9 @@ if (builder.ExecutionContext.IsPublishMode)
     sensorsIngestion.WithReference(keyVault);
 
     // Application Insights for telemetry
-    var appInsights = builder.AddAzureApplicationInsights("appinsights");
+    var appInsights = builder
+        .AddAzureApplicationInsights("appinsights")
+        .WithLogAnalyticsWorkspace(logAnalytics);
     ecoportal.WithReference(appInsights);
     sensorsIngestion.WithReference(appInsights);
     seeder.WithReference(appInsights);

--- a/src/Host/EcoData.AppHost/EcoData.AppHost.csproj
+++ b/src/Host/EcoData.AppHost/EcoData.AppHost.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.2.0" />
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" Version="13.2.0" />
     <PackageReference Include="Aspire.Hosting.Azure.KeyVault" Version="13.2.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.OperationalInsights" Version="13.2.0" />
     <PackageReference Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.2.0" />
     <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.4" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.2.0" />


### PR DESCRIPTION
## Problem

The deploy run for #232 failed with:

```
Failed to provision aca-env: Deployment failed: Error code = Conflict, Message = Workspace cannot be updated while current provisioning state is not Succeeded
```

Root cause: #232 and #233 merged 15 seconds apart, and `azure-dev.yml` has no concurrency control, so both workflow runs deployed into `rg-ecodata-prod` simultaneously (runs 31056917753 and 31056931091 overlap exactly). Their ARM deployments both PUT the aca-env Log Analytics workspace; Azure rejects an update while another is in flight, and both runs failed. The `build-ecoportal` / `provision-postgres` / `provision-keyvault` / `provision-appinsights` failures in the log are just the pipeline abort cancelling in-flight steps — `EcoPortal.Server` builds clean in Release locally.

## Fix

- **`azure-dev.yml`** — add a `concurrency` group (`cancel-in-progress: false`) so deploy runs queue instead of overlapping. Note: if several pushes queue up, GitHub keeps only the newest pending run; since `deploy-affected` diffs each push''s own `before..sha` range, a superseded run''s range is skipped until the next change touches those projects (`workflow_dispatch` is the manual backstop).
- **`AppHost.cs`** — declare one explicit Log Analytics workspace (`law`) shared by `aca-env` and `appinsights`. Previously each provisioned its own workspace (`acaenvlaw-*`, `lawappinsights-*`), splitting telemetry across two workspaces and re-PUTting workspace state on every deploy. Verified against the generated bicep: only `law.module.bicep` now creates a workspace; `aca-env` references it as `existing` and `appinsights` consumes its resource id, so redeploys no longer touch workspace state at all.
- **`generate-deploy-mappings.cs`** — map `EcoData.AppHost` to every deployable resource. An AppHost-only change previously matched nothing in `deployable-resources.json` and deployed nothing — which would have stranded this fix, and also means merging this PR will redeploy ecoportal/faunafinder/seeder and ship the stranded #232/#233 changes.

## Verification

- `EcoData.AppHost` builds in Release with 0 errors on top of master.
- Regenerated the Aspire manifest before/after: old bicep had a workspace resource in both `aca-env.module.bicep` and `appinsights.module.bicep`; new bicep has exactly one, in `law.module.bicep`.
- `generate-deploy-mappings.cs` runs and emits `"EcoData.AppHost": ["ecoportal", "faunafinder", "seeder"]`.

First deploy after merge will create the new `law-*` workspace and repoint the ACA environment and Application Insights at it; the old per-resource workspaces stay behind (historical logs) and can be deleted manually once cold.