### PR TITLE
fix(deploy): make manual dispatch actually deploy something

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -3,6 +3,11 @@ name: Deploy to Azure
 
 on:
   workflow_dispatch:
+    inputs:
+      from:
+        description: "Git ref to diff against when picking affected services (default: previous commit)"
+        required: false
+        type: string
   push:
     branches:
       - master
@@ -62,4 +67,10 @@ jobs:
           Parameters__jwt-sensor-secret-key: ${{ secrets.JWT_SENSOR_SECRET_KEY }}
           Parameters__customDomain: ${{ vars.CUSTOM_DOMAIN }}
           Parameters__certificateName: ${{ vars.CERTIFICATE_NAME }}
-        run: dotnet run scripts/deploy-affected.cs -- --from ${{ github.event.before }} --to ${{ github.sha }}
+          # Empty on a manual dispatch, where there is no previous-push ref.
+          DEPLOY_FROM: ${{ inputs.from || github.event.before }}
+          DEPLOY_TO: ${{ github.sha }}
+        run: |
+          dotnet run scripts/deploy-affected.cs -- \
+            --from "${DEPLOY_FROM:-HEAD~1}" \
+            --to "$DEPLOY_TO"

--- a/scripts/deploy-affected.cs
+++ b/scripts/deploy-affected.cs
@@ -89,7 +89,13 @@ return 0;
 static string? GetArg(string[] args, string name)
 {
     var index = Array.IndexOf(args, name);
-    return index >= 0 && index < args.Length - 1 ? args[index + 1] : null;
+    if (index < 0 || index >= args.Length - 1)
+        return null;
+
+    // An empty value (e.g. github.event.before on a manual dispatch) collapses
+    // during shell word splitting, leaving the next flag as this flag's value.
+    var value = args[index + 1];
+    return value.StartsWith("--") ? null : value;
 }
 
 static string FindRepoRoot(string path)


### PR DESCRIPTION
`github.event.before` is empty on a `workflow_dispatch`, and it was interpolated unquoted, so the argument list collapsed:

```
--from <before> --to <sha>    ->    --from --to <sha>
```

`GetArg` then returned `"--to"` as the from-ref, `dotnet affected` failed, no `affected.txt` was written, and the run reported **success having deployed nothing**.

Found while trying to re-drive the deploy for #237 after the push trigger produced no run (GitHub Actions major outage).

- Ignore flag-shaped values when reading an argument
- Fall back to `HEAD~1` when no from-ref is supplied
- Add a `from` input so a dispatch can target an explicit commit range

The push path is unchanged.