### PR TITLE
fix(seeder): report a failed seed as a failed job

### DIFF
--- a/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
+++ b/src/Host/EcoData.Seeder/DatabaseSeederWorker.cs
@@ -50,6 +50,9 @@ public sealed class DatabaseSeederWorker(
         catch (Exception ex)
         {
             logger.LogError(ex, "An error occurred while seeding the databases.");
+            // StopHost lets Run() return normally, so without this the container
+            // exits 0 and the Container App Job reports Succeeded on a failed seed.
+            Environment.ExitCode = 1;
             throw;
         }
         finally


### PR DESCRIPTION
`BackgroundServiceExceptionBehavior.StopHost` lets `Run()` return normally after the worker throws, so the container exits 0 and the Container App Job reports **Succeeded**.

Hit this for real while deploying #237: a run died migrating the Sensors database on a transient Postgres timeout, reported success, and left the wildlife data untouched. It was only caught by querying the API afterwards and noticing nothing had changed.

Sets `Environment.ExitCode = 1` so the job surfaces the failure.