### PR TITLE
feat(faunafinder): show the species' portrait in the mobile title bar

### DIFF
--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor
@@ -1,0 +1,33 @@
+@namespace FaunaFinder.Client.Components.Shell
+@inherits LocalizedComponentBase
+@inject INativeNavigationManager Navigation
+@inject INativeNavbarManager Navbar
+
+@* The mobile app bar's lead slot: the wordmark at the root, otherwise a back
+   button and the page title.
+
+   A detail page can hand it a portrait to sit beside the title — the way a
+   messaging app shows who you're looking at — by publishing Avatar. The
+   portrait is dropped on every navigation, so a page only ever has to set
+   one; nothing has to remember to clear it. *@
+
+<div class="ff-mobile-title">
+    @if (IsRootPage)
+    {
+        <span class="logo-text">FaunaFinder</span>
+    }
+    else
+    {
+        <NuiNativeNavbar ShowBackButton="true" ShowTitle="false" ShowActions="false" />
+
+        @if (_avatarSrc is not null)
+        {
+            <img class="ff-mobile-avatar"
+                 src="@_avatarSrc"
+                 alt="@(_avatarAlt ?? string.Empty)"
+                 loading="lazy" />
+        }
+
+        <span class="page-title">@Navbar.State.Title</span>
+    }
+</div>

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.cs
@@ -1,0 +1,67 @@
+using EcoData.NativeUi;
+using FaunaFinder.Client.Localization;
+using Tempest;
+
+namespace FaunaFinder.Client.Components.Shell;
+
+// The [Event] handler lives in this code-behind (with the base stated
+// explicitly) because Tempest's razor frontend matches the @inherits text by
+// simple name and can't see that LocalizedComponentBase is a StatefulComponent;
+// the C# symbol frontend can.
+public partial class FfMobileTitle : LocalizedComponentBase
+{
+    /// <summary>
+    /// A portrait to show beside the mobile page title — the species you have
+    /// open, the way a messaging app shows who you are talking to.
+    ///
+    /// <para>Publish with a null <paramref name="Src"/> to show none. Nested
+    /// here because <c>[Event]</c> only binds to a record declared on the
+    /// handling component; pages say
+    /// <c>Bus.Publish(new FfMobileTitle.Avatar(src, alt))</c>.</para>
+    /// </summary>
+    /// <param name="Src">Image URL, or null for no portrait.</param>
+    /// <param name="Alt">
+    /// Alternative text. Empty is correct when the title beside it already
+    /// names the same thing — otherwise a screen reader hears it twice.
+    /// </param>
+    public sealed record Avatar(string? Src, string? Alt);
+
+    private string? _avatarSrc;
+    private string? _avatarAlt;
+
+    private bool IsRootPage =>
+        Navigation.State.Path is "/" or "";
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        Navigation.OnStateChanged += HandleNavigationStateChanged;
+        Navbar.OnStateChanged += HandleNavbarStateChanged;
+    }
+
+    public override void Dispose()
+    {
+        Navigation.OnStateChanged -= HandleNavigationStateChanged;
+        Navbar.OnStateChanged -= HandleNavbarStateChanged;
+        base.Dispose();
+    }
+
+    [Event]
+    private void OnAvatar(Avatar avatar)
+    {
+        _avatarSrc = avatar.Src;
+        _avatarAlt = avatar.Alt;
+    }
+
+    // Dropping the portrait here rather than asking pages to clear it on the
+    // way out: a page that forgets would leave its animal sitting over the
+    // next screen's title.
+    private void HandleNavigationStateChanged()
+    {
+        _avatarSrc = null;
+        _avatarAlt = null;
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleNavbarStateChanged() => InvokeAsync(StateHasChanged);
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.css
@@ -8,7 +8,9 @@
 .ff-mobile-title {
     display: flex;
     align-items: center;
-    gap: 8px;
+    /* Tight on purpose — the title is the only child that truncates, so every
+       pixel spent here comes out of a species name. */
+    gap: 6px;
     flex: 1;
     min-width: 0;
 }
@@ -28,6 +30,10 @@
     font-size: 1.125rem;
     color: var(--fauna-fg);
     letter-spacing: var(--fauna-tracking-tight);
+    /* Negative tracking is applied after the last glyph as well, so the
+       content box ends inside its ink and overflow:hidden shaves the final
+       letter. Pad the box back out; the ellipsis still lands correctly. */
+    padding-right: 0.09em;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -40,8 +46,8 @@
    it circular when a long name squeezes the row. */
 .ff-mobile-avatar {
     flex: none;
-    width: 30px;
-    height: 30px;
+    width: 28px;
+    height: 28px;
     border-radius: 50%;
     object-fit: cover;
     background: var(--fauna-bg-alt);

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.css
@@ -11,7 +11,12 @@
     /* Tight on purpose — the title is the only child that truncates, so every
        pixel spent here comes out of a species name. */
     gap: 6px;
-    flex: 1;
+
+    /* Basis auto, not `flex: 1`. With a 0 basis the slot's own content counts
+       for nothing and it merely splits leftover space with the toolbar's
+       spacer, which leaves a species name about one letter wide. Starting
+       from the content width means it only gives ground when it has to. */
+    flex: 1 1 auto;
     min-width: 0;
 }
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.css
@@ -1,0 +1,63 @@
+/* ==========================================================================
+   Mobile app bar lead — back button, optional portrait, page title.
+
+   Moved here from MainLayout when the slot became its own component so it
+   could own the Avatar event.
+   ========================================================================== */
+
+.ff-mobile-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+}
+
+/* Wordmark, shown at the root instead of a back button */
+.logo-text {
+    font-family: var(--fauna-font-serif);
+    font-weight: 700;
+    font-size: 1.375rem;
+    color: var(--fauna-primary);
+    letter-spacing: var(--fauna-tracking-tight);
+}
+
+.page-title {
+    font-family: var(--fauna-font-serif);
+    font-weight: 600;
+    font-size: 1.125rem;
+    color: var(--fauna-fg);
+    letter-spacing: var(--fauna-tracking-tight);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+
+/* The portrait. Round and small so it reads as identity rather than as
+   content — the same move a messaging app makes with a contact photo. The
+   tinted ground shows only while the image is in flight; `flex: none` keeps
+   it circular when a long name squeezes the row. */
+.ff-mobile-avatar {
+    flex: none;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: var(--fauna-bg-alt);
+    border: 1px solid var(--fauna-line);
+    animation: ff-avatar-in var(--fauna-t-base) var(--fauna-ease);
+}
+
+@keyframes ff-avatar-in {
+    from {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ff-mobile-avatar {
+        animation: none;
+    }
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Components/Shell/FfMobileTitle.razor.css
@@ -20,6 +20,25 @@
     min-width: 0;
 }
 
+/* The back arrow.
+
+   NuiNativeNavbar hardcodes Color.Dark on it, which resolves to near-black in
+   either theme and disappears against the dark ground. That component is
+   shared with EcoPortal, so re-point the colour here instead of changing it
+   there. MudBlazor sets its own colour on the same element, hence the
+   !important. */
+.ff-mobile-title ::deep .mud-icon-button {
+    color: var(--fauna-fg) !important;
+}
+
+.ff-mobile-title ::deep .mud-icon-button .mud-icon-root {
+    color: inherit !important;
+}
+
+.ff-mobile-title ::deep .mud-icon-button:hover {
+    background-color: var(--fauna-bg-alt);
+}
+
 /* Wordmark, shown at the root instead of a back button */
 .logo-text {
     font-family: var(--fauna-font-serif);

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor
@@ -23,19 +23,11 @@
     <div class="@ShellClass">
         <MudLayout>
             <MudAppBar Elevation="0" Fixed="true" Class="ff-appbar">
-                @* Mobile: Back button + Title OR Logo *@
+                @* Mobile lead slot. It owns the Avatar event, so a detail page
+                   can put a portrait beside its title without the layout
+                   knowing which pages have one. *@
                 <MudHidden Breakpoint="Breakpoint.MdAndUp">
-                    <div class="d-flex align-center appbar-mobile-lead">
-                        @if (!IsRootPage)
-                        {
-                            <NuiNativeNavbar ShowBackButton="true" ShowTitle="false" ShowActions="false" />
-                            <span class="page-title">@Navbar.State.Title</span>
-                        }
-                        else
-                        {
-                            <span class="logo-text">FaunaFinder</span>
-                        }
-                    </div>
+                    <FfMobileTitle />
                 </MudHidden>
 
                 @* Desktop: notebook toggle + Logo + Page Title *@

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
@@ -84,6 +84,19 @@
     ::deep .ff-theme-toggle {
         margin-right: 0;
     }
+
+    /* The spacer also grows, so it and the title slot were halving the free
+       space between them. The title is the only thing here that truncates —
+       let it take the lot and leave the spacer as a plain separator. */
+    ::deep .ff-appbar .mud-spacer {
+        flex-grow: 0;
+    }
+
+    /* The language pill sizes to its own content; cap it so a long language
+       name can't push into the title. */
+    ::deep .ff-lang-menu > .mud-button-root {
+        max-width: 68px;
+    }
 }
 
 /* Wordmark and page title — the desktop copies. FfMobileTitle carries its

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
@@ -71,13 +71,8 @@
     border-radius: inherit;
 }
 
-/* Mobile app bar lead slot (back button + title, or the logo) */
-.appbar-mobile-lead {
-    flex: 1;
-    min-width: 0;
-}
-
-/* Wordmark and page title — ink on paper */
+/* Wordmark and page title — the desktop copies. FfMobileTitle carries its
+   own; scoped CSS is per-component, so the mobile slot can't share these. */
 .logo-text {
     font-family: var(--fauna-font-serif);
     font-weight: 700;

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Layout/MainLayout.razor.css
@@ -71,6 +71,21 @@
     border-radius: inherit;
 }
 
+/* On a phone the bar carries a back button, a portrait, the title, the theme
+   toggle and the language pill on ~360px. The title is the only thing that
+   truncates, so it gets the slack: trim the toolbar's own padding and the
+   toggle's margin rather than letting a species name lose its last letter. */
+@media (max-width: 959.98px) {
+    ::deep .ff-appbar > .mud-toolbar {
+        padding-left: 8px;
+        padding-right: 4px;
+    }
+
+    ::deep .ff-theme-toggle {
+        margin-right: 0;
+    }
+}
+
 /* Wordmark and page title — the desktop copies. FfMobileTitle carries its
    own; scoped CSS is per-component, so the mobile slot can't share these. */
 .logo-text {
@@ -87,6 +102,10 @@
     font-size: 1.125rem;
     color: var(--fauna-fg);
     letter-spacing: var(--fauna-tracking-tight);
+    /* Negative tracking is applied after the last glyph as well, so the
+       content box ends inside its ink and overflow:hidden shaves the final
+       letter. Pad the box back out; the ellipsis still lands correctly. */
+    padding-right: 0.09em;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Species.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Species.razor
@@ -245,7 +245,18 @@ else
         if (result.TryPickT0(out var detail, out var error))
         {
             _detailLoadError = null;
-            Navbar.SetTitle(GetSpeciesName(detail));
+
+            var name = GetSpeciesName(detail);
+            Navbar.SetTitle(name);
+
+            // Put the animal beside its own name in the mobile bar. Alt is
+            // empty on purpose: the title next to it already says the name,
+            // and a screen reader shouldn't hear it twice. The mobile slot
+            // drops the portrait on navigation, so there is nothing to undo.
+            Bus.Publish(new FfMobileTitle.Avatar(
+                detail.HasProfileImage ? $"/wildlife/species/{detail.Id}/image" : null,
+                Alt: string.Empty));
+
             return detail;
         }
         // A missing species keeps the dedicated not-found empty state.

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/wwwroot/app.css
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/wwwroot/app.css
@@ -209,24 +209,6 @@ h1:focus {
     margin: 0 auto;
 }
 
-/* Mobile back button - outlined style */
-.back-btn-mobile {
-    background: transparent !important;
-    border: 1.5px solid #ccc !important;
-    border-radius: 10px !important;
-    width: 36px !important;
-    height: 36px !important;
-    min-width: 36px !important;
-}
-
-.back-btn-mobile:hover {
-    background: rgba(0, 0, 0, 0.04) !important;
-}
-
-.back-btn-mobile:disabled {
-    opacity: 0.5;
-}
-
 /* ==========================================================================
    Mobile Bottom Navigation Spacing
    ========================================================================== */


### PR DESCRIPTION
Opening a species on a phone now puts its photograph beside the name in the app bar — the way a messaging app shows who you're looking at. Small and round, so it reads as identity rather than as content.

## How it's wired

The mobile lead slot became its own component, `FfMobileTitle`, to carry it. `[Event]` binds only to a record declared on the **handling** component, so the component owns the `Avatar` record and the species page publishes one:

```csharp
Bus.Publish(new FfMobileTitle.Avatar(
    detail.HasProfileImage ? $"/wildlife/species/{detail.Id}/image" : null,
    Alt: string.Empty));
```

The layout never learns which pages have a portrait, and giving another detail page one later needs no change here — same shape as `FfBottomNav.Hidden`/`Shown`, and the case the recent [component-autonomy scan](docs/faunafinder-component-autonomy.md) calls out as what events are actually for: a page influencing chrome it doesn't own.

## Three decisions worth reviewing

**The portrait is dropped on navigation, not on page teardown.** Asking every page to clear it on the way out means one that forgets leaves its animal sitting over the next screen's title. `FfMobileTitle` clears on `OnStateChanged`, so a page only ever has to *set* one.

**Alt text is deliberately empty.** The title immediately beside it already says the name; a screen reader announcing "Iguaca" twice is worse than not announcing the image at all. It's a decorative duplicate of adjacent text, which is exactly the case for `alt=""`.

**Species with no photograph get no portrait** — the bar looks exactly as it does today. A taxon-glyph fallback would also be defensible and would need the taxon code threaded into the record; I left the record minimal instead. Say if you'd rather have the fallback.

## Note for the reviewer

The desktop app bar uses the same `.logo-text` / `.page-title` class names. Scoped CSS is per-component, so those rules now exist in **both** `MainLayout.razor.css` and `FfMobileTitle.razor.css` — deliberate duplication, not a leftover. Removing either copy breaks one of the two bars.

**Not visually verified.** The client builds with 0 errors and no `TEM` analyzer warnings (which is the signal the event binding is correct), but this is a mobile-breakpoint change and I haven't rendered it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
