### PR TITLE
feat(wildlife): serve the catalogue as an MCP connector

### DIFF
--- a/EcoData.slnx
+++ b/EcoData.slnx
@@ -76,6 +76,7 @@
     <Project Path="src/Features/Wildlife/EcoData.Wildlife.Contracts/EcoData.Wildlife.Contracts.csproj" />
     <Project Path="src/Features/Wildlife/EcoData.Wildlife.DataAccess/EcoData.Wildlife.DataAccess.csproj" />
     <Project Path="src/Features/Wildlife/EcoData.Wildlife.Database/EcoData.Wildlife.Database.csproj" />
+    <Project Path="src/Features/Wildlife/EcoData.Wildlife.Mcp/EcoData.Wildlife.Mcp.csproj" />
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="tests/EcoData.IntegrationTests/EcoData.IntegrationTests.csproj" />

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/FaunaFinder.Server.csproj
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/FaunaFinder.Server.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.Api\EcoData.Wildlife.Api.csproj" />
     <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.DataAccess\EcoData.Wildlife.DataAccess.csproj" />
     <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.Database\EcoData.Wildlife.Database.csproj" />
+    <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.Mcp\EcoData.Wildlife.Mcp.csproj" />
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Api\EcoData.Locations.Api.csproj" />
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.DataAccess\EcoData.Locations.DataAccess.csproj" />
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Database\EcoData.Locations.Database.csproj" />

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
@@ -5,6 +5,7 @@ using EcoData.Locations.Database.Extensions;
 using EcoData.Wildlife.Api;
 using EcoData.Wildlife.DataAccess;
 using EcoData.Wildlife.Database.Extensions;
+using EcoData.Wildlife.Mcp;
 using FaunaFinder.Server.Components;
 using MudBlazor.Services;
 using Tempest;
@@ -20,6 +21,7 @@ builder.Services.AddMudServices();
 builder.Services.AddTempest();
 builder.Services.AddLocationsDataAccess();
 builder.Services.AddWildlifeDataAccess(builder.Configuration);
+builder.Services.AddWildlifeMcp();
 
 var app = builder.Build();
 
@@ -44,5 +46,6 @@ app.MapRazorComponents<App>()
 app.MapStateEndpoints();
 app.MapMunicipalityEndpoints();
 app.MapWildlifeApiEndpoints();
+app.MapWildlifeMcp();
 
 app.Run();

--- a/src/Features/Wildlife/EcoData.Wildlife.Mcp/EcoData.Wildlife.Mcp.csproj
+++ b/src/Features/Wildlife/EcoData.Wildlife.Mcp/EcoData.Wildlife.Mcp.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EcoData.Wildlife.DataAccess\EcoData.Wildlife.DataAccess.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Features/Wildlife/EcoData.Wildlife.Mcp/Tools/ConservationTools.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Mcp/Tools/ConservationTools.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel;
+using EcoData.Wildlife.DataAccess.Interfaces;
+using ModelContextProtocol.Server;
+
+namespace EcoData.Wildlife.Mcp.Tools;
+
+/// <summary>
+/// The conservation half of the connector: the NRCS practices landowners can
+/// carry out, and the Fish &amp; Wildlife Service recovery actions those
+/// practices deliver.
+/// </summary>
+// Sealed rather than static, for the same reason as SpeciesTools.
+[McpServerToolType]
+public sealed class ConservationTools
+{
+    [McpServerTool(Name = "list_conservation_practices")]
+    [Description("""
+        List the NRCS conservation practices recorded for Puerto Rico, by code
+        and name. These are the on-the-ground practices a landowner can carry
+        out; list_recovery_actions covers the outcomes they serve.
+        """)]
+    public static async Task<IReadOnlyList<ConservationPractice>> ListConservationPractices(
+        INrcsPracticeRepository repository,
+        CancellationToken cancellationToken
+    )
+    {
+        var practices = await repository.GetAllAsync(cancellationToken);
+
+        return practices
+            .Select(practice => new ConservationPractice(
+                practice.Code,
+                WildlifeMcpMapping.ResolveName(practice.Name, practice.Code)
+            ))
+            .ToList();
+    }
+
+    [McpServerTool(Name = "list_recovery_actions")]
+    [Description("""
+        List the Fish & Wildlife Service recovery actions recorded for Puerto
+        Rico, by code and name. These are the conservation outcomes that NRCS
+        practices are meant to deliver.
+        """)]
+    public static async Task<IReadOnlyList<RecoveryAction>> ListRecoveryActions(
+        IFwsActionRepository repository,
+        CancellationToken cancellationToken
+    )
+    {
+        var actions = await repository.GetAllAsync(cancellationToken);
+
+        return actions
+            .Select(action => new RecoveryAction(
+                action.Code,
+                WildlifeMcpMapping.ResolveName(action.Name, action.Code)
+            ))
+            .ToList();
+    }
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Mcp/Tools/SpeciesTools.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Mcp/Tools/SpeciesTools.cs
@@ -1,0 +1,208 @@
+using System.ComponentModel;
+using EcoData.Wildlife.Contracts;
+using EcoData.Wildlife.Contracts.Parameters;
+using EcoData.Wildlife.DataAccess.Interfaces;
+using ModelContextProtocol.Server;
+
+namespace EcoData.Wildlife.Mcp.Tools;
+
+/// <summary>
+/// The species half of the wildlife connector.
+///
+/// <para>Tools take their repository through the method signature rather than a
+/// constructor: the server resolves each argument from the request scope, which
+/// is the same scope the HTTP endpoints get, so a tool call reads the database
+/// exactly as a page request would.</para>
+/// </summary>
+// Sealed rather than static: WithTools<T> takes the type as a generic argument,
+// and a static type can't be one. The tools themselves are all static methods,
+// so nothing is ever constructed.
+[McpServerToolType]
+public sealed class SpeciesTools
+{
+    /// <summary>Bounds on how much catalogue one call can pull back.</summary>
+    private const int MaxResults = 50;
+    private const int DefaultResults = 20;
+
+    /// <summary>Puerto Rico is small; a radius past this stops meaning "near".</summary>
+    private const double MaxRadiusMeters = 50_000;
+
+    [McpServerTool(Name = "search_species")]
+    [Description("""
+        Search the Puerto Rico wildlife catalogue. Returns a summary per match;
+        call get_species for the full record. Every filter is optional — with no
+        arguments this returns the first page of the whole catalogue. Use
+        list_taxon_categories first if you need valid taxon codes.
+        """)]
+    public static async Task<IReadOnlyList<SpeciesSummary>> SearchSpecies(
+        ISpeciesRepository repository,
+        CancellationToken cancellationToken,
+        [Description("Free text matched against common and scientific names.")]
+        string? search = null,
+        [Description("Taxon code from list_taxon_categories, e.g. 'bird' or 'amphib'.")]
+        string? taxonCode = null,
+        [Description("IUCN Red List status: LC, NT, VU, EN, CR, DD or EX.")]
+        string? iucnStatus = null,
+        [Description("True to return only species endemic to Puerto Rico.")]
+        bool? endemicOnly = null,
+        [Description("True for animals only, false for plants only, omit for both.")]
+        bool? faunaOnly = null,
+        [Description("How many to return, 1-50. Defaults to 20.")]
+        int limit = DefaultResults
+    )
+    {
+        var parameters = new SpeciesParameters(
+            PageSize: Math.Clamp(limit, 1, MaxResults),
+            Search: search,
+            IsFauna: faunaOnly,
+            IsEndemic: endemicOnly,
+            IucnStatuses: ParseIucnStatus(iucnStatus),
+            TaxonCodes: string.IsNullOrWhiteSpace(taxonCode) ? null : [taxonCode]
+        );
+
+        var results = new List<SpeciesSummary>();
+
+        await foreach (var species in repository
+            .GetSpeciesAsync(parameters, cancellationToken)
+            .WithCancellation(cancellationToken))
+        {
+            results.Add(new SpeciesSummary(
+                species.Id,
+                WildlifeMcpMapping.ResolveName(species.CommonName, species.ScientificName),
+                species.ScientificName,
+                WildlifeMcpMapping.Kind(species.IsFauna),
+                species.IucnStatus?.ToString(),
+                species.IsEndemic,
+                species.TaxonCode,
+                species.MunicipalityCount,
+                species.LastObservedAtUtc
+            ));
+        }
+
+        return results;
+    }
+
+    [McpServerTool(Name = "get_species")]
+    [Description("""
+        Get the full record for one species by id, including habitat,
+        taxonomic categories and how many municipios it has been recorded in.
+        Ids come from search_species or find_species_near.
+        """)]
+    public static async Task<SpeciesDetail?> GetSpecies(
+        ISpeciesRepository repository,
+        CancellationToken cancellationToken,
+        [Description("The species id.")] Guid id
+    )
+    {
+        var species = await repository.GetByIdAsync(id, cancellationToken);
+        if (species is null)
+        {
+            // Null reads as "no such species" on the wire; throwing would report
+            // a tool failure for what is an ordinary answer.
+            return null;
+        }
+
+        var categories = species.Categories
+            .Select(category => WildlifeMcpMapping.ResolveName(category.Name, category.Code))
+            .ToList();
+
+        return new SpeciesDetail(
+            species.Id,
+            WildlifeMcpMapping.ResolveName(species.CommonName, species.ScientificName),
+            species.ScientificName,
+            WildlifeMcpMapping.Kind(species.IsFauna),
+            species.IucnStatus?.ToString(),
+            species.IsEndemic,
+            species.Habitat,
+            categories,
+            species.MunicipalityIds.Count,
+            species.LastObservedAtUtc,
+            species.ImageSourceUrl
+        );
+    }
+
+    [McpServerTool(Name = "find_species_near")]
+    [Description("""
+        Find species recorded within a radius of a point, nearest first.
+        Coordinates are decimal degrees (WGS 84); Puerto Rico spans roughly
+        latitude 17.9 to 18.5 and longitude -67.3 to -65.2.
+        """)]
+    public static async Task<IReadOnlyList<NearbySpecies>> FindSpeciesNear(
+        ISpeciesRepository repository,
+        CancellationToken cancellationToken,
+        [Description("Latitude in decimal degrees.")] double latitude,
+        [Description("Longitude in decimal degrees.")] double longitude,
+        [Description("Search radius in metres, up to 50000. Defaults to 5000.")]
+        double radiusMeters = 5000
+    )
+    {
+        var nearby = await repository.GetNearbyAsync(
+            latitude,
+            longitude,
+            Math.Clamp(radiusMeters, 1, MaxRadiusMeters),
+            cancellationToken
+        );
+
+        return nearby
+            .Select(species => new NearbySpecies(
+                species.Id,
+                WildlifeMcpMapping.ResolveName(species.CommonName, species.ScientificName),
+                species.ScientificName,
+                WildlifeMcpMapping.Kind(species.IsFauna),
+                species.DistanceMeters,
+                species.LocationDescription
+            ))
+            .ToList();
+    }
+
+    [McpServerTool(Name = "list_taxon_categories")]
+    [Description("""
+        List the taxonomic groups species are catalogued under. The codes
+        returned here are what search_species accepts as taxonCode.
+        """)]
+    public static async Task<IReadOnlyList<TaxonCategory>> ListTaxonCategories(
+        ISpeciesCategoryRepository repository,
+        CancellationToken cancellationToken
+    )
+    {
+        var categories = await repository.GetAllAsync(cancellationToken);
+
+        return categories
+            .Select(category => new TaxonCategory(
+                category.Code,
+                WildlifeMcpMapping.ResolveName(category.Name, category.Code)
+            ))
+            .ToList();
+    }
+
+    [McpServerTool(Name = "get_catalogue_stats")]
+    [Description("""
+        Totals for the whole catalogue: species recorded, how many are endemic,
+        how many are threatened (IUCN VU through CR), and municipio coverage.
+        """)]
+    public static async Task<CatalogueStats> GetCatalogueStats(
+        ISpeciesRepository repository,
+        CancellationToken cancellationToken
+    )
+    {
+        var stats = await repository.GetStatsAsync(cancellationToken);
+
+        return new CatalogueStats(
+            stats.TotalSpecies,
+            stats.EndemicCount,
+            stats.ThreatenedCount,
+            stats.MunicipalitiesCovered,
+            stats.TotalMunicipalities
+        );
+    }
+
+    /// <summary>
+    /// A status the model spelled itself, so an unparseable one is treated as no
+    /// filter rather than an error — a search that quietly ignores a bad code
+    /// still answers, and the codes are named in the tool description.
+    /// </summary>
+    private static IucnStatus[]? ParseIucnStatus(string? status) =>
+        Enum.TryParse<IucnStatus>(status, ignoreCase: true, out var parsed)
+            ? [parsed]
+            : null;
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Mcp/WildlifeMcpExtensions.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Mcp/WildlifeMcpExtensions.cs
@@ -1,0 +1,46 @@
+using EcoData.Wildlife.Mcp.Tools;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EcoData.Wildlife.Mcp;
+
+/// <summary>
+/// Mounts the wildlife catalogue as an MCP server so it can be added to Claude
+/// (or any MCP client) as a custom connector.
+///
+/// <para>The transport is Streamable HTTP, which is what a remote connector
+/// requires — a stdio server can only be reached from the machine it runs on.
+/// The tools read through the same repositories the HTTP endpoints use, in the
+/// same request scope, so there is no second copy of the query logic and no
+/// loopback call into our own API.</para>
+///
+/// <para>Nothing here is authenticated, matching the wildlife endpoints
+/// themselves: the catalogue is public reference data and every tool is
+/// read-only. Anything that later exposes per-user or write access needs OAuth
+/// in front of it first.</para>
+/// </summary>
+public static class WildlifeMcpExtensions
+{
+    public static IServiceCollection AddWildlifeMcp(this IServiceCollection services)
+    {
+        services
+            .AddMcpServer()
+            .WithHttpTransport()
+            .WithTools<SpeciesTools>()
+            .WithTools<ConservationTools>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Serves the connector at <c>/mcp</c>. This is the URL a reader pastes into
+    /// their client, so it is deliberately boring and stable.
+    /// </summary>
+    public static IEndpointRouteBuilder MapWildlifeMcp(this IEndpointRouteBuilder app)
+    {
+        app.MapMcp("/mcp");
+
+        return app;
+    }
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Mcp/WildlifeMcpViews.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Mcp/WildlifeMcpViews.cs
@@ -1,0 +1,102 @@
+using EcoData.Common.i18n;
+
+namespace EcoData.Wildlife.Mcp;
+
+// The shapes the tools hand back to a model, deliberately narrower than the
+// DTOs the web app reads. A tool result is spent from a context window, so the
+// list shapes carry only what a model needs to decide whether to ask for the
+// detail — the full record is one `get_species` call away.
+//
+// Names arrive from the repositories as a per-locale list; these carry the one
+// resolved string instead, so the model never has to pick a translation.
+
+public sealed record SpeciesSummary(
+    Guid Id,
+    string CommonName,
+    string ScientificName,
+    string Kind,
+    string? IucnStatus,
+    bool IsEndemic,
+    string? TaxonCode,
+    int MunicipalityCount,
+    DateTimeOffset? LastObservedAtUtc
+);
+
+public sealed record SpeciesDetail(
+    Guid Id,
+    string CommonName,
+    string ScientificName,
+    string Kind,
+    string? IucnStatus,
+    bool IsEndemic,
+    string? Habitat,
+    IReadOnlyList<string> Categories,
+    int MunicipalityCount,
+    DateTimeOffset? LastObservedAtUtc,
+    string? ImageSourceUrl
+);
+
+public sealed record NearbySpecies(
+    Guid Id,
+    string CommonName,
+    string ScientificName,
+    string Kind,
+    double DistanceMeters,
+    string? LocationDescription
+);
+
+public sealed record TaxonCategory(string Code, string Name);
+
+public sealed record ConservationPractice(string Code, string Name);
+
+public sealed record RecoveryAction(string Code, string Name);
+
+public sealed record CatalogueStats(
+    int TotalSpecies,
+    int EndemicCount,
+    int ThreatenedCount,
+    int MunicipalitiesCovered,
+    int TotalMunicipalities
+);
+
+/// <summary>
+/// Turning stored wildlife records into the shapes above.
+/// </summary>
+internal static class WildlifeMcpMapping
+{
+    private const string DefaultLocale = "en";
+
+    /// <summary>
+    /// The one name to show. Prefers English, falls back to whatever locale the
+    /// record does carry, and finally to the scientific name — a species with no
+    /// common name at all still has to read as something.
+    /// </summary>
+    internal static string ResolveName(
+        IReadOnlyList<LocaleValue> localized,
+        string fallback
+    )
+    {
+        foreach (var value in localized)
+        {
+            if (string.Equals(value.Code, DefaultLocale, StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrWhiteSpace(value.Value))
+            {
+                return value.Value;
+            }
+        }
+
+        foreach (var value in localized)
+        {
+            if (!string.IsNullOrWhiteSpace(value.Value))
+            {
+                return value.Value;
+            }
+        }
+
+        return fallback;
+    }
+
+    // "fauna"/"flora" rather than the stored boolean: the model reads the
+    // answer instead of having to know which way the flag points.
+    internal static string Kind(bool isFauna) => isFauna ? "fauna" : "flora";
+}


### PR DESCRIPTION
Mounts the wildlife catalogue as an MCP server at `/mcp`, so a reader can add FaunaFinder to Claude — or any MCP client — as a custom connector and ask about Puerto Rico's species from wherever they already work.

## What's here

A new `EcoData.Wildlife.Mcp` project, mounted into `FaunaFinder.Server` alongside the existing endpoints. Seven read-only tools:

| Tool | What it answers |
|---|---|
| `search_species` | Free text + taxon / IUCN / endemic / fauna filters, capped at 50 |
| `get_species` | One full record by id |
| `find_species_near` | What's recorded within a radius of a point, nearest first |
| `list_taxon_categories` | The groups species are filed under — the codes `search_species` accepts |
| `get_catalogue_stats` | Totals: species, endemic, threatened, municipio coverage |
| `list_conservation_practices` | NRCS practices, by code and name |
| `list_recovery_actions` | FWS recovery actions, by code and name |

## Notes for review

- **Tools read the repositories directly.** Each takes its repository through the method signature, so it resolves from the same request scope the HTTP endpoints use — no loopback call into our own API, and no second copy of the query logic.
- **Results are narrower than the DTOs.** A tool result is spent from a context window, so the list shapes carry only enough to decide whether to ask for the detail, and names arrive resolved to one locale rather than as a per-language list.
- **Streamable HTTP, not stdio.** A remote connector can't be a stdio server; that's the transport claude.ai requires.
- **Unauthenticated,** matching the wildlife endpoints themselves — the catalogue is public reference data and every tool is read-only. Anything exposing per-user or write access would need OAuth in front of it first.

## Verification

Ran against the AppHost with a live database and drove the connector over HTTP:

- `initialize` negotiates protocol `2025-06-18`; `tools/list` returns all seven.
- `get_catalogue_stats` → `{"totalSpecies":79,"endemicCount":5,"threatenedCount":58,"municipalitiesCovered":58,"totalMunicipalities":78}`
- `search_species {endemicOnly: true}` → Puerto Rican sharp-shinned hawk, Puerto Rican broad-winged hawk, …
- `find_species_near` at San Juan / 20 km → yellow-shouldered blackbird at 3.3 km, Puerto Rican boa, …
- `get_species` with an unknown id → empty content rather than a tool error.

Testing also caught a wrong example in the `taxonCode` description (`AVES`; the real codes are `bird`, `amphib`, …), fixed before commit.

## Trying it

With the app running, add `<host>/mcp` as a custom connector in Claude, or:

```
claude mcp add --transport http faunafinder http://localhost:5300/mcp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
