### PR TITLE
feat(faunafinder): rate limit the data endpoints

### DIFF
--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
@@ -7,6 +7,7 @@ using EcoData.Wildlife.DataAccess;
 using EcoData.Wildlife.Database.Extensions;
 using EcoData.Wildlife.Mcp;
 using FaunaFinder.Server.Components;
+using FaunaFinder.Server.RateLimiting;
 using MudBlazor.Services;
 using Tempest;
 
@@ -22,8 +23,13 @@ builder.Services.AddTempest();
 builder.Services.AddLocationsDataAccess();
 builder.Services.AddWildlifeDataAccess(builder.Configuration);
 builder.Services.AddWildlifeMcp();
+builder.Services.AddFaunaFinderRateLimiting();
 
 var app = builder.Build();
+
+// First in the pipeline: everything downstream that cares who is calling —
+// the rate limiter above all — reads the address this restores.
+app.UseForwardedHeaders();
 
 app.MapDefaultEndpoints();
 
@@ -37,6 +43,7 @@ else
 }
 
 app.UseAntiforgery();
+app.UseRateLimiter();
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>()

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/RateLimiting/FaunaFinderRateLimiterExtensions.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/RateLimiting/FaunaFinderRateLimiterExtensions.cs
@@ -1,0 +1,143 @@
+using System.Globalization;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.HttpOverrides;
+
+namespace FaunaFinder.Server.RateLimiting;
+
+/// <summary>
+/// Caps how hard one caller can hit FaunaFinder's data endpoints.
+///
+/// <para>Everything the app serves is anonymous, so there is no user to key on
+/// and the partition is the client address. Two buckets rather than one: the
+/// MCP connector is looped over by a model that pages until it has what it
+/// wants, while the REST endpoints are paced by a person clicking, so they are
+/// not the same kind of traffic and should not share a budget.</para>
+///
+/// <para>A token bucket rather than a window: both callers arrive in bursts —
+/// a page view fires several requests at once, and a model fans out tool calls
+/// — and a bucket absorbs that up to its capacity while still holding the
+/// long-run rate down. A window of the same size would reject the burst and
+/// then sit idle.</para>
+///
+/// <para>Only the data paths are metered. A Blazor WebAssembly load pulls down
+/// a long tail of static assets, and a limiter that counted those would reject
+/// the app while it was still booting.</para>
+/// </summary>
+public static class FaunaFinderRateLimiterExtensions
+{
+    /// <summary>The connector: a model pages through tools without a human pacing it.</summary>
+    private const int McpRequestsPerMinute = 60;
+
+    /// <summary>The REST endpoints: several calls per page view, driven by a reader.</summary>
+    private const int ApiRequestsPerMinute = 120;
+
+    /// <summary>
+    /// How often the bucket tops up. Short enough that a caller who runs dry
+    /// waits seconds rather than a minute, which matters most for the
+    /// connector: a model that stalls a full minute tends to give up on the
+    /// tool rather than wait for it.
+    /// </summary>
+    private static readonly TimeSpan ReplenishmentPeriod = TimeSpan.FromSeconds(10);
+
+    private const int PeriodsPerMinute = 6;
+
+    private const string McpPath = "/mcp";
+    private static readonly string[] ApiPaths = ["/wildlife", "/locations"];
+
+    public static IServiceCollection AddFaunaFinderRateLimiting(this IServiceCollection services)
+    {
+        // Container Apps terminates ingress, so the socket address is the
+        // ingress' own. Without this every caller collapses into one partition
+        // and the limiter throttles the whole world together instead of per
+        // client. The proxy is upstream and unknown to us by address, so the
+        // default known-network allowlist has to be cleared for the header to
+        // be honoured.
+        services.Configure<ForwardedHeadersOptions>(options =>
+        {
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+            options.KnownNetworks.Clear();
+            options.KnownProxies.Clear();
+        });
+
+        services.AddRateLimiter(options =>
+        {
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+            {
+                var path = context.Request.Path;
+
+                if (path.StartsWithSegments(McpPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return TokenBucket($"mcp:{ClientKey(context)}", McpRequestsPerMinute);
+                }
+
+                foreach (var apiPath in ApiPaths)
+                {
+                    if (path.StartsWithSegments(apiPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return TokenBucket($"api:{ClientKey(context)}", ApiRequestsPerMinute);
+                    }
+                }
+
+                // Pages, static assets and the WASM payload: unmetered.
+                return RateLimitPartition.GetNoLimiter("unmetered");
+            });
+
+            options.OnRejected = async (context, cancellationToken) =>
+            {
+                context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+
+                // Tell the caller when to come back. An MCP client reads this
+                // and waits; without it the usual answer is to retry at once.
+                // The bucket reports the wait itself; the replenishment period
+                // is the floor for the shapes that don't.
+                var retryAfterSeconds = context.Lease.TryGetMetadata(
+                    MetadataName.RetryAfter,
+                    out var retryAfter
+                )
+                    ? (int)Math.Ceiling(retryAfter.TotalSeconds)
+                    : (int)ReplenishmentPeriod.TotalSeconds;
+
+                context.HttpContext.Response.Headers.RetryAfter =
+                    retryAfterSeconds.ToString(NumberFormatInfo.InvariantInfo);
+
+                await context.HttpContext.Response.WriteAsync(
+                    "Too many requests. Slow down and try again shortly.",
+                    cancellationToken
+                );
+            };
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// A bucket that holds a minute's worth of requests and refills a sixth of
+    /// it every ten seconds — so a caller may spend the whole minute at once,
+    /// then continues at the sustained rate.
+    /// </summary>
+    private static RateLimitPartition<string> TokenBucket(string key, int requestsPerMinute) =>
+        RateLimitPartition.GetTokenBucketLimiter(
+            key,
+            _ => new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = requestsPerMinute,
+                TokensPerPeriod = requestsPerMinute / PeriodsPerMinute,
+                ReplenishmentPeriod = ReplenishmentPeriod,
+                AutoReplenishment = true,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+
+                // Reject rather than hold the request. A queued MCP call reads
+                // as a slow tool to the model, which is worse than a 429 it can
+                // act on.
+                QueueLimit = 0,
+            }
+        );
+
+    /// <summary>
+    /// Who to count against. Callers behind one NAT share a bucket — the cost
+    /// of having no identity to key on — so the buckets are sized wide enough
+    /// that ordinary shared use does not trip them.
+    /// </summary>
+    private static string ClientKey(HttpContext context) =>
+        context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+}


### PR DESCRIPTION
Nothing FaunaFinder serves was rate limited. #245 made that worth fixing: `/mcp` is anonymous, public, and every tool call runs a database query — including `find_species_near`, a spatial query whose radius the caller picks. An MCP client is also looped over by a model that pages until it has what it wants, so the traffic arrives without a human pacing it.

## What's here

Token buckets, partitioned by client address, applied as a global limiter that meters only the data paths.

| Path | Bucket | Refill |
|---|---|---|
| `/mcp` | 60 requests | 10 every 10s |
| `/wildlife`, `/locations` | 120 requests | 20 every 10s |
| everything else | unmetered | — |

Rejections return `429` with a `Retry-After`.

## Why these choices

- **Buckets, not windows.** Both callers arrive in bursts — a page view fires several requests at once, a model fans out tool calls — and a bucket absorbs that up to capacity while still holding the long-run rate down. A window of the same size would reject the burst and then sit idle.
- **Two buckets.** The connector and the REST endpoints aren't the same kind of traffic and shouldn't share a budget.
- **Only data paths metered.** A Blazor WebAssembly load pulls down a long tail of static assets; a limiter counting those would reject the app while it was still booting.
- **`UseForwardedHeaders` first in the pipeline.** Container Apps terminates ingress, so without it `RemoteIpAddress` is the ingress' own — every caller collapses into one bucket and the limiter throttles the whole world together instead of per client. This is the part that's easy to get wrong and silently useless.
- **`QueueLimit = 0`.** A queued MCP call reads as a slow tool to the model, which is worse than a 429 it can act on.

## Verification

Driven against a running host:

- **Burst**: 75 rapid `/mcp` calls → 62 × `200`, 13 × `429` (60 capacity plus what replenished mid-run).
- **Retry-After**: present on rejection, `Retry-After: 10`.
- **Replenishment**: after 11s idle, 11 × `200` then `429` again — a sixth of the bucket back, as configured.
- **App shell not metered**: 150 consecutive `GET /` → 150 × `200`.
- **Buckets independent**: exhausting the `/wildlife` bucket (12 × `429`) left `/mcp` still answering `200`.

## Judgment calls worth a look

- **Shared addresses share a bucket.** There's no identity to key on, so callers behind one NAT count together. The buckets are sized wide enough that ordinary shared use shouldn't trip, but a large office on the REST endpoints is the case that would.
- **The numbers are a starting point**, not measured against real traffic. Easy to revise once there's telemetry.
- The `Retry-After` fallback exists because the partitioned bucket doesn't always populate `MetadataName.RetryAfter`; the replenishment period is the floor when it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
