### PR TITLE
feat(locations): add location tools to the MCP connector

### DIFF
--- a/EcoData.slnx
+++ b/EcoData.slnx
@@ -51,6 +51,7 @@
     <Project Path="src/Features/Locations/EcoData.Locations.Contracts/EcoData.Locations.Contracts.csproj" />
     <Project Path="src/Features/Locations/EcoData.Locations.DataAccess/EcoData.Locations.DataAccess.csproj" />
     <Project Path="src/Features/Locations/EcoData.Locations.Database/EcoData.Locations.Database.csproj" />
+    <Project Path="src/Features/Locations/EcoData.Locations.Mcp/EcoData.Locations.Mcp.csproj" />
     <Project Path="src/Features/Locations/EcoData.Locations.Helpers/EcoData.Locations.Helpers.csproj" />
   </Folder>
   <Folder Name="/Features/Organization/">

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/FaunaFinder.Server.csproj
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/FaunaFinder.Server.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Api\EcoData.Locations.Api.csproj" />
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.DataAccess\EcoData.Locations.DataAccess.csproj" />
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Database\EcoData.Locations.Database.csproj" />
+    <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Mcp\EcoData.Locations.Mcp.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Mcp/FaunaFinderMcpExtensions.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Mcp/FaunaFinderMcpExtensions.cs
@@ -1,0 +1,42 @@
+using EcoData.Locations.Mcp;
+using EcoData.Wildlife.Mcp;
+
+namespace FaunaFinder.Server.Mcp;
+
+/// <summary>
+/// Assembles FaunaFinder's MCP connector: one server, one endpoint, with each
+/// feature contributing the tools it can answer.
+///
+/// <para>The transport is Streamable HTTP, which is what a remote connector
+/// requires — a stdio server can only be reached from the machine it runs
+/// on.</para>
+///
+/// <para>Nothing here is authenticated, matching the endpoints the tools read
+/// through: the catalogue and the municipio list are public reference data and
+/// every tool is read-only. Anything that later exposes per-user or write
+/// access needs OAuth in front of it first.</para>
+/// </summary>
+public static class FaunaFinderMcpExtensions
+{
+    public static IServiceCollection AddFaunaFinderMcp(this IServiceCollection services)
+    {
+        services
+            .AddMcpServer()
+            .WithHttpTransport()
+            .AddWildlifeMcpTools()
+            .AddLocationsMcpTools();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Serves the connector at <c>/mcp</c>. This is the URL a reader pastes into
+    /// their client, so it is deliberately boring and stable.
+    /// </summary>
+    public static IEndpointRouteBuilder MapFaunaFinderMcp(this IEndpointRouteBuilder app)
+    {
+        app.MapMcp("/mcp");
+
+        return app;
+    }
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
@@ -5,8 +5,8 @@ using EcoData.Locations.Database.Extensions;
 using EcoData.Wildlife.Api;
 using EcoData.Wildlife.DataAccess;
 using EcoData.Wildlife.Database.Extensions;
-using EcoData.Wildlife.Mcp;
 using FaunaFinder.Server.Components;
+using FaunaFinder.Server.Mcp;
 using FaunaFinder.Server.RateLimiting;
 using MudBlazor.Services;
 using Tempest;
@@ -22,7 +22,7 @@ builder.Services.AddMudServices();
 builder.Services.AddTempest();
 builder.Services.AddLocationsDataAccess();
 builder.Services.AddWildlifeDataAccess(builder.Configuration);
-builder.Services.AddWildlifeMcp();
+builder.Services.AddFaunaFinderMcp();
 builder.Services.AddFaunaFinderRateLimiting();
 
 var app = builder.Build();
@@ -53,6 +53,6 @@ app.MapRazorComponents<App>()
 app.MapStateEndpoints();
 app.MapMunicipalityEndpoints();
 app.MapWildlifeApiEndpoints();
-app.MapWildlifeMcp();
+app.MapFaunaFinderMcp();
 
 app.Run();

--- a/src/Features/Locations/EcoData.Locations.Mcp/EcoData.Locations.Mcp.csproj
+++ b/src/Features/Locations/EcoData.Locations.Mcp/EcoData.Locations.Mcp.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EcoData.Locations.DataAccess\EcoData.Locations.DataAccess.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Features/Locations/EcoData.Locations.Mcp/LocationsMcpExtensions.cs
+++ b/src/Features/Locations/EcoData.Locations.Mcp/LocationsMcpExtensions.cs
@@ -1,0 +1,17 @@
+using EcoData.Locations.Mcp.Tools;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EcoData.Locations.Mcp;
+
+/// <summary>
+/// Contributes the location tools to whatever MCP server the host is building.
+///
+/// <para>The feature adds tools rather than standing up a server of its own:
+/// a connector is one endpoint with one tool list, so the host owns the server
+/// and each feature hands it what it can answer.</para>
+/// </summary>
+public static class LocationsMcpExtensions
+{
+    public static IMcpServerBuilder AddLocationsMcpTools(this IMcpServerBuilder builder) =>
+        builder.WithTools<MunicipalityTools>();
+}

--- a/src/Features/Locations/EcoData.Locations.Mcp/LocationsMcpViews.cs
+++ b/src/Features/Locations/EcoData.Locations.Mcp/LocationsMcpViews.cs
@@ -1,0 +1,23 @@
+namespace EcoData.Locations.Mcp;
+
+// What the location tools hand back, deliberately narrower than the DTOs the
+// web app reads. The boundary polygon in particular never crosses this line:
+// it is thousands of coordinates, useful to a map and useless in a context
+// window.
+
+public sealed record MunicipalitySummary(
+    Guid Id,
+    string Name,
+    double CentroidLatitude,
+    double CentroidLongitude
+);
+
+public sealed record MunicipalityDetail(
+    Guid Id,
+    string Name,
+    string State,
+    string StateCode,
+    string CountyFipsCode,
+    double CentroidLatitude,
+    double CentroidLongitude
+);

--- a/src/Features/Locations/EcoData.Locations.Mcp/Tools/MunicipalityTools.cs
+++ b/src/Features/Locations/EcoData.Locations.Mcp/Tools/MunicipalityTools.cs
@@ -1,0 +1,122 @@
+using System.ComponentModel;
+using EcoData.Locations.Contracts.Parameters;
+using EcoData.Locations.DataAccess.Interfaces;
+using ModelContextProtocol.Server;
+
+namespace EcoData.Locations.Mcp.Tools;
+
+/// <summary>
+/// The places half of the connector: Puerto Rico's 78 municipios, which are
+/// what the wildlife records are filed against.
+///
+/// <para>Sealed rather than static so the type can be a generic argument to
+/// <c>WithTools</c>; every tool is a static method and nothing is
+/// constructed.</para>
+/// </summary>
+[McpServerToolType]
+public sealed class MunicipalityTools
+{
+    /// <summary>
+    /// Puerto Rico has 78 municipios, so the default returns all of them — the
+    /// whole list is small enough to be worth having in one call, and a model
+    /// that has it can resolve a name to an id without asking again.
+    /// </summary>
+    private const int DefaultResults = 78;
+
+    private const int MaxResults = 100;
+
+    [McpServerTool(Name = "search_municipalities")]
+    [Description("""
+        List or search Puerto Rico's municipios. With no arguments this returns
+        all of them with their ids and centre points, which is what the wildlife
+        tools take as municipalityId. Pass search to narrow by name.
+        """)]
+    public static async Task<IReadOnlyList<MunicipalitySummary>> SearchMunicipalities(
+        IMunicipalityRepository repository,
+        CancellationToken cancellationToken,
+        [Description("Free text matched against the municipio name.")]
+        string? search = null,
+        [Description("How many to return, 1-100. Defaults to 78, the whole island.")]
+        int limit = DefaultResults
+    )
+    {
+        var parameters = new MunicipalityParameters(
+            PageSize: Math.Clamp(limit, 1, MaxResults),
+            Search: search
+        );
+
+        var results = new List<MunicipalitySummary>();
+
+        await foreach (var municipality in repository
+            .GetMunicipalitiesAsync(parameters, cancellationToken)
+            .WithCancellation(cancellationToken))
+        {
+            results.Add(new MunicipalitySummary(
+                municipality.Id,
+                municipality.Name,
+                (double)municipality.CentroidLatitude,
+                (double)municipality.CentroidLongitude
+            ));
+        }
+
+        return results;
+    }
+
+    [McpServerTool(Name = "get_municipality")]
+    [Description("""
+        Get one municipio by id, including which state it belongs to, its county
+        FIPS code and its centre point. Ids come from search_municipalities or
+        find_municipality_at_point.
+        """)]
+    public static async Task<MunicipalityDetail?> GetMunicipality(
+        IMunicipalityRepository repository,
+        CancellationToken cancellationToken,
+        [Description("The municipio id.")] Guid id
+    )
+    {
+        var municipality = await repository.GetByIdAsync(id, cancellationToken);
+
+        // Null reads as "no such municipio"; throwing would report a tool
+        // failure for what is an ordinary answer.
+        return municipality is null ? null : ToDetail(municipality);
+    }
+
+    [McpServerTool(Name = "find_municipality_at_point")]
+    [Description("""
+        Find which municipio contains a point — the reverse of looking one up by
+        name. Coordinates are decimal degrees (WGS 84). Returns nothing if the
+        point falls outside every municipio boundary, which includes points at
+        sea or off the island.
+        """)]
+    public static async Task<MunicipalityDetail?> FindMunicipalityAtPoint(
+        IMunicipalityRepository repository,
+        CancellationToken cancellationToken,
+        [Description("Latitude in decimal degrees.")] double latitude,
+        [Description("Longitude in decimal degrees.")] double longitude
+    )
+    {
+        // The boundary test is done in the database against the stored polygon,
+        // so this is a real point-in-polygon lookup rather than a nearest-
+        // centroid guess.
+        var municipality = await repository.GetByPointAsync(
+            (decimal)latitude,
+            (decimal)longitude,
+            cancellationToken
+        );
+
+        return municipality is null ? null : ToDetail(municipality);
+    }
+
+    private static MunicipalityDetail ToDetail(
+        Contracts.Dtos.MunicipalityDtoForDetail municipality
+    ) =>
+        new(
+            municipality.Id,
+            municipality.Name,
+            municipality.StateName,
+            municipality.StateCode,
+            municipality.CountyFipsCode,
+            (double)municipality.CentroidLatitude,
+            (double)municipality.CentroidLongitude
+        );
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Mcp/Tools/SpeciesTools.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Mcp/Tools/SpeciesTools.cs
@@ -66,17 +66,7 @@ public sealed class SpeciesTools
             .GetSpeciesAsync(parameters, cancellationToken)
             .WithCancellation(cancellationToken))
         {
-            results.Add(new SpeciesSummary(
-                species.Id,
-                WildlifeMcpMapping.ResolveName(species.CommonName, species.ScientificName),
-                species.ScientificName,
-                WildlifeMcpMapping.Kind(species.IsFauna),
-                species.IucnStatus?.ToString(),
-                species.IsEndemic,
-                species.TaxonCode,
-                species.MunicipalityCount,
-                species.LastObservedAtUtc
-            ));
+            results.Add(ToSummary(species));
         }
 
         return results;
@@ -155,6 +145,57 @@ public sealed class SpeciesTools
             .ToList();
     }
 
+    [McpServerTool(Name = "list_species_in_municipality")]
+    [Description("""
+        List the species recorded in one municipio. Municipio ids come from
+        search_municipalities or find_municipality_at_point. This is filed
+        against the municipio a record belongs to, so unlike find_species_near
+        it does not depend on a radius.
+        """)]
+    public static async Task<IReadOnlyList<SpeciesSummary>> ListSpeciesInMunicipality(
+        ISpeciesRepository repository,
+        CancellationToken cancellationToken,
+        [Description("The municipio id.")] Guid municipalityId,
+        [Description("How many to return, 1-50. Defaults to 20.")]
+        int limit = DefaultResults
+    )
+    {
+        var parameters = new SpeciesParameters(
+            PageSize: Math.Clamp(limit, 1, MaxResults),
+            MunicipalityId: municipalityId
+        );
+
+        var results = new List<SpeciesSummary>();
+
+        await foreach (var species in repository
+            .GetSpeciesAsync(parameters, cancellationToken)
+            .WithCancellation(cancellationToken))
+        {
+            results.Add(ToSummary(species));
+        }
+
+        return results;
+    }
+
+    [McpServerTool(Name = "get_species_richness_by_municipality")]
+    [Description("""
+        How many species are recorded in each municipio, for comparing one place
+        against another. Returns municipio ids and counts only — pair it with
+        search_municipalities, which returns every id with its name, to put
+        names to them.
+        """)]
+    public static async Task<IReadOnlyList<MunicipalityRichness>> GetSpeciesRichnessByMunicipality(
+        ISpeciesRepository repository,
+        CancellationToken cancellationToken
+    )
+    {
+        var counts = await repository.GetCountsByMunicipalityAsync(cancellationToken);
+
+        return counts
+            .Select(count => new MunicipalityRichness(count.MunicipalityId, count.Count))
+            .ToList();
+    }
+
     [McpServerTool(Name = "list_taxon_categories")]
     [Description("""
         List the taxonomic groups species are catalogued under. The codes
@@ -195,6 +236,19 @@ public sealed class SpeciesTools
             stats.TotalMunicipalities
         );
     }
+
+    private static SpeciesSummary ToSummary(Contracts.Dtos.SpeciesDtoForList species) =>
+        new(
+            species.Id,
+            WildlifeMcpMapping.ResolveName(species.CommonName, species.ScientificName),
+            species.ScientificName,
+            WildlifeMcpMapping.Kind(species.IsFauna),
+            species.IucnStatus?.ToString(),
+            species.IsEndemic,
+            species.TaxonCode,
+            species.MunicipalityCount,
+            species.LastObservedAtUtc
+        );
 
     /// <summary>
     /// A status the model spelled itself, so an unparseable one is treated as no

--- a/src/Features/Wildlife/EcoData.Wildlife.Mcp/WildlifeMcpExtensions.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Mcp/WildlifeMcpExtensions.cs
@@ -1,46 +1,23 @@
 using EcoData.Wildlife.Mcp.Tools;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EcoData.Wildlife.Mcp;
 
 /// <summary>
-/// Mounts the wildlife catalogue as an MCP server so it can be added to Claude
-/// (or any MCP client) as a custom connector.
+/// Contributes the wildlife tools to whatever MCP server the host is building.
 ///
-/// <para>The transport is Streamable HTTP, which is what a remote connector
-/// requires — a stdio server can only be reached from the machine it runs on.
-/// The tools read through the same repositories the HTTP endpoints use, in the
-/// same request scope, so there is no second copy of the query logic and no
-/// loopback call into our own API.</para>
+/// <para>The feature adds tools rather than standing up a server of its own:
+/// a connector is one endpoint with one tool list, so the host owns the server
+/// and each feature hands it what it can answer.</para>
 ///
-/// <para>Nothing here is authenticated, matching the wildlife endpoints
-/// themselves: the catalogue is public reference data and every tool is
-/// read-only. Anything that later exposes per-user or write access needs OAuth
-/// in front of it first.</para>
+/// <para>The tools read through the same repositories the HTTP endpoints use,
+/// in the same request scope, so there is no second copy of the query logic and
+/// no loopback call into our own API.</para>
 /// </summary>
 public static class WildlifeMcpExtensions
 {
-    public static IServiceCollection AddWildlifeMcp(this IServiceCollection services)
-    {
-        services
-            .AddMcpServer()
-            .WithHttpTransport()
+    public static IMcpServerBuilder AddWildlifeMcpTools(this IMcpServerBuilder builder) =>
+        builder
             .WithTools<SpeciesTools>()
             .WithTools<ConservationTools>();
-
-        return services;
-    }
-
-    /// <summary>
-    /// Serves the connector at <c>/mcp</c>. This is the URL a reader pastes into
-    /// their client, so it is deliberately boring and stable.
-    /// </summary>
-    public static IEndpointRouteBuilder MapWildlifeMcp(this IEndpointRouteBuilder app)
-    {
-        app.MapMcp("/mcp");
-
-        return app;
-    }
 }

--- a/src/Features/Wildlife/EcoData.Wildlife.Mcp/WildlifeMcpViews.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Mcp/WildlifeMcpViews.cs
@@ -45,6 +45,13 @@ public sealed record NearbySpecies(
     string? LocationDescription
 );
 
+/// <summary>
+/// How many species one municipio has on record. Carries the id rather than the
+/// name: the municipio list lives in the locations feature, and a model that
+/// wants names has it in one call from there.
+/// </summary>
+public sealed record MunicipalityRichness(Guid MunicipalityId, int SpeciesCount);
+
 public sealed record TaxonCategory(string Code, string Name);
 
 public sealed record ConservationPractice(string Code, string Name);


### PR DESCRIPTION
The connector could answer *what* a species is, but not *where* — other than by radius. This adds the places side: the 78 municipios the wildlife records are actually filed against. Twelve tools now, up from seven.

## New tools

**Locations** (new `EcoData.Locations.Mcp`)

| Tool | What it answers |
|---|---|
| `search_municipalities` | List or search the municipios; with no arguments returns all 78 with ids and centre points |
| `get_municipality` | One municipio by id — state, county FIPS, centroid |
| `find_municipality_at_point` | Which municipio contains a coordinate |

**Wildlife** (closing the loop)

| Tool | What it answers |
|---|---|
| `list_species_in_municipality` | Species recorded in a given municipio |
| `get_species_richness_by_municipality` | Species count per municipio, for comparing places |

`find_municipality_at_point` is the interesting one: it's a real point-in-polygon test against the stored boundary (`IMunicipalityRepository.GetByPointAsync`), not a nearest-centroid guess — so a coordinate resolves to the municipio a record would actually be filed under. Together with `list_species_in_municipality` it turns a coordinate into an answer in two calls, which `find_species_near` can't do without guessing a radius.

## Structural change

Each feature now **contributes tools to a server the host owns**, instead of standing up one of its own — a connector is one endpoint with one tool list, and there are two features feeding it now.

- `AddWildlifeMcp()` / `MapWildlifeMcp()` → `AddWildlifeMcpTools(this IMcpServerBuilder)`
- new `AddLocationsMcpTools(this IMcpServerBuilder)`
- host composes both in `FaunaFinder.Server/Mcp/FaunaFinderMcpExtensions.cs` and owns `MapMcp("/mcp")`

The endpoint, transport and auth posture are unchanged.

## A deliberate omission

`get_species_richness_by_municipality` returns **ids and counts, not names**. Naming them would mean the wildlife feature reaching into the locations one; the municipio list is one cheap call away from the tool that already owns it. A model joins the two itself.

## Verification

Against the AppHost with a live database:

- `tools/list` → 12 tools.
- `find_municipality_at_point(18.4655, -66.1057)` → San Juan, PR, FIPS 127.
- Chained: that id into `list_species_in_municipality` → Palo de ramon (CR), *Chamaecrista glandulosa var. mirabilis* (DD), Beautiful goetzea (CR).
- `search_municipalities` → 78 with no filter; `"Ponce"` → exactly Ponce.
- `get_species_richness_by_municipality` → 58 entries, top count 11. The 58 matches `municipalitiesCovered` from `get_catalogue_stats`, so the two tools agree — municipios with no records simply aren't listed.
- A point at sea (20.0, -60.0) → empty, not an error.

Branch already sits on top of #246, so rate limiting is in place and `/mcp` stays metered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
