### PR TITLE
fix(messaging): authenticate to Service Bus with managed identity

### DIFF
--- a/src/Features/Common/EcoData.Common.Messaging/AzureServiceBus/AzureServiceBusOptions.cs
+++ b/src/Features/Common/EcoData.Common.Messaging/AzureServiceBus/AzureServiceBusOptions.cs
@@ -8,7 +8,20 @@ public sealed class AzureServiceBusOptions
     public const string SectionName = "Messaging:ServiceBus";
 
     /// <summary>
-    /// Service Bus namespace connection string. For local dev this can point at the Service Bus emulator.
+    /// How to reach the Service Bus namespace. Accepts either shape that Aspire hands us:
+    /// <list type="bullet">
+    /// <item><description>
+    /// A full connection string containing <c>Endpoint=</c> (and a shared access key) — this is what
+    /// the local Service Bus emulator supplies, e.g.
+    /// <c>Endpoint=sb://localhost:5672;SharedAccessKeyName=...;SharedAccessKey=...;UseDevelopmentEmulator=true</c>.
+    /// </description></item>
+    /// <item><description>
+    /// A bare namespace endpoint with no key, e.g. <c>https://contoso.servicebus.windows.net:443/</c> —
+    /// this is what a provisioned namespace supplies when authentication is via managed identity.
+    /// </description></item>
+    /// </list>
+    /// The property name is kept for compatibility with the <c>Messaging:ServiceBus:ConnectionString</c>
+    /// configuration key that AppHost sets; the transport picks the right client overload at runtime.
     /// </summary>
     public string ConnectionString { get; set; } = string.Empty;
 

--- a/src/Features/Common/EcoData.Common.Messaging/AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/Features/Common/EcoData.Common.Messaging/AzureServiceBus/AzureServiceBusTransport.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Channels;
+using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using EcoData.Common.Messaging.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -40,8 +41,40 @@ public sealed class AzureServiceBusTransport : IMessageTransport, IAsyncDisposab
                 $"{AzureServiceBusOptions.SectionName}:ConnectionString is required when using the Azure Service Bus transport.");
         }
 
-        _client = new ServiceBusClient(_options.ConnectionString);
+        // The overload has to be picked at runtime because the same configuration key carries two
+        // different shapes depending on where we run. The emulator (Aspire's .RunAsEmulator()) hands
+        // us a real connection string with a shared access key, while a provisioned namespace using
+        // managed identity hands us only the service endpoint URI — there is no key to put in it.
+        // ServiceBusClient(string) parses its argument strictly as a connection string, so feeding it
+        // the endpoint form throws FormatException at construction and the app never starts.
+        _client = _options.ConnectionString.Contains("Endpoint=", StringComparison.OrdinalIgnoreCase)
+            ? new ServiceBusClient(_options.ConnectionString)
+            : new ServiceBusClient(NormalizeNamespace(_options.ConnectionString), new DefaultAzureCredential());
+
         _sender = _client.CreateSender(_options.TopicName);
+    }
+
+    /// <summary>
+    /// Reduces a configured namespace endpoint to the bare host that
+    /// <see cref="ServiceBusClient(string, Azure.Core.TokenCredential)"/> expects, e.g.
+    /// <c>https://contoso.servicebus.windows.net:443/</c> → <c>contoso.servicebus.windows.net</c>.
+    /// </summary>
+    private static string NormalizeNamespace(string value)
+    {
+        var candidate = value.Trim();
+
+        // Prepend a scheme when there isn't one. A bare host carrying a port
+        // ("contoso.servicebus.windows.net:443") does parse as an absolute Uri, but the host is taken
+        // as the *scheme* and Uri.Host comes back empty — so parsing it as-is would silently hand
+        // ServiceBusClient an empty namespace instead of failing loudly.
+        if (!candidate.Contains("://", StringComparison.Ordinal))
+        {
+            candidate = "https://" + candidate;
+        }
+
+        return Uri.TryCreate(candidate, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Host)
+            ? uri.Host
+            : value.Trim();
     }
 
     public async Task PublishAsync<T>(

--- a/src/Features/Common/EcoData.Common.Messaging/EcoData.Common.Messaging.csproj
+++ b/src/Features/Common/EcoData.Common.Messaging/EcoData.Common.Messaging.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup Condition="'$(RuntimeIdentifier)' != 'browser-wasm'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

`ecoportal` replicas have been crash-looping in production. Every deploy since **2026-04-27** has failed to start, and ingress has been quietly falling back to revision `ecoportal--0000098` (created April 27) — that stale revision is currently the only thing serving `portal.ecodatapr.com`.

```
System.FormatException: The connection string could not be parsed; either it was
malformed or contains no well-known tokens.
   at Azure.Messaging.ServiceBus.ServiceBusConnectionStringProperties.Parse(String)
   at EcoData.Common.Messaging.AzureServiceBus.AzureServiceBusTransport..ctor(...)
      AzureServiceBusTransport.cs:line 43
   at Program.<Main>$(String[]) EcoPortal.Server/Program.cs:line 102
```

## Cause

`AzureServiceBusTransport` always used `new ServiceBusClient(connectionString)`, which parses its argument strictly as a connection string. Aspire supplies two different shapes through the same config key:

| Environment | `Messaging__ServiceBus__ConnectionString` |
|---|---|
| Local (`.RunAsEmulator()`) | `Endpoint=sb://localhost:5672;SharedAccessKey=…` |
| Production (managed identity) | `https://servicebus-tpul2rq4execo.servicebus.windows.net:443/` |

The production form has no key to embed, so it can never parse — the host threw at startup every time.

## Fix

Pick the `ServiceBusClient` overload from the shape of the configured value: connection-string constructor when it contains `Endpoint=`, otherwise reduce the endpoint to its bare host and use the `TokenCredential` overload with `DefaultAzureCredential`.

The container already sets `AZURE_CLIENT_ID` and `AZURE_TOKEN_CREDENTIALS=ManagedIdentityCredential`, and `ecoportal_identity` already holds **Azure Service Bus Data Owner** on the namespace — so no infra change is needed.

Config key and property name are unchanged.

## Cost impact

Crash-looping replicas bill at the **active** vCPU rate, 8× idle (`$0.000024` vs `$0.000003` per vCPU-second). `ecoportal` billed **$90.79** in July against **$12** each for `faunafinder` and `sensors-ingestion`, which have identical sizing but boot cleanly. Expected saving ≈ **$55/month**, plus ~$12 more once the stale April revision can safely be deactivated.

## Verification

- `dotnet build` on `EcoData.Common.Messaging` and `EcoPortal.Server` — 0 errors.
- Exercised the **public** `AzureServiceBusTransport` constructor directly:
  - old code path reproduces the exact production `FormatException` on the real prod value;
  - fixed path constructs for the real prod value, `https://…/`, `sb://…/`, bare host, bare host + port, and the emulator connection string;
  - the empty/whitespace guard still throws `InvalidOperationException`.

## Follow-up (not in this PR)

1. After deploy, confirm the new revision reports `Healthy` with a ready replica, then deactivate `ecoportal--0000098`.
2. `sensors_ingestion_identity` has **no** role assignment on the Service Bus namespace; that app will fail auth once it publishes. Its deployed revision also lacks the `Messaging__*` env vars entirely.