### PR TITLE
Let the faunafinder container app scale to zero when idle, to stop payin

### DIFF
--- a/src/Host/EcoData.AppHost/AppHost.cs
+++ b/src/Host/EcoData.AppHost/AppHost.cs
@@ -121,8 +121,15 @@ var faunafinder = builder
     .PublishAsAzureContainerApp(
         (infra, app) =>
         {
-            // Configure 2 max replicas
-            app.Template.Scale.MinReplicas = 1;
+            // Scales to zero when idle. faunafinder has external HTTP ingress, so
+            // ACA's HTTP scale trigger wakes a replica on the next request — with
+            // MinReplicas = 1 we were paying the idle-replica rate around the clock
+            // (~$12 in July) for a month in which the app served no requests at all.
+            // The cost is a cold start on the first request after an idle period:
+            // image pull plus .NET startup, on the order of tens of seconds. Do not
+            // copy this to sensors-ingestion — it has no ingress, so no HTTP trigger
+            // would ever start it back up.
+            app.Template.Scale.MinReplicas = 0;
             app.Template.Scale.MaxReplicas = 2;
         }
     );


### PR DESCRIPTION
Let the faunafinder container app scale to zero when idle, to stop paying for a permanently-running replica.

MEASURED PROBLEM: faunafinder is configured with MinReplicas = 1, so one replica runs 24/7. Azure Container Apps billing charges that replica the reduced "idle" rate, which still came to $12.05 in July. Over 18 days of July the faunafinder container app served exactly 0 HTTP requests (Azure Monitor "Requests" metric, total = 0). We are paying about $12/month for a replica that has never handled a request.

WHERE: src/Host/EcoData.AppHost/AppHost.cs, the `faunafinder` resource, inside its PublishAsAzureContainerApp callback which currently sets:
    app.Template.Scale.MinReplicas = 1;
    app.Template.Scale.MaxReplicas = 2;

WHAT TO DO: change MinReplicas to 0 for faunafinder ONLY, so the revision scales to zero when there is no traffic and Azure charges nothing for it. Leave MaxReplicas = 2.

CRITICAL CONSTRAINTS - read carefully:
- Change faunafinder ONLY. Do NOT change ecoportal: it serves the live custom domain portal.ecodatapr.com and must stay warm.
- Do NOT change sensors-ingestion. It is a background consumer with NO HTTP ingress, so it has no HTTP scale trigger; setting its MinReplicas to 0 would mean it never starts at all and would silently stop consuming events. Leave it exactly as it is.
- Do not alter the seeder job.
- Add a comment above the changed line explaining the trade-off honestly: scale-to-zero removes the idle charge but the first request after an idle period pays a cold start (container pull + .NET startup, on the order of tens of seconds). Match this repo's existing comment style in AppHost.cs, which explains reasoning and consequences rather than restating code.

VERIFY: `dotnet build src/Host/EcoData.AppHost/EcoData.AppHost.csproj` succeeds.
Use a conventional commit subject like "perf(faunafinder): scale to zero when idle".

---
Opened by covirtual. Generated by Claude Code in an ephemeral workspace from `112819776174`.
