### PR TITLE
Stop the container registry from filling up, which will start costing mo

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -74,3 +74,46 @@ jobs:
           dotnet run scripts/deploy-affected.cs -- \
             --from "${DEPLOY_FROM:-HEAD~1}" \
             --to "$DEPLOY_TO"
+
+      # Housekeeping, not shipping: every deploy pushes new image tags and
+      # nothing ever removed the old ones, so the Basic-SKU registry was
+      # creeping towards its included 10 GiB (past that Azure bills per GiB).
+      # Runs only after a successful deploy of master, and never fails the run.
+      - name: Purge Stale Container Images
+        if: github.ref == 'refs/heads/master'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+
+          registry=$(az acr list \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --query "[0].name" -o tsv)
+
+          if [ -z "$registry" ]; then
+            echo "No container registry in $AZURE_RESOURCE_GROUP; nothing to purge."
+            exit 0
+          fi
+
+          # Every repository, discovered rather than hard-coded, so repositories
+          # added by a future service are cleaned up without touching this file.
+          filters=""
+          for repo in $(az acr repository list --name "$registry" -o tsv); do
+            filters="$filters --filter '$repo:.*'"
+          done
+
+          if [ -z "$filters" ]; then
+            echo "Registry $registry has no repositories; nothing to purge."
+            exit 0
+          fi
+
+          echo "Purging $registry:$filters"
+
+          # --ago 0d with --keep 10 means "every tag except the 10 most recent",
+          # which is the rollback window.
+          az acr run --registry "$registry" --timeout 3600 \
+            --cmd "acr purge $filters --ago 0d --keep 10" /dev/null
+
+          # Manifests orphaned when a tag moved to a newer digest. The 7-day
+          # floor leaves digests a recently deployed revision may still pin.
+          az acr run --registry "$registry" --timeout 3600 \
+            --cmd "acr purge $filters --ago 7d --untagged" /dev/null

--- a/next-steps.md
+++ b/next-steps.md
@@ -53,6 +53,16 @@ In addition, for each project resource referenced by your app host, a `container
 
 Visit the *Cost Management + Billing* page in Azure Portal to track current spend. For more information about how you're billed, and how you can monitor the costs incurred in your Azure subscriptions, visit [billing overview](https://learn.microsoft.com/azure/developer/intro/azure-developer-billing).
 
+### Container image retention
+
+The registry is on the Basic SKU, which includes 10 GiB of storage in its flat monthly fee and bills per GiB beyond that. Because every deploy pushes new image tags and nothing removed the old ones, the `Purge Stale Container Images` step in `.github/workflows/azure-dev.yml` runs an [ACR purge task](https://learn.microsoft.com/azure/container-registry/container-registry-auto-purge) after each successful deploy:
+
+- **The 10 most recent tags per repository are kept.** Older tags are deleted. Anything within that window is still available to roll back to.
+- **Untagged manifests are deleted once they are older than 7 days.** These are digests orphaned when a tag moved to a newer image; the delay leaves digests that a recently deployed revision might still pin.
+- It applies to **every repository in the registry**, discovered at run time rather than listed in the workflow, so a new service is covered automatically.
+
+The step only runs on `master`, only after the deploy succeeds, and is marked `continue-on-error` — purging is housekeeping, so a registry problem is reported but never fails a deploy that already shipped. If it consistently reports failures, check that the deploy identity can run tasks and delete images in the registry (`Contributor`, or `AcrDelete` plus task-run rights).
+
 ## Troubleshooting
 
 Q: I visited the service endpoint listed, and I'm seeing a blank page, a generic welcome page, or an error page.


### PR DESCRIPTION
Stop the container registry from filling up, which will start costing money once it overflows its included storage.

MEASURED PROBLEM: the Azure Container Registry acaenvacrtpul2rq4execo (Basic SKU, resource group rg-ecodata-prod) is using 6,842,221,122 bytes of its 10,737,418,240 byte (10 GiB) included quota - about 68% full. Basic includes 10 GiB for the flat monthly fee; beyond that Azure bills per GiB. Every deploy pushes new images and nothing ever removes old ones. The sensors-ingestion repository alone has 45 tags, and the ecoportal/faunafinder/seeder repositories hold additional untagged manifests left behind by repeated deploys. At the current rate this registry will cross 10 GiB and start incurring overage.

WHAT TO DO: add an automated cleanup step to the existing deploy workflow in .github/workflows/ (find the workflow that deploys to Azure - it is the one that runs `azd` / deploys the container apps). After a deploy succeeds, purge old images from the registry using the ACR purge task, e.g. via `az acr run` with the `acr purge` command, or `az acr manifest list-metadata` plus deletion.

RETENTION POLICY - be conservative, this must never break the ability to roll back:
- Keep the most recent 10 tagged images per repository.
- Delete untagged manifests older than 7 days.
- Apply it to every repository in that registry (ecoportal, faunafinder, seeder, sensors-ingestion) rather than hard-coding a single one.
- The cleanup must NOT fail the workflow if purging errors - it is housekeeping, not part of shipping. Make that step tolerant of failure (e.g. continue-on-error) so a purge problem never blocks or red-flags a successful deploy.
- Only run the cleanup after a successful deploy, and only on the default branch - never on pull request runs.

Also add a short note to the deploy documentation if the repo has one describing the retention policy, so the behaviour is not a surprise.

Do not change any application code. This is a CI/workflow change only.
Use a conventional commit subject like "ci: purge stale container images after deploy".

---
Opened by covirtual. Generated by Claude Code in an ephemeral workspace from `112819776174`.
