### PR TITLE
Reduce Azure Monitor / Application Insights metrics ingestion cost.

MEA

### DIFF
--- a/src/Host/EcoData.ServiceDefaults/Extensions.cs
+++ b/src/Host/EcoData.ServiceDefaults/Extensions.cs
@@ -1,6 +1,7 @@
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -18,6 +19,15 @@ public static class Extensions
 {
     private const string HealthEndpointPath = "/health";
     private const string AlivenessEndpointPath = "/alive";
+
+    // Metrics dominate what we pay Log Analytics for: over the last 14 days AppMetrics was 0.901 GB of the
+    // 1.201 GB billed (75%), against 0.208 GB of traces and 0.090 GB of dependencies - roughly 2.6 GB and $7
+    // a month. The apps behind it serve about 4 requests an hour, so that volume is not traffic, it is the
+    // periodic exporter shipping every instrument every minute around the clock. Exporting on a 5 minute
+    // cadence instead divides the row count by five and costs us nothing in coverage: every instrument and
+    // every dimension is still recorded, just batched into fewer, larger exports.
+    private const string MetricExportIntervalConfigKey = "Telemetry:MetricExportIntervalMilliseconds";
+    private const int DefaultMetricExportIntervalMilliseconds = 300_000;
 
     public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
@@ -93,6 +103,19 @@ public static class Extensions
         {
             builder.Services.AddOpenTelemetry()
                .UseAzureMonitor();
+
+            // Only stretch the interval on the billed path. When the Aspire dashboard is wired up the charts
+            // are driven by the same exporter, and a 5 minute gap between points makes the dashboard look
+            // broken - local telemetry is free, so it keeps the responsive default.
+            if (!useOtlpExporter)
+            {
+                var exportIntervalMilliseconds = builder.Configuration.GetValue(
+                    MetricExportIntervalConfigKey,
+                    DefaultMetricExportIntervalMilliseconds);
+
+                builder.Services.Configure<MetricReaderOptions>(readerOptions =>
+                    readerOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = exportIntervalMilliseconds);
+            }
         }
 
         return builder;


### PR DESCRIPTION
Reduce Azure Monitor / Application Insights metrics ingestion cost.

MEASURED PROBLEM (Log Analytics `Usage` table, billable rows, last 14 days, workspace lawappinsights-tpul2rq4execo):
    AppMetrics       0.901 GB   <-- 75% of all billable ingestion
    AppTraces        0.208 GB
    AppDependencies  0.090 GB
    AppExceptions    0.001 GB
    AppRequests      0.001 GB
That is ~2.6 GB/month of metrics, costing roughly $7/month, for apps that together serve about 4 HTTP requests per hour. The volume is entirely from periodic metric export running 24/7 across ecoportal, faunafinder, sensors-ingestion and seeder, not from request volume.

WHERE: src/Host/EcoData.ServiceDefaults/Extensions.cs, in ConfigureOpenTelemetry / AddOpenTelemetryExporters.
Current setup: .WithMetrics(m => m.AddAspNetCoreInstrumentation().AddHttpClientInstrumentation().AddRuntimeInstrumentation()) and exporting through .UseAzureMonitor() (Azure Monitor OpenTelemetry Distro), which exports metrics on the OpenTelemetry default interval of 60 seconds.

WHAT TO DO:
Raise the periodic metric export interval so far fewer metric points are shipped, by configuring PeriodicExportingMetricReaderOptions (OpenTelemetry.Metrics). Use 300000 ms (5 minutes). That cuts metric ingestion roughly 5x while keeping every instrument and every dimension intact - no metric is lost, they are just exported less often.

REQUIREMENTS:
- Apply it to the Azure Monitor export path. Do NOT change behaviour when OTEL_EXPORTER_OTLP_ENDPOINT is set (the local Aspire dashboard path) - local dev should keep the responsive default interval, because a 5 minute interval makes the dashboard feel broken.
- Make the interval configurable rather than hard-coded, reading from configuration with 300000 as the default, so it can be tuned without a redeploy of code. Suggested key: "Telemetry:MetricExportIntervalMilliseconds".
- Keep AddRuntimeInstrumentation/AddAspNetCoreInstrumentation/AddHttpClientInstrumentation - do NOT delete instrumentation to save money; the point is export frequency, not coverage.
- Add a comment explaining WHY the interval is raised (ingestion cost, measured numbers above), matching this repo's style of comments that explain the reason rather than restating the code.
- Do not touch tracing or logging configuration.

VERIFY: `dotnet build src/Host/EcoData.ServiceDefaults/EcoData.ServiceDefaults.csproj` and `dotnet build src/Apps/EcoPortal/EcoPortal.Server/EcoPortal.Server.csproj` both succeed.
Use a conventional commit subject like "perf(telemetry): cut metric export frequency to reduce ingestion cost".

---
Opened by covirtual. Generated by Claude Code in an ephemeral workspace from `112819776174`.
