### PR TITLE
fix: make the mobile back button actually render

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/_Imports.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/_Imports.razor
@@ -18,6 +18,7 @@
 @using EcoData.Spa.Navigation
 @using EcoData.Spa.Navigation.Events
 @using EcoData.Spa.Navigation.Navbar
+@using EcoData.NativeUi.Components.NativeNavbar
 @using EcoData.NativeUi.Components.PageLayout
 @using EcoData.NativeUi.Components.SearchBar
 @using EcoData.NativeUi.Components.SectionHeader

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Actions.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Actions.razor
@@ -7,6 +7,7 @@
 @inject IConservationLinkHttpClient LinkClient
 @inject ISpeciesHttpClient SpeciesHttpClient
 @inject INavbarManager Navbar
+@inject INavigationManager Navigation
 @inject NavigationManager NavigationManager
 @inject ILocalizer L
 
@@ -221,6 +222,15 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        // The list sits one level under Browse, but its path has a single
+        // segment, so the manager reads it as a navigation root and offers no
+        // back button on its own. Saying so here is what puts one there. The
+        // detail route gets the same treatment from NuiPageLayout's ParentPath.
+        if (Code is null)
+        {
+            Navigation.SetParentPath("/browse");
+        }
+
         // Both routes need the action list: the detail resolves its heading
         // from it, since the route carries only the code.
         if (LoadActionsState.Result is null && !LoadActionsState.IsLoading)

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Categories.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Categories.razor
@@ -61,7 +61,7 @@
 else
 {
     @* Categories List *@
-    <NuiPageLayout Title="Categories">
+    <NuiPageLayout Title="Categories" ParentPath="/browse">
         @if (_categoriesLoadError is not null)
         {
             <MudAlert Severity="Severity.Error">@_categoriesLoadError</MudAlert>

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Practices.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Pages/Practices.razor
@@ -7,6 +7,7 @@
 @inject IConservationLinkHttpClient LinkClient
 @inject ISpeciesHttpClient SpeciesHttpClient
 @inject INavbarManager Navbar
+@inject INavigationManager Navigation
 @inject NavigationManager NavigationManager
 @inject ILocalizer L
 
@@ -221,6 +222,15 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
+        // The list sits one level under Browse, but its path has a single
+        // segment, so the manager reads it as a navigation root and offers no
+        // back button on its own. Saying so here is what puts one there. The
+        // detail route gets the same treatment from NuiPageLayout's ParentPath.
+        if (Code is null)
+        {
+            Navigation.SetParentPath("/browse");
+        }
+
         // Both routes need the practice list: the detail resolves its heading
         // from it, since the route carries only the code.
         if (LoadPracticesState.Result is null && !LoadPracticesState.IsLoading)

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/Program.cs
@@ -17,7 +17,9 @@ var baseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 builder.Services.AddLocationsClient(baseAddress);
 builder.Services.AddWildlifeClient(baseAddress);
 
-builder.Services.AddSpaNavigation();
+// The four bottom-nav destinations. Everything else — including Browse's
+// single-segment children — is a page you can go back from.
+builder.Services.AddSpaNavigation("/", "/species", "/municipalities", "/browse");
 builder.Services.AddMudServices();
 
 // The reader's browser-local state. Singleton, not scoped: one browser, and the

--- a/src/Apps/FaunaFinder/FaunaFinder.Client/_Imports.razor
+++ b/src/Apps/FaunaFinder/FaunaFinder.Client/_Imports.razor
@@ -31,6 +31,7 @@
 @using EcoData.Spa.Navigation
 @using EcoData.Spa.Navigation.Events
 @using EcoData.Spa.Navigation.Navbar
+@using EcoData.NativeUi.Components.NativeNavbar
 @using EcoData.NativeUi.Components.PageLayout
 @using EcoData.NativeUi.Components.SearchBar
 @using EcoData.NativeUi.Components.SectionHeader

--- a/src/Features/Common/EcoData.NativeUi/Components/PageLayout/NuiPageLayout.razor
+++ b/src/Features/Common/EcoData.NativeUi/Components/PageLayout/NuiPageLayout.razor
@@ -3,9 +3,12 @@
 @inject INavbarManager Navbar
 
 <div class="nui-page-layout">
+    @* Desktop only. On mobile the app bar owns going back, and SmAndDown is
+       what both shells mean by mobile — Xs alone would leave this button in the
+       page on a 600-960px viewport while the bar showed one too. *@
     @if (!string.IsNullOrEmpty(ParentPath))
     {
-        <MudHidden Breakpoint="Breakpoint.Xs">
+        <MudHidden Breakpoint="Breakpoint.SmAndDown">
             <MudButton Variant="Variant.Text"
                        StartIcon="@Icons.Material.Filled.ArrowBack"
                        OnClick="GoBack"
@@ -28,9 +31,11 @@
                     }
                 </MudStack>
 
+                @* Same rule: SetActions has already handed these to the app bar,
+                   so showing them inline on mobile would render each twice. *@
                 @if (Actions is { Count: > 0 })
                 {
-                    <MudHidden Breakpoint="Breakpoint.Xs">
+                    <MudHidden Breakpoint="Breakpoint.SmAndDown">
                         <div class="nui-page-actions">
                             <MudStack Row Spacing="2">
                                 @foreach (var action in Actions)

--- a/src/Features/Common/EcoData.Spa.Navigation/DependencyInjection.cs
+++ b/src/Features/Common/EcoData.Spa.Navigation/DependencyInjection.cs
@@ -10,9 +10,18 @@ public static class DependencyInjection
     /// Adds the navigation and navbar managers, and the shared kernel they
     /// publish on. A host calls this instead of <c>AddSpaCore()</c> directly.
     /// </summary>
-    public static IServiceCollection AddSpaNavigation(this IServiceCollection services)
+    /// <param name="rootPaths">
+    /// The app's navigation roots — the destinations its tab bar owns. Landing
+    /// on one resets the back stack; every other page can be gone back from.
+    /// Pass none to keep the old guess that any single-segment path is a root,
+    /// which is wrong for any app whose sections link sideways.
+    /// </param>
+    public static IServiceCollection AddSpaNavigation(
+        this IServiceCollection services,
+        params string[] rootPaths)
     {
         services.AddSpaCore();
+        services.AddSingleton(new SpaNavigationOptions { RootPaths = rootPaths });
         services.AddScoped<INavigationManager, SpaNavigationManager>();
         services.AddScoped<INavbarManager, SpaNavbarManager>();
         return services;

--- a/src/Features/Common/EcoData.Spa.Navigation/SpaNavigationManager.cs
+++ b/src/Features/Common/EcoData.Spa.Navigation/SpaNavigationManager.cs
@@ -19,17 +19,23 @@ internal sealed class SpaNavigationManager : INavigationManager, IDisposable
     private readonly NavigationManager _nav;
     private readonly IJSRuntime _js;
     private readonly IEventBus _bus;
+    private readonly SpaNavigationOptions _options;
 
     private int _depth;
     private string? _parentPath;
     private bool _isNavigatingBack;
     private NavigationDirection _direction = NavigationDirection.None;
 
-    public SpaNavigationManager(NavigationManager navigationManager, IJSRuntime jsRuntime, IEventBus bus)
+    public SpaNavigationManager(
+        NavigationManager navigationManager,
+        IJSRuntime jsRuntime,
+        IEventBus bus,
+        SpaNavigationOptions options)
     {
         _nav = navigationManager;
         _js = jsRuntime;
         _bus = bus;
+        _options = options;
         _nav.LocationChanged += OnLocationChanged;
 
         // Initialize depth - deep links start at depth 1
@@ -104,12 +110,29 @@ internal sealed class SpaNavigationManager : INavigationManager, IDisposable
 
     private void Notify() => _bus.Publish(new NavigationChanged(State));
 
-    private static bool IsRootPath(string path)
+    private bool IsRootPath(string path)
     {
-        // A path is considered a "root" if it has no segments or just one segment
-        // e.g., "/" or "/monitor" but not "/sensors/123"
+        // An app that names its roots gets an exact answer. Anything it did not
+        // name is a page you can go back from, however few segments it has.
+        if (_options.RootPaths.Count > 0)
+        {
+            return _options.RootPaths.Any(root => PathsMatch(root, path));
+        }
+
+        // Otherwise guess: no segments or one segment reads as a root, e.g. "/"
+        // or "/monitor" but not "/sensors/123". Wrong for any app whose sections
+        // link sideways, which is why RootPaths exists.
         var trimmed = path.TrimStart('/');
         return string.IsNullOrEmpty(trimmed) || !trimmed.Contains('/');
+    }
+
+    private static bool PathsMatch(string left, string right) =>
+        string.Equals(Normalize(left), Normalize(right), StringComparison.OrdinalIgnoreCase);
+
+    private static string Normalize(string path)
+    {
+        var trimmed = path.Trim().TrimEnd('/');
+        return trimmed.Length == 0 ? "/" : trimmed;
     }
 
     private static string GetPathFromUri(string uri)

--- a/src/Features/Common/EcoData.Spa.Navigation/SpaNavigationOptions.cs
+++ b/src/Features/Common/EcoData.Spa.Navigation/SpaNavigationOptions.cs
@@ -1,0 +1,21 @@
+namespace EcoData.Spa.Navigation;
+
+/// <summary>
+/// The paths an app treats as navigation roots — the destinations its bottom
+/// nav or tab bar owns. Landing on one resets the back stack; anything else is
+/// a page you can go back from.
+///
+/// <para>Leave <see cref="RootPaths"/> empty and the manager falls back to
+/// calling any single-segment path a root. That guess is wrong for any app
+/// whose sections link sideways — FaunaFinder's Browse hub links to
+/// <c>/categories</c>, <c>/practices</c> and <c>/actions</c>, all one segment,
+/// so every one of them looked like a root and offered no way back.</para>
+/// </summary>
+public sealed class SpaNavigationOptions
+{
+    /// <summary>
+    /// Root paths, compared case-insensitively with trailing slashes ignored.
+    /// Empty means "use the single-segment heuristic".
+    /// </summary>
+    public IReadOnlyList<string> RootPaths { get; init; } = [];
+}


### PR DESCRIPTION
The mobile back button was missing. Two independent bugs were stacking, and the first one hid the second.

## Bug 1 — the component never rendered (regression from #258, mine)

`NuiNativeNavbar` lives in `EcoData.NativeUi.Components.NativeNavbar`. That namespace also held the two navigation manager interfaces, and when those moved to `EcoData.Spa.Navigation` in #258 I deleted the `@using` from both apps' `_Imports.razor` along with them. **The managers moved; the component did not.**

Razor doesn't fail on an unresolved component — it emits the tag as literal markup and warns `RZ10012`. So every build stayed green while the browser received an inert element:

```html
<nuinativenavbar showbackbutton="true" showtitle="false" showactions="false"></nuinativenavbar>
```

No behaviour, no children. That's why there was no back button **anywhere, on any page, in either app**. EcoPortal renders `NuiNativeNavbar` twice in its own `MainLayout` and was equally broken.

## Bug 2 — every child of Browse looked like a navigation root

`IsRootPath` guessed that any single-segment path was a root, so landing on one reset `_depth` to 0 and `CanGoBack` went false. Browse links to `/categories`, `/practices` and `/actions` — all one segment — so every child of Browse offered no way back.

That heuristic can't be right for both apps from inside a shared library, so the app now says:

```csharp
// FaunaFinder — the four bottom-nav destinations
builder.Services.AddSpaNavigation("/", "/species", "/municipalities", "/browse");

// EcoPortal — passes none, keeps the old heuristic, unchanged
builder.Services.AddSpaNavigation();
```

Anything not named is a page you can go back from, so a forward navigation increments `_depth` and back works through history — the same way it already did on detail pages.

This replaces a per-page `SetParentPath` workaround I tried first. It worked for Practices and Actions but never for Categories: on a client-side navigation `OnLocationChanged` clears `_parentPath` *after* the page sets it, and which one won wasn't something the page could control. Depth doesn't race.

## Bug 3 — the in-page back button showed on mobile

`NuiPageLayout` used `<MudHidden Breakpoint="Breakpoint.Xs">`. `MudHidden` hides when the breakpoint **matches**, so that hid the in-page Back button below 600px and showed it from 600px up — including `Sm`, which both shells treat as mobile. Both shells say mobile with `MdAndUp`/`SmAndDown` across fourteen `MudHidden` uses, and `Species.razor:356` writes it as `breakpoint is Breakpoint.Xs or Breakpoint.Sm`. `NuiPageLayout` was the only place in the solution using `Breakpoint.Xs`.

Its page-actions block had the same bug with a louder symptom: `SetActions` has already handed those buttons to the app bar, so on `Sm` each action rendered twice.

## Verification

Driven in a real browser at 393px, not read from source:

| Case | Result |
|---|---|
| `/`, `/species`, `/municipalities`, `/browse` | no back button — correct, they're tab roots |
| Browse → `/categories` | back button, tapping it lands on `/browse` |
| Browse → `/practices` | back button, tapping it lands on `/browse` |
| Browse → `/actions` | back button, tapping it lands on `/browse` |
| `/species/{id}` | back button in the app bar |
| desktop 1280px | in-page back button on Categories, mobile bar clean |

EcoPortal is unchanged behaviourally: it passes no root paths, so it keeps the old heuristic, and it gains the `@using` fix that makes its own `NuiNativeNavbar` render.
