### PR TITLE
feat(authorization): add the Common.Authorization library

### DIFF
--- a/EcoData.slnx
+++ b/EcoData.slnx
@@ -30,6 +30,7 @@
   </Folder>
   <Folder Name="/Features/" />
   <Folder Name="/Features/Common/">
+    <Project Path="src/Features/Common/EcoData.Common.Authorization/EcoData.Common.Authorization.csproj" />
     <Project Path="src/Features/Common/EcoData.Common.Http.Helpers/EcoData.Common.Http.Helpers.csproj" />
     <Project Path="src/Features/Common/EcoData.Common.i18n/EcoData.Common.i18n.csproj" />
     <Project Path="src/Features/Common/EcoData.Common.Messaging/EcoData.Common.Messaging.csproj" />

--- a/covirtual.json
+++ b/covirtual.json
@@ -1,0 +1,7 @@
+{
+  "repo": "https://github.com/andres-m-rodriguez/EcoData.git",
+  "branchPrefix": "ecodata-agents",
+  "pr": true,
+  "prBase": "master",
+  "timeout": 45
+}

--- a/src/Features/Common/EcoData.Common.Authorization/Authorization.cs
+++ b/src/Features/Common/EcoData.Common.Authorization/Authorization.cs
@@ -1,0 +1,52 @@
+using System.Collections.Frozen;
+
+namespace EcoData.Common.Authorization;
+
+/// <summary>
+/// Routes each question to the source that owns its scope kind.
+/// </summary>
+public sealed class Authorization : IAuthorization
+{
+    private readonly FrozenDictionary<string, IPermissionSource> _sources;
+
+    public Authorization(IEnumerable<IPermissionSource> sources)
+    {
+        var byKind = new Dictionary<string, IPermissionSource>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var source in sources)
+        {
+            if (!byKind.TryAdd(source.ScopeKind, source))
+            {
+                throw new InvalidOperationException(
+                    $"Two permission sources claim scope kind '{source.ScopeKind}': "
+                        + $"{byKind[source.ScopeKind].GetType().Name} and {source.GetType().Name}."
+                );
+            }
+        }
+
+        _sources = byKind.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public Task<bool> HasPermissionAsync(
+        PermissionScope scope,
+        string permission,
+        CancellationToken cancellationToken = default
+    ) => Source(scope).HasPermissionAsync(scope, permission, cancellationToken);
+
+    public Task<bool> IsInRoleAsync(
+        PermissionScope scope,
+        string role,
+        CancellationToken cancellationToken = default
+    ) => Source(scope).IsInRoleAsync(scope, role, cancellationToken);
+
+    // A missing source is a wiring mistake, not a denied user. Failing loudly beats
+    // returning false, which would look exactly like "correctly configured, no access"
+    // and hide the misconfiguration behind a plausible answer.
+    private IPermissionSource Source(PermissionScope scope) =>
+        _sources.TryGetValue(scope.Kind, out var source)
+            ? source
+            : throw new InvalidOperationException(
+                $"No permission source is registered for scope kind '{scope.Kind}'. "
+                    + $"Registered kinds: {(_sources.Count is 0 ? "(none)" : string.Join(", ", _sources.Keys))}."
+            );
+}

--- a/src/Features/Common/EcoData.Common.Authorization/DependencyInjection.cs
+++ b/src/Features/Common/EcoData.Common.Authorization/DependencyInjection.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EcoData.Common.Authorization;
+
+public static class DependencyInjection
+{
+    /// <summary>
+    /// Registers the unified <see cref="IAuthorization"/> entry point. Add a source per
+    /// scope kind the host uses with <see cref="AddPermissionSource{T}"/>.
+    /// </summary>
+    public static IServiceCollection AddAuthorization(this IServiceCollection services)
+    {
+        services.AddScoped<IAuthorization, Authorization>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the source answering for one scope kind. Two sources claiming the same
+    /// kind throws when <see cref="IAuthorization"/> is first resolved.
+    /// </summary>
+    public static IServiceCollection AddPermissionSource<T>(this IServiceCollection services)
+        where T : class, IPermissionSource
+    {
+        services.AddScoped<IPermissionSource, T>();
+
+        return services;
+    }
+}

--- a/src/Features/Common/EcoData.Common.Authorization/EcoData.Common.Authorization.csproj
+++ b/src/Features/Common/EcoData.Common.Authorization/EcoData.Common.Authorization.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Features/Common/EcoData.Common.Authorization/IAuthorization.cs
+++ b/src/Features/Common/EcoData.Common.Authorization/IAuthorization.cs
@@ -1,0 +1,34 @@
+namespace EcoData.Common.Authorization;
+
+/// <summary>
+/// The one thing callers use to ask an authorization question, whatever the answer is
+/// backed by. Always about the current user.
+/// </summary>
+/// <remarks>
+/// Ambient — there is no principal parameter — because the browser has no
+/// <c>ClaimsPrincipal</c> to pass, and the same call has to compile on both sides. Server
+/// code asking about somebody other than the caller should go to the owning module directly.
+/// <para>
+/// Both questions take a scope, so "Owner of this organization" and "GlobalAdmin anywhere"
+/// are the same shape:
+/// <code>
+/// await auth.HasPermissionAsync(PermissionScope.Organization(orgId), "sensor:update");
+/// await auth.HasPermissionAsync(PermissionScope.Application("faunafinder"), "fauna:occurrence:submit");
+/// await auth.IsInRoleAsync(PermissionScope.Global, "GlobalAdmin");
+/// </code>
+/// </para>
+/// </remarks>
+public interface IAuthorization
+{
+    Task<bool> HasPermissionAsync(
+        PermissionScope scope,
+        string permission,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<bool> IsInRoleAsync(
+        PermissionScope scope,
+        string role,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Features/Common/EcoData.Common.Authorization/IPermissionSource.cs
+++ b/src/Features/Common/EcoData.Common.Authorization/IPermissionSource.cs
@@ -1,0 +1,31 @@
+namespace EcoData.Common.Authorization;
+
+/// <summary>
+/// Answers authorization questions for one kind of scope. Whichever module owns a scope's
+/// storage implements this: Organization for <c>organization</c>, Identity for
+/// <c>global</c>, and so on.
+/// </summary>
+/// <remarks>
+/// Registering a source is how a scope kind becomes usable. Feature modules never implement
+/// this — they ask <see cref="IAuthorization"/> and stay unaware of where answers come from.
+/// </remarks>
+public interface IPermissionSource
+{
+    /// <summary>
+    /// The <see cref="PermissionScope.Kind"/> this source answers for. Exactly one source
+    /// may claim a kind.
+    /// </summary>
+    string ScopeKind { get; }
+
+    Task<bool> HasPermissionAsync(
+        PermissionScope scope,
+        string permission,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<bool> IsInRoleAsync(
+        PermissionScope scope,
+        string role,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Features/Common/EcoData.Common.Authorization/PermissionScope.cs
+++ b/src/Features/Common/EcoData.Common.Authorization/PermissionScope.cs
@@ -1,0 +1,30 @@
+namespace EcoData.Common.Authorization;
+
+/// <summary>
+/// What a permission or role is being asked about. Scopes differ in <em>kind</em>, not just
+/// in value: an organization is identified by a guid, while a global question has nothing
+/// to identify at all.
+/// </summary>
+/// <remarks>
+/// Build one through the factory members rather than the constructor — the kind strings are
+/// matched against <c>IPermissionSource.ScopeKind</c>, so a typo would route to no source.
+/// <see cref="Custom"/> exists for kinds this library does not define.
+/// </remarks>
+public readonly record struct PermissionScope(string Kind, string? Id)
+{
+    public const string GlobalKind = "global";
+    public const string OrganizationKind = "organization";
+
+    /// <summary>Not scoped to anything — "may this user do X anywhere".</summary>
+    public static PermissionScope Global => new(GlobalKind, null);
+
+    /// <summary>Within one organization.</summary>
+    public static PermissionScope Organization(Guid organizationId) =>
+        new(OrganizationKind, organizationId.ToString());
+
+    /// <summary>
+    /// A kind this library does not define. The host must register a source for it, or
+    /// checks against it throw.
+    /// </summary>
+    public static PermissionScope Custom(string kind, string? id) => new(kind, id);
+}

--- a/src/Features/Common/EcoData.Common.Authorization/README.md
+++ b/src/Features/Common/EcoData.Common.Authorization/README.md
@@ -1,0 +1,334 @@
+# EcoData.Common.Authorization
+
+One call shape for every authorization question. A scope varies in **kind** — organization or global — and each kind is answered by whichever module owns its storage.
+
+```csharp
+await auth.HasPermissionAsync(PermissionScope.Organization(orgId), "wildlife:occurrence:submit");
+await auth.IsInRoleAsync(PermissionScope.Organization(orgId), "Owner");
+await auth.IsInRoleAsync(PermissionScope.Global, "GlobalAdmin");
+```
+
+Per-app permissions are modelled as an organization: FaunaFinder resolves to the org that runs it, so there is one mechanism rather than two. See §3.
+
+## 1. Declare the keys — `<Feature>.Application`
+
+Namespaced by feature, never by app — the org mapping is a deployment decision, the permission is a domain fact.
+
+```csharp
+namespace EcoData.Wildlife.Application;
+
+public static class WildlifePermissions
+{
+    public const string ReadSpecies = "wildlife:species:read";
+    public const string SubmitOccurrence = "wildlife:occurrence:submit";
+    public const string VerifyOccurrence = "wildlife:occurrence:verify";
+}
+```
+
+## 2. Wrap them in a typed contract — `<Feature>.Application`
+
+One method per permission, so no call site types a key.
+
+```csharp
+public interface IWildlifePermission
+{
+    Task<bool> CanReadSpeciesAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<bool> CanVerifyOccurrenceAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default
+    );
+}
+```
+
+## 3. Hide the organization where it is fixed
+
+FaunaFinder's contributors are members of the organization that runs it. Call sites should not know that — resolving the org here means swapping to a real app scope later touches one file.
+
+```csharp
+// FaunaFinder.Server/Options/FaunaFinderOptions.cs
+public sealed class FaunaFinderOptions
+{
+    public const string SectionName = "FaunaFinder";
+
+    // A slug, not a guid: organizations are created at runtime, so the id differs per
+    // environment and cannot be committed as configuration. The slug is stable.
+    public required string OrganizationSlug { get; set; }
+}
+
+// Resolved once at startup, then held as the id.
+public sealed class FaunaFinderOrganization(Guid id)
+{
+    public Guid Id { get; } = id;
+}
+
+public interface IFaunaFinderPermission
+{
+    Task<bool> CanSubmitOccurrenceAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class FaunaFinderPermission(IAuthorization auth, FaunaFinderOrganization organization)
+    : IFaunaFinderPermission
+{
+    public Task<bool> CanSubmitOccurrenceAsync(CancellationToken cancellationToken = default) =>
+        auth.HasPermissionAsync(
+            PermissionScope.Organization(organization.Id),
+            WildlifePermissions.SubmitOccurrence,
+            cancellationToken
+        );
+}
+```
+
+## 4. Implement a source per scope kind
+
+Only the module that owns the storage writes one. Features never do.
+
+### Organization — server
+
+```csharp
+public sealed class OrganizationPermissionSource(
+    IHttpContextAccessor httpContextAccessor,
+    IOrganizationPermissionService permissions,
+    IOrganizationMembershipRepository memberships
+) : IPermissionSource
+{
+    public string ScopeKind => PermissionScope.OrganizationKind;
+
+    public async Task<bool> HasPermissionAsync(
+        PermissionScope scope,
+        string permission,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (!TryResolve(scope, out var userId, out var organizationId))
+            return false;
+
+        return await permissions.HasPermissionAsync(
+            userId,
+            organizationId,
+            permission,
+            cancellationToken
+        );
+    }
+
+    public async Task<bool> IsInRoleAsync(
+        PermissionScope scope,
+        string role,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (!TryResolve(scope, out var userId, out var organizationId))
+            return false;
+
+        var membership = await memberships.GetAsync(userId, organizationId, cancellationToken);
+
+        return string.Equals(membership?.RoleName, role, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool TryResolve(PermissionScope scope, out Guid userId, out Guid organizationId)
+    {
+        userId = default;
+
+        if (!Guid.TryParse(scope.Id, out organizationId))
+            return false;
+
+        var user = httpContextAccessor.HttpContext?.User;
+
+        if (user is null)
+            return false;
+
+        var token = new RequestClaimToken(user);
+
+        if (!token.IsAuthenticated)
+            return false;
+
+        userId = token.UserId.Value;
+
+        return true;
+    }
+}
+```
+
+### Global — server
+
+No scope id. Roles come off the principal; nothing is granted globally except by role.
+
+```csharp
+public sealed class GlobalPermissionSource(IHttpContextAccessor httpContextAccessor)
+    : IPermissionSource
+{
+    public string ScopeKind => PermissionScope.GlobalKind;
+
+    public Task<bool> HasPermissionAsync(
+        PermissionScope scope,
+        string permission,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(false);
+
+    public Task<bool> IsInRoleAsync(
+        PermissionScope scope,
+        string role,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var user = httpContextAccessor.HttpContext?.User;
+
+        return Task.FromResult(user?.IsInRole(role) ?? false);
+    }
+}
+```
+
+### Organization — client
+
+Same scope kind, different transport: one fetch per scope, cached, answering every question about it.
+
+```csharp
+public sealed class OrganizationPermissionSource(IPermissionHttpClient permissionClient)
+    : IPermissionSource
+{
+    private readonly Dictionary<Guid, Task<UserPermissionsDto>> _cache = [];
+
+    public string ScopeKind => PermissionScope.OrganizationKind;
+
+    public async Task<bool> HasPermissionAsync(
+        PermissionScope scope,
+        string permission,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (!Guid.TryParse(scope.Id, out var organizationId))
+            return false;
+
+        var permissions = await GetAsync(organizationId, cancellationToken);
+
+        return permissions.IsGlobalAdmin || permissions.Permissions.Contains(permission);
+    }
+
+    public Task<bool> IsInRoleAsync(
+        PermissionScope scope,
+        string role,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(false);
+
+    // Caches the Task, not the result, so concurrent callers share one request.
+    private Task<UserPermissionsDto> GetAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken
+    )
+    {
+        if (_cache.TryGetValue(organizationId, out var cached))
+            return cached;
+
+        var task = FetchAsync(organizationId, cancellationToken);
+        _cache[organizationId] = task;
+
+        return task;
+    }
+}
+```
+
+## 5. Register — host
+
+Each host registers only the kinds it uses.
+
+```csharp
+// EcoPortal.Server
+builder.Services.AddAuthorization();
+builder.Services.AddPermissionSource<OrganizationPermissionSource>();
+builder.Services.AddPermissionSource<GlobalPermissionSource>();
+
+// EcoPortal.Client
+builder.Services.AddAuthorization();
+builder.Services.AddPermissionSource<OrganizationPermissionSource>();   // the HTTP one
+```
+
+FaunaFinder additionally resolves its organization once, at startup:
+
+```csharp
+// FaunaFinder.Server/Program.cs
+builder.Services.Configure<FaunaFinderOptions>(
+    builder.Configuration.GetSection(FaunaFinderOptions.SectionName)
+);
+builder.Services.AddAuthorization();
+builder.Services.AddPermissionSource<OrganizationPermissionSource>();
+
+var app = builder.Build();
+
+await using (var scope = app.Services.CreateAsyncScope())
+{
+    var slug = scope
+        .ServiceProvider.GetRequiredService<IOptions<FaunaFinderOptions>>()
+        .Value.OrganizationSlug;
+
+    var organization =
+        await scope
+            .ServiceProvider.GetRequiredService<IOrganizationRepository>()
+            .GetBySlugAsync(slug)
+        ?? throw new InvalidOperationException(
+            $"FaunaFinder is configured for organization '{slug}', which does not exist."
+        );
+
+    app.Services.GetRequiredService<FaunaFinderOrganization>();   // registered from organization.Id
+}
+```
+
+```json
+{ "FaunaFinder": { "OrganizationSlug": "intermetro" } }
+```
+
+## 6. Use it
+
+```csharp
+// Endpoint
+group
+    .MapPost(
+        "/{id:guid}/verify",
+        async Task<Results<NoContent, ForbidHttpResult, NotFound>> (
+            Guid id,
+            IWildlifePermission wildlife,
+            IOccurrenceRepository repository,
+            CancellationToken ct
+        ) =>
+        {
+            var occurrence = await repository.GetByIdAsync(id, ct);
+
+            if (occurrence is null)
+                return TypedResults.NotFound();
+
+            if (!await wildlife.CanVerifyOccurrenceAsync(occurrence.OrganizationId, ct))
+                return TypedResults.Forbid();
+
+            await repository.VerifyAsync(id, ct);
+
+            return TypedResults.NoContent();
+        }
+    )
+    .RequireAuthorization();
+```
+
+```razor
+@inject IFaunaFinderPermission Permission
+
+@if (_canSubmit)
+{
+    <MudButton OnClick="SubmitAsync">Submit sighting</MudButton>
+}
+
+@code {
+    private bool _canSubmit;
+
+    protected override async Task OnInitializedAsync() =>
+        _canSubmit = await Permission.CanSubmitOccurrenceAsync();
+}
+```
+
+## Rules
+
+- Adding a scope kind means adding a source. An unregistered kind **throws** naming the missing kind — it never denies silently, because a silent `false` is indistinguishable from a correct denial.
+- Two sources claiming one kind throws when `IAuthorization` is first resolved.
+- Client answers shape UI only. They can be more permissive than the server, which sees rules the browser cannot. The endpoint check is the enforcement.
+- Permission keys appear in `<Feature>.Application` and inside sources. Never at a call site.
+- FaunaFinder's organization is configuration, not a constant. It becomes wrong the day a second institution contributes — at which point the fix is a new scope kind behind `IFaunaFinderPermission`, and no call site changes.


### PR DESCRIPTION
Adds `EcoData.Common.Authorization` — one entry point for authorization questions, so callers ask the same way regardless of what backs the answer.

## The idea

A scope varies in **kind**, not just value. That is what lets one API cover org-scoped and global questions without a second mechanism:

```csharp
await auth.HasPermissionAsync(PermissionScope.Organization(orgId), "wildlife:occurrence:submit");
await auth.IsInRoleAsync(PermissionScope.Organization(orgId), "Owner");
await auth.IsInRoleAsync(PermissionScope.Global, "GlobalAdmin");
```

Roles and permissions both take a scope, so "Owner of this organization" and "GlobalAdmin anywhere" stop being separate paths — today the latter is a `RequireClaim` policy sitting outside the permission system entirely.

## Shape

| Type | Role |
|---|---|
| `PermissionScope` | `Global` / `Organization(guid)` / `Custom(kind, id)` |
| `IAuthorization` | the only thing call sites touch |
| `IPermissionSource` | one per scope kind, implemented by whoever owns that storage |
| `Authorization` | routes on `scope.Kind` |
| `DependencyInjection` | `AddAuthorization()` · `AddPermissionSource<T>()` |

Organization implements the `organization` source, Identity the `global` one. Feature modules depend on `IAuthorization` alone and never learn where answers come from. The library references nothing but `Microsoft.Extensions.DependencyInjection.Abstractions`.

## Two deliberate choices

**An unregistered scope kind throws**, naming the missing kind, rather than returning `false`. A silent denial is indistinguishable from a correct one — the same failure mode that let the `"GlobalAdmin"` vs `"Admin"` claim mismatch in `AuthService` go unnoticed. Scope kinds come from code, never user input, so this cannot be triggered by a request.

**Duplicate sources for one kind throw** when `IAuthorization` is first resolved, rather than silently first-wins.

## Not in this PR

No sources ship yet — a call currently throws with a message naming the missing kind. The README covers declaring keys, wrapping them in a typed per-feature contract, implementing sources for server and client, and host wiring, including modelling per-app permissions as an organization resolved from a configured slug.

The natural follow-up is the organization server source, since that is the only scope kind with storage behind it today.

## Note

This branch also carries `chore: add covirtual agent config` (`9f2008d`), unrelated to the library. Happy to split it out if you would rather it land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)