### PR TITLE
feat(faunafinder): add authentication and organization-scoped authorization

### DIFF
--- a/EcoData.slnx
+++ b/EcoData.slnx
@@ -65,6 +65,7 @@
     <Project Path="src/Features/Organization/EcoData.Organization.Api/EcoData.Organization.Api.csproj" />
     <Project Path="src/Features/Organization/EcoData.Organization.Application.Client/EcoData.Organization.Application.Client.csproj" />
     <Project Path="src/Features/Organization/EcoData.Organization.Application.Server/EcoData.Organization.Application.Server.csproj" />
+    <Project Path="src/Features/Organization/EcoData.Organization.Authorization/EcoData.Organization.Authorization.csproj" />
     <Project Path="src/Features/Organization/EcoData.Organization.Contracts/EcoData.Organization.Contracts.csproj" />
     <Project Path="src/Features/Organization/EcoData.Organization.DataAccess/EcoData.Organization.DataAccess.csproj" />
     <Project Path="src/Features/Organization/EcoData.Organization.Database/EcoData.Organization.Database.csproj" />

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOptions.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOptions.cs
@@ -1,0 +1,16 @@
+namespace FaunaFinder.Server.Authorization;
+
+public sealed class FaunaFinderOptions
+{
+    public const string SectionName = "FaunaFinder";
+
+    /// <summary>
+    /// The organization whose members may contribute to FaunaFinder.
+    /// </summary>
+    /// <remarks>
+    /// A slug rather than an id: organizations are created at runtime, so the guid differs
+    /// per environment and cannot be committed as configuration. The slug is stable, and
+    /// <c>organizations.slug</c> carries a unique index.
+    /// </remarks>
+    public string OrganizationSlug { get; set; } = string.Empty;
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOptions.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOptions.cs
@@ -3,14 +3,5 @@ namespace FaunaFinder.Server.Authorization;
 public sealed class FaunaFinderOptions
 {
     public const string SectionName = "FaunaFinder";
-
-    /// <summary>
-    /// The organization whose members may contribute to FaunaFinder.
-    /// </summary>
-    /// <remarks>
-    /// A slug rather than an id: organizations are created at runtime, so the guid differs
-    /// per environment and cannot be committed as configuration. The slug is stable, and
-    /// <c>organizations.slug</c> carries a unique index.
-    /// </remarks>
     public string OrganizationSlug { get; set; } = string.Empty;
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganization.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganization.cs
@@ -1,15 +1,21 @@
 namespace FaunaFinder.Server.Authorization;
 
 /// <summary>
-/// The resolved id of the organization FaunaFinder contributes to, filled in once at
-/// startup by <see cref="FaunaFinderOrganizationResolver"/>.
+/// The organization FaunaFinder contributes to, read once at startup and held in memory.
 /// </summary>
 /// <remarks>
-/// <see cref="Id"/> stays null when the configured slug matches no organization. That is
-/// not fatal — FaunaFinder is a public catalogue first, so it serves anonymous traffic
-/// normally and every contributor permission simply answers false.
+/// Carries more than the id because the rest is useful to the app and free once resolved —
+/// the name and branding for "contributing to…" surfaces, the slug for links back to the
+/// organization page. Fields the catalogue has no business holding (tax id, legal status)
+/// are deliberately not copied across.
 /// </remarks>
-public sealed class FaunaFinderOrganization
-{
-    public Guid? Id { get; internal set; }
-}
+public sealed record FaunaFinderOrganization(
+    Guid Id,
+    string Slug,
+    string Name,
+    string? Tagline,
+    string? ProfilePictureUrl,
+    string? WebsiteUrl,
+    string? PrimaryColor,
+    string? AccentColor
+);

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganization.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganization.cs
@@ -1,0 +1,15 @@
+namespace FaunaFinder.Server.Authorization;
+
+/// <summary>
+/// The resolved id of the organization FaunaFinder contributes to, filled in once at
+/// startup by <see cref="FaunaFinderOrganizationResolver"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="Id"/> stays null when the configured slug matches no organization. That is
+/// not fatal — FaunaFinder is a public catalogue first, so it serves anonymous traffic
+/// normally and every contributor permission simply answers false.
+/// </remarks>
+public sealed class FaunaFinderOrganization
+{
+    public Guid? Id { get; internal set; }
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationAccessor.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationAccessor.cs
@@ -1,0 +1,16 @@
+namespace FaunaFinder.Server.Authorization;
+
+/// <summary>
+/// Holds the resolved <see cref="FaunaFinderOrganization"/>, or nothing when the configured
+/// slug matches no organization.
+/// </summary>
+/// <remarks>
+/// One nullable reference rather than a nullable field per property: callers check once,
+/// then work with non-null values. Absence is not fatal — FaunaFinder is a public catalogue
+/// first, so it serves anonymous traffic normally and every contributor permission answers
+/// false.
+/// </remarks>
+public sealed class FaunaFinderOrganizationAccessor
+{
+    public FaunaFinderOrganization? Organization { get; internal set; }
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationResolver.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationResolver.cs
@@ -1,0 +1,57 @@
+using EcoData.Organization.DataAccess.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace FaunaFinder.Server.Authorization;
+
+/// <summary>
+/// Turns the configured slug into an organization id once, before the app serves traffic.
+/// </summary>
+public sealed class FaunaFinderOrganizationResolver(
+    IServiceScopeFactory scopeFactory,
+    IOptions<FaunaFinderOptions> options,
+    FaunaFinderOrganization organization,
+    ILogger<FaunaFinderOrganizationResolver> logger
+) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var slug = options.Value.OrganizationSlug;
+
+        if (string.IsNullOrWhiteSpace(slug))
+        {
+            logger.LogWarning(
+                "No {Section}:{Key} configured. Contributor permissions will be denied.",
+                FaunaFinderOptions.SectionName,
+                nameof(FaunaFinderOptions.OrganizationSlug)
+            );
+
+            return;
+        }
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+
+        var organizations = scope.ServiceProvider.GetRequiredService<IOrganizationRepository>();
+        var resolved = await organizations.GetBySlugAsync(slug, cancellationToken);
+
+        if (resolved is null)
+        {
+            logger.LogWarning(
+                "Organization '{Slug}' was not found. Contributor permissions will be denied "
+                    + "until it exists.",
+                slug
+            );
+
+            return;
+        }
+
+        organization.Id = resolved.Id;
+
+        logger.LogInformation(
+            "FaunaFinder contributes to organization '{Slug}' ({OrganizationId}).",
+            slug,
+            resolved.Id
+        );
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationResolver.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationResolver.cs
@@ -4,12 +4,12 @@ using Microsoft.Extensions.Options;
 namespace FaunaFinder.Server.Authorization;
 
 /// <summary>
-/// Turns the configured slug into an organization id once, before the app serves traffic.
+/// Reads the configured organization once, before the app serves traffic.
 /// </summary>
 public sealed class FaunaFinderOrganizationResolver(
     IServiceScopeFactory scopeFactory,
     IOptions<FaunaFinderOptions> options,
-    FaunaFinderOrganization organization,
+    FaunaFinderOrganizationAccessor accessor,
     ILogger<FaunaFinderOrganizationResolver> logger
 ) : IHostedService
 {
@@ -44,11 +44,21 @@ public sealed class FaunaFinderOrganizationResolver(
             return;
         }
 
-        organization.Id = resolved.Id;
+        accessor.Organization = new FaunaFinderOrganization(
+            resolved.Id,
+            resolved.Slug,
+            resolved.Name,
+            resolved.Tagline,
+            resolved.ProfilePictureUrl,
+            resolved.WebsiteUrl,
+            resolved.PrimaryColor,
+            resolved.AccentColor
+        );
 
         logger.LogInformation(
-            "FaunaFinder contributes to organization '{Slug}' ({OrganizationId}).",
-            slug,
+            "FaunaFinder contributes to {Name} ('{Slug}', {OrganizationId}).",
+            resolved.Name,
+            resolved.Slug,
             resolved.Id
         );
     }

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationResolver.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationResolver.cs
@@ -4,16 +4,23 @@ using Microsoft.Extensions.Options;
 namespace FaunaFinder.Server.Authorization;
 
 /// <summary>
-/// Reads the configured organization once, before the app serves traffic.
+/// Reads the configured organization. Says nothing about when it runs — the host decides
+/// whether that is once at startup, lazily on first use, or on a refresh.
 /// </summary>
 public sealed class FaunaFinderOrganizationResolver(
-    IServiceScopeFactory scopeFactory,
     IOptions<FaunaFinderOptions> options,
-    FaunaFinderOrganizationAccessor accessor,
+    IOrganizationRepository organizations,
     ILogger<FaunaFinderOrganizationResolver> logger
-) : IHostedService
+)
 {
-    public async Task StartAsync(CancellationToken cancellationToken)
+    /// <returns>
+    /// The organization, or <see langword="null"/> when none is configured or the
+    /// configured slug matches nothing. Both cases are logged and neither throws:
+    /// FaunaFinder is a public catalogue first and has to keep serving anonymous traffic.
+    /// </returns>
+    public async Task<FaunaFinderOrganization?> ResolveAsync(
+        CancellationToken cancellationToken = default
+    )
     {
         var slug = options.Value.OrganizationSlug;
 
@@ -25,12 +32,9 @@ public sealed class FaunaFinderOrganizationResolver(
                 nameof(FaunaFinderOptions.OrganizationSlug)
             );
 
-            return;
+            return null;
         }
 
-        await using var scope = scopeFactory.CreateAsyncScope();
-
-        var organizations = scope.ServiceProvider.GetRequiredService<IOrganizationRepository>();
         var resolved = await organizations.GetBySlugAsync(slug, cancellationToken);
 
         if (resolved is null)
@@ -41,10 +45,17 @@ public sealed class FaunaFinderOrganizationResolver(
                 slug
             );
 
-            return;
+            return null;
         }
 
-        accessor.Organization = new FaunaFinderOrganization(
+        logger.LogInformation(
+            "FaunaFinder contributes to {Name} ('{Slug}', {OrganizationId}).",
+            resolved.Name,
+            resolved.Slug,
+            resolved.Id
+        );
+
+        return new FaunaFinderOrganization(
             resolved.Id,
             resolved.Slug,
             resolved.Name,
@@ -54,14 +65,5 @@ public sealed class FaunaFinderOrganizationResolver(
             resolved.PrimaryColor,
             resolved.AccentColor
         );
-
-        logger.LogInformation(
-            "FaunaFinder contributes to {Name} ('{Slug}', {OrganizationId}).",
-            resolved.Name,
-            resolved.Slug,
-            resolved.Id
-        );
     }
-
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationStartupTask.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderOrganizationStartupTask.cs
@@ -1,0 +1,26 @@
+namespace FaunaFinder.Server.Authorization;
+
+/// <summary>
+/// The host's choice of <em>when</em>: resolve once, before the app serves traffic.
+/// </summary>
+/// <remarks>
+/// Swapping this for lazy resolution or a periodic refresh means replacing this class and
+/// nothing else — <see cref="FaunaFinderOrganizationResolver"/> has no lifecycle of its own.
+/// </remarks>
+public sealed class FaunaFinderOrganizationStartupTask(
+    IServiceScopeFactory scopeFactory,
+    FaunaFinderOrganizationAccessor accessor
+) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+
+        var resolver =
+            scope.ServiceProvider.GetRequiredService<FaunaFinderOrganizationResolver>();
+
+        accessor.Organization = await resolver.ResolveAsync(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderPermission.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderPermission.cs
@@ -5,7 +5,7 @@ namespace FaunaFinder.Server.Authorization;
 
 public sealed class FaunaFinderPermission(
     IAuthorization authorization,
-    FaunaFinderOrganization organization
+    FaunaFinderOrganizationAccessor accessor
 ) : IFaunaFinderPermission
 {
     public Task<bool> CanSubmitOccurrenceAsync(CancellationToken cancellationToken = default) =>
@@ -16,13 +16,14 @@ public sealed class FaunaFinderPermission(
 
     private Task<bool> HasAsync(string permission, CancellationToken cancellationToken)
     {
-        // Unresolved organization means the deployment has no contributor org configured;
-        // deny rather than ask, since there is no scope to ask about.
-        if (organization.Id is not { } organizationId)
+        // No configured organization means there is no scope to ask about, so deny rather
+        // than ask. The single check here is why the accessor holds one nullable reference
+        // instead of a nullable field per property.
+        if (accessor.Organization is not { } organization)
             return Task.FromResult(false);
 
         return authorization.HasPermissionAsync(
-            PermissionScope.Organization(organizationId),
+            PermissionScope.Organization(organization.Id),
             permission,
             cancellationToken
         );

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderPermission.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/FaunaFinderPermission.cs
@@ -1,0 +1,30 @@
+using EcoData.Common.Authorization;
+using EcoData.Wildlife.Contracts;
+
+namespace FaunaFinder.Server.Authorization;
+
+public sealed class FaunaFinderPermission(
+    IAuthorization authorization,
+    FaunaFinderOrganization organization
+) : IFaunaFinderPermission
+{
+    public Task<bool> CanSubmitOccurrenceAsync(CancellationToken cancellationToken = default) =>
+        HasAsync(WildlifePermissions.SubmitOccurrence, cancellationToken);
+
+    public Task<bool> CanVerifyOccurrenceAsync(CancellationToken cancellationToken = default) =>
+        HasAsync(WildlifePermissions.VerifyOccurrence, cancellationToken);
+
+    private Task<bool> HasAsync(string permission, CancellationToken cancellationToken)
+    {
+        // Unresolved organization means the deployment has no contributor org configured;
+        // deny rather than ask, since there is no scope to ask about.
+        if (organization.Id is not { } organizationId)
+            return Task.FromResult(false);
+
+        return authorization.HasPermissionAsync(
+            PermissionScope.Organization(organizationId),
+            permission,
+            cancellationToken
+        );
+    }
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/IFaunaFinderPermission.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Authorization/IFaunaFinderPermission.cs
@@ -1,0 +1,17 @@
+namespace FaunaFinder.Server.Authorization;
+
+/// <summary>
+/// What a signed-in user may do in FaunaFinder. One method per permission, so no caller
+/// types a permission key — or needs to know an organization is involved at all.
+/// </summary>
+/// <remarks>
+/// Contributor rights currently come from membership of the organization that runs
+/// FaunaFinder. If a second institution ever contributes, this interface is where that
+/// changes, and no call site moves.
+/// </remarks>
+public interface IFaunaFinderPermission
+{
+    Task<bool> CanSubmitOccurrenceAsync(CancellationToken cancellationToken = default);
+
+    Task<bool> CanVerifyOccurrenceAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/FaunaFinder.Server.csproj
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/FaunaFinder.Server.csproj
@@ -14,6 +14,14 @@
   <ItemGroup>
     <ProjectReference Include="..\FaunaFinder.Client\FaunaFinder.Client.csproj" />
     <ProjectReference Include="..\..\..\Host\EcoData.ServiceDefaults\EcoData.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\..\Features\Common\EcoData.Common.Authorization\EcoData.Common.Authorization.csproj" />
+    <ProjectReference Include="..\..\..\Features\Identity\EcoData.Identity.Api\EcoData.Identity.Api.csproj" />
+    <ProjectReference Include="..\..\..\Features\Identity\EcoData.Identity.Application\EcoData.Identity.Application.csproj" />
+    <ProjectReference Include="..\..\..\Features\Identity\EcoData.Identity.DataAccess\EcoData.Identity.DataAccess.csproj" />
+    <ProjectReference Include="..\..\..\Features\Identity\EcoData.Identity.Database\EcoData.Identity.Database.csproj" />
+    <ProjectReference Include="..\..\..\Features\Organization\EcoData.Organization.Authorization\EcoData.Organization.Authorization.csproj" />
+    <ProjectReference Include="..\..\..\Features\Organization\EcoData.Organization.DataAccess\EcoData.Organization.DataAccess.csproj" />
+    <ProjectReference Include="..\..\..\Features\Organization\EcoData.Organization.Database\EcoData.Organization.Database.csproj" />
     <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.Api\EcoData.Wildlife.Api.csproj" />
     <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.DataAccess\EcoData.Wildlife.DataAccess.csproj" />
     <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.Database\EcoData.Wildlife.Database.csproj" />

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
@@ -59,7 +59,7 @@ builder.Services.AddLoginRateLimiting();
 builder.Services.Configure<FaunaFinderOptions>(
     builder.Configuration.GetSection(FaunaFinderOptions.SectionName)
 );
-builder.Services.AddSingleton<FaunaFinderOrganization>();
+builder.Services.AddSingleton<FaunaFinderOrganizationAccessor>();
 builder.Services.AddHostedService<FaunaFinderOrganizationResolver>();
 builder.Services.AddScoped<IFaunaFinderPermission, FaunaFinderPermission>();
 

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
@@ -60,7 +60,8 @@ builder.Services.Configure<FaunaFinderOptions>(
     builder.Configuration.GetSection(FaunaFinderOptions.SectionName)
 );
 builder.Services.AddSingleton<FaunaFinderOrganizationAccessor>();
-builder.Services.AddHostedService<FaunaFinderOrganizationResolver>();
+builder.Services.AddScoped<FaunaFinderOrganizationResolver>();
+builder.Services.AddHostedService<FaunaFinderOrganizationStartupTask>();
 builder.Services.AddScoped<IFaunaFinderPermission, FaunaFinderPermission>();
 
 var app = builder.Build();

--- a/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
+++ b/src/Apps/FaunaFinder/FaunaFinder.Server/Program.cs
@@ -1,10 +1,21 @@
 // FaunaFinder Blazor host — Aspire-orchestrated container app.
+using EcoData.Common.Authorization;
+using EcoData.Identity.Api.Authentication;
+using EcoData.Identity.Api.Endpoints;
+using EcoData.Identity.Api.RateLimiting;
+using EcoData.Identity.Application.Extensions;
+using EcoData.Identity.DataAccess.Extensions;
+using EcoData.Identity.Database.Extensions;
 using EcoData.Locations.Api;
 using EcoData.Locations.DataAccess.Extensions;
 using EcoData.Locations.Database.Extensions;
+using EcoData.Organization.Authorization;
+using EcoData.Organization.DataAccess;
+using EcoData.Organization.Database.Extensions;
 using EcoData.Wildlife.Api;
 using EcoData.Wildlife.DataAccess;
 using EcoData.Wildlife.Database.Extensions;
+using FaunaFinder.Server.Authorization;
 using FaunaFinder.Server.Components;
 using FaunaFinder.Server.Mcp;
 using FaunaFinder.Server.RateLimiting;
@@ -14,16 +25,43 @@ using Tempest;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
+builder.AddIdentityDatabase();
 builder.AddLocationsDatabase();
+builder.AddOrganizationDatabase();
 builder.AddWildlifeDatabase();
 
 builder.Services.AddRazorComponents().AddInteractiveWebAssemblyComponents();
 builder.Services.AddMudServices();
 builder.Services.AddTempest();
+builder.Services.AddIdentityDataAccess();
+builder.Services.AddIdentityApplication(builder.Configuration);
 builder.Services.AddLocationsDataAccess();
+builder.Services.AddOrganizationDataAccess();
 builder.Services.AddWildlifeDataAccess(builder.Configuration);
 builder.Services.AddFaunaFinderMcp();
 builder.Services.AddFaunaFinderRateLimiting();
+
+// FaunaFinder issues its own cookie: auth_token is host-only and SameSite=Strict, so an
+// EcoPortal session never reaches this host. Same accounts, separate sign-in.
+builder
+    .Services.AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = UserJwtAuthentication.SchemeName;
+        options.DefaultChallengeScheme = UserJwtAuthentication.SchemeName;
+    })
+    .AddUserJwtAuthentication(builder.Configuration);
+
+builder.Services.AddAuthorization();
+builder.Services.AddPermissions();
+builder.Services.AddOrganizationPermissionSource();
+builder.Services.AddLoginRateLimiting();
+
+builder.Services.Configure<FaunaFinderOptions>(
+    builder.Configuration.GetSection(FaunaFinderOptions.SectionName)
+);
+builder.Services.AddSingleton<FaunaFinderOrganization>();
+builder.Services.AddHostedService<FaunaFinderOrganizationResolver>();
+builder.Services.AddScoped<IFaunaFinderPermission, FaunaFinderPermission>();
 
 var app = builder.Build();
 
@@ -42,6 +80,9 @@ else
     app.UseHsts();
 }
 
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseLoginRateLimiting();
 app.UseAntiforgery();
 app.UseRateLimiter();
 
@@ -50,6 +91,7 @@ app.MapRazorComponents<App>()
     .AddInteractiveWebAssemblyRenderMode()
     .AddAdditionalAssemblies(typeof(FaunaFinder.Client._Imports).Assembly);
 
+app.MapUserAuthEndpoints();
 app.MapStateEndpoints();
 app.MapMunicipalityEndpoints();
 app.MapWildlifeApiEndpoints();

--- a/src/Features/Common/EcoData.Common.Authorization/DependencyInjection.cs
+++ b/src/Features/Common/EcoData.Common.Authorization/DependencyInjection.cs
@@ -5,10 +5,12 @@ namespace EcoData.Common.Authorization;
 public static class DependencyInjection
 {
     /// <summary>
-    /// Registers the unified <see cref="IAuthorization"/> entry point. Add a source per
+    /// Registers the unified <see cref="IAuthorization"/> entry point. Named to avoid
+    /// colliding with ASP.NET Core's <c>AddAuthorization</c>, which hosts also need.
+    /// Add a source per
     /// scope kind the host uses with <see cref="AddPermissionSource{T}"/>.
     /// </summary>
-    public static IServiceCollection AddAuthorization(this IServiceCollection services)
+    public static IServiceCollection AddPermissions(this IServiceCollection services)
     {
         services.AddScoped<IAuthorization, Authorization>();
 

--- a/src/Features/Common/EcoData.Common.Authorization/README.md
+++ b/src/Features/Common/EcoData.Common.Authorization/README.md
@@ -236,12 +236,12 @@ Each host registers only the kinds it uses.
 
 ```csharp
 // EcoPortal.Server
-builder.Services.AddAuthorization();
+builder.Services.AddPermissions();
 builder.Services.AddPermissionSource<OrganizationPermissionSource>();
 builder.Services.AddPermissionSource<GlobalPermissionSource>();
 
 // EcoPortal.Client
-builder.Services.AddAuthorization();
+builder.Services.AddPermissions();
 builder.Services.AddPermissionSource<OrganizationPermissionSource>();   // the HTTP one
 ```
 
@@ -252,7 +252,7 @@ FaunaFinder additionally resolves its organization once, at startup:
 builder.Services.Configure<FaunaFinderOptions>(
     builder.Configuration.GetSection(FaunaFinderOptions.SectionName)
 );
-builder.Services.AddAuthorization();
+builder.Services.AddPermissions();
 builder.Services.AddPermissionSource<OrganizationPermissionSource>();
 
 var app = builder.Build();

--- a/src/Features/Organization/EcoData.Organization.Authorization/DependencyInjection.cs
+++ b/src/Features/Organization/EcoData.Organization.Authorization/DependencyInjection.cs
@@ -1,0 +1,21 @@
+using EcoData.Common.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EcoData.Organization.Authorization;
+
+public static class DependencyInjection
+{
+    /// <summary>
+    /// Registers the source answering organization-scoped permission and role questions.
+    /// Requires <c>AddOrganizationDataAccess</c> for the repositories it reads.
+    /// </summary>
+    public static IServiceCollection AddOrganizationPermissionSource(
+        this IServiceCollection services
+    )
+    {
+        services.AddHttpContextAccessor();
+        services.AddPermissionSource<OrganizationPermissionSource>();
+
+        return services;
+    }
+}

--- a/src/Features/Organization/EcoData.Organization.Authorization/EcoData.Organization.Authorization.csproj
+++ b/src/Features/Organization/EcoData.Organization.Authorization/EcoData.Organization.Authorization.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EcoData.Organization.Application.Server\EcoData.Organization.Application.Server.csproj" />
+    <ProjectReference Include="..\EcoData.Organization.DataAccess\EcoData.Organization.DataAccess.csproj" />
+    <ProjectReference Include="..\..\Common\EcoData.Common.Authorization\EcoData.Common.Authorization.csproj" />
+    <ProjectReference Include="..\..\Identity\EcoData.Identity.Contracts\EcoData.Identity.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Features/Organization/EcoData.Organization.Authorization/OrganizationPermissionSource.cs
+++ b/src/Features/Organization/EcoData.Organization.Authorization/OrganizationPermissionSource.cs
@@ -1,0 +1,80 @@
+using EcoData.Common.Authorization;
+using EcoData.Identity.Contracts.Claims;
+using EcoData.Organization.Application.Server.Services;
+using EcoData.Organization.DataAccess.Interfaces;
+using Microsoft.AspNetCore.Http;
+
+namespace EcoData.Organization.Authorization;
+
+/// <summary>
+/// Answers <see cref="PermissionScope.OrganizationKind"/> questions from the caller's
+/// membership. Registered by any host that asks organization-scoped questions.
+/// </summary>
+/// <remarks>
+/// Organization owns roles and their permissions, so this is the only place that reads
+/// them. Feature modules ask <see cref="IAuthorization"/> and never see this type.
+/// </remarks>
+public sealed class OrganizationPermissionSource(
+    IHttpContextAccessor httpContextAccessor,
+    IOrganizationPermissionService permissions,
+    IOrganizationMembershipRepository memberships
+) : IPermissionSource
+{
+    public string ScopeKind => PermissionScope.OrganizationKind;
+
+    public async Task<bool> HasPermissionAsync(
+        PermissionScope scope,
+        string permission,
+        CancellationToken cancellationToken = default
+    )
+    {
+        // GlobalAdmin short-circuits inside the permission service, so a global admin is
+        // allowed here without the global source being registered.
+        if (!TryResolve(scope, out var userId, out var organizationId))
+            return false;
+
+        return await permissions.HasPermissionAsync(
+            userId,
+            organizationId,
+            permission,
+            cancellationToken
+        );
+    }
+
+    public async Task<bool> IsInRoleAsync(
+        PermissionScope scope,
+        string role,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (!TryResolve(scope, out var userId, out var organizationId))
+            return false;
+
+        var membership = await memberships.GetAsync(userId, organizationId, cancellationToken);
+
+        return membership is not null
+            && string.Equals(membership.RoleName, role, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool TryResolve(PermissionScope scope, out Guid userId, out Guid organizationId)
+    {
+        userId = default;
+
+        if (!Guid.TryParse(scope.Id, out organizationId))
+            return false;
+
+        var user = httpContextAccessor.HttpContext?.User;
+
+        if (user is null)
+            return false;
+
+        var token = new RequestClaimToken(user);
+
+        if (!token.IsAuthenticated)
+            return false;
+
+        userId = token.UserId.Value;
+
+        return true;
+    }
+}

--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/Permissions.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/Permissions.cs
@@ -1,0 +1,12 @@
+namespace EcoData.Wildlife.Contracts;
+
+/// <summary>
+/// Permissions the Wildlife module defines. Namespaced by feature, never by app — which
+/// application grants them is a deployment decision, the permission is a domain fact.
+/// </summary>
+public static class WildlifePermissions
+{
+    public const string ReadSpecies = "wildlife:species:read";
+    public const string SubmitOccurrence = "wildlife:occurrence:submit";
+    public const string VerifyOccurrence = "wildlife:occurrence:verify";
+}

--- a/src/Host/EcoData.AppHost/AppHost.cs
+++ b/src/Host/EcoData.AppHost/AppHost.cs
@@ -124,8 +124,21 @@ var ecoportal = builder
 var faunafinder = builder
     .AddProject<Projects.FaunaFinder_Server>("faunafinder")
     .WithExternalHttpEndpoints()
+    .WithReference(identityDb)
     .WithReference(locationsDb)
+    .WithReference(organizationDb)
     .WithReference(wildlifeDb)
+    // FaunaFinder signs users in itself. auth_token is host-only and SameSite=Strict, so an
+    // EcoPortal session cannot reach this host — same accounts, separate cookie. It shares
+    // the user signing key so a token minted here validates here.
+    .WithEnvironment("Jwt__UserSecretKey", jwtUserSecretKey)
+    .WithEnvironment("Jwt__SensorSecretKey", jwtSensorSecretKey)
+    .WithEnvironment("Jwt__Issuer", "EcoData")
+    .WithEnvironment("Jwt__Audience", "EcoData")
+    .WithEnvironment("Jwt__ExpirationHours", "24")
+    // Contributors are members of the organization that runs FaunaFinder. A slug, not an
+    // id: organizations are created at runtime, so the guid differs per environment.
+    .WithEnvironment("FaunaFinder__OrganizationSlug", "intermetro")
     .WaitFor(seeder)
     .PublishAsAzureContainerApp(
         (infra, app) =>


### PR DESCRIPTION
FaunaFinder had **no authentication at all** — no Identity references, no `AddAuthentication`, and AppHost gave it neither `identityDb` nor the JWT secrets. Authorization there was inert, so this PR adds both halves.

## Sign-in

FaunaFinder issues its own cookie against the shared identity database. `auth_token` is host-only with `SameSite=Strict`, EcoPortal runs on its own custom domain, and FaunaFinder has none — so an EcoPortal session cannot reach this host regardless. Same accounts, separate sign-in.

Shared-domain SSO stays available later: it needs a subdomain plus `Domain=.ecodatapr.com` and `SameSite=Lax`, which would change EcoPortal's cookie too. Deliberately not in this PR.

## Authorization

Adds `EcoData.Organization.Authorization` — the `organization` scope source for `Common.Authorization`. It reads membership, role, and role permissions, which Organization owns, so no feature module touches that storage. EcoPortal can register the same source when it moves onto `IAuthorization`.

Contributor rights come from **membership of the organization that runs FaunaFinder**, not a separate per-app permission store. One mechanism rather than two, and it reuses roles, grants, and `my-permissions` as they already exist.

```csharp
// no organization argument — call sites do not know one is involved
await permission.CanSubmitOccurrenceAsync(ct);
```

The organization is configured as a **slug**, not an id:

```csharp
.WithEnvironment("FaunaFinder__OrganizationSlug", "intermetro")
```

Organizations are created at runtime — there is no seeded row — so the guid differs per environment and cannot be committed. `organizations.slug` carries a unique index, and it resolves once at startup into a singleton.

## Failure behaviour

A slug matching no organization **logs a warning and denies contributor permissions** rather than failing startup. FaunaFinder is a public catalogue first; a misconfigured contributor org must not take the anonymous read path down with it.

## Also

Renames `AddAuthorization` to `AddPermissions` in `Common.Authorization`. The old name was ambiguous with ASP.NET Core's `AddAuthorization`, which hosts also need to call — FaunaFinder hit `CS0121` on the first build.

## Known limits

- **Nothing is gated yet.** FaunaFinder's endpoints stay anonymous; this adds the machinery, not the enforcement. Occurrence submission does not exist to gate.
- **`organization_role_permissions` is still never written to** anywhere in the codebase, so every check returns false for non-GlobalAdmins until a grant path exists. That is the blocker for making any of this observable.
- **No `intermetro` organization exists** in any environment yet, so the resolver logs its warning on boot today.
- Conflates *runs FaunaFinder* with *may contribute to it*. Fine while one institution runs the program; the slug indirection is the cheap exit when that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)