### PR TITLE
feat(organization): manage roles and their permissions; role-aware access requests

### DIFF
--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/AccessDenied.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/AccessDenied.razor
@@ -1,6 +1,4 @@
-@using System.Text.RegularExpressions
 @using EcoPortal.Client.Services
-@inject NavigationManager Navigation
 @inject AuthStateService AuthState
 
 <PageTitle>No Access - EcoData</PageTitle>
@@ -29,16 +27,16 @@
         </MudStack>
 
         <MudStack Row="true" Spacing="2" Class="mt-4 flex-wrap justify-center">
-            @if (OrganizationPath is { } organizationPath)
+            @if (OrganizationId is { } organizationId)
             {
                 <MudButton Variant="Variant.Filled"
                            Color="Color.Primary"
                            StartIcon="@Icons.Material.Filled.Business"
-                           Href="@organizationPath">
+                           Href="@($"/organizations/{organizationId}")">
                     Back to organization
                 </MudButton>
             }
-            <MudButton Variant="@(OrganizationPath is null ? Variant.Filled : Variant.Outlined)"
+            <MudButton Variant="@(OrganizationId is null ? Variant.Filled : Variant.Outlined)"
                        Color="Color.Primary"
                        StartIcon="@Icons.Material.Filled.Home"
                        Href="/">
@@ -49,17 +47,7 @@
 </MudContainer>
 
 @code {
-    private const string OrganizationRoutePattern =
-        @"/organizations/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})";
-
-    // The denied page is usually one level inside an organization; offer the way back to it.
-    private string? OrganizationPath
-    {
-        get
-        {
-            var match = Regex.Match(Navigation.Uri, OrganizationRoutePattern, RegexOptions.IgnoreCase);
-
-            return match.Success ? $"/organizations/{match.Groups[1].Value}" : null;
-        }
-    }
+    // The organization the denied page belongs to, when its route has one.
+    [Parameter]
+    public Guid? OrganizationId { get; set; }
 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Components/AccessDenied.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Components/AccessDenied.razor
@@ -1,0 +1,65 @@
+@using System.Text.RegularExpressions
+@using EcoPortal.Client.Services
+@inject NavigationManager Navigation
+@inject AuthStateService AuthState
+
+<PageTitle>No Access - EcoData</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="d-flex align-center justify-center pa-8 mt-16">
+    <MudStack AlignItems="AlignItems.Center" Spacing="4">
+        <MudAvatar Color="Color.Warning" Size="Size.Large">
+            <MudIcon Icon="@Icons.Material.Filled.Lock" />
+        </MudAvatar>
+
+        <MudStack Spacing="1" AlignItems="AlignItems.Center">
+            <MudText Typo="Typo.h5" Align="Align.Center">You don't have access to this page</MudText>
+            <MudText Typo="Typo.body1" Color="Color.Secondary" Align="Align.Center">
+                @if (AuthState.CurrentUser is { } user)
+                {
+                    <text>You're signed in as <strong>@user.Email</strong>, but your role in this organization doesn't include the permission this page needs.</text>
+                }
+                else
+                {
+                    <text>Your role in this organization doesn't include the permission this page needs.</text>
+                }
+            </MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center">
+                Ask an administrator of the organization to grant it to your role.
+            </MudText>
+        </MudStack>
+
+        <MudStack Row="true" Spacing="2" Class="mt-4 flex-wrap justify-center">
+            @if (OrganizationPath is { } organizationPath)
+            {
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Business"
+                           Href="@organizationPath">
+                    Back to organization
+                </MudButton>
+            }
+            <MudButton Variant="@(OrganizationPath is null ? Variant.Filled : Variant.Outlined)"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Home"
+                       Href="/">
+                Go to Dashboard
+            </MudButton>
+        </MudStack>
+    </MudStack>
+</MudContainer>
+
+@code {
+    private const string OrganizationRoutePattern =
+        @"/organizations/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})";
+
+    // The denied page is usually one level inside an organization; offer the way back to it.
+    private string? OrganizationPath
+    {
+        get
+        {
+            var match = Regex.Match(Navigation.Uri, OrganizationRoutePattern, RegexOptions.IgnoreCase);
+
+            return match.Success ? $"/organizations/{match.Groups[1].Value}" : null;
+        }
+    }
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/EcoPortal.Client.csproj
+++ b/src/Apps/EcoPortal/EcoPortal.Client/EcoPortal.Client.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\..\Features\Organization\EcoData.Organization.Contracts\EcoData.Organization.Contracts.csproj" />
     <ProjectReference Include="..\..\..\Features\Sensors\EcoData.Sensors.Application.Client\EcoData.Sensors.Application.Client.csproj" />
     <ProjectReference Include="..\..\..\Features\Sensors\EcoData.Sensors.Contracts\EcoData.Sensors.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\Features\Wildlife\EcoData.Wildlife.Contracts\EcoData.Wildlife.Contracts.csproj" />
     <ProjectReference Include="..\..\..\Features\Identity\EcoData.Identity.Application.Client\EcoData.Identity.Application.Client.csproj" />
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Contracts\EcoData.Locations.Contracts.csproj" />
     <ProjectReference Include="..\..\..\Features\Locations\EcoData.Locations.Application.Client\EcoData.Locations.Application.Client.csproj" />

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Dialogs/RequestAccessDialog.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Dialogs/RequestAccessDialog.razor
@@ -1,9 +1,11 @@
+@using EcoData.Organization.Contracts
 @using EcoData.Organization.Contracts.Dtos
 @using EcoData.Organization.Contracts.Requests
 @using EcoData.Organization.Application.Client
 @using EcoPortal.Client.Features.Organizations.Components
 @inherits StatefulComponent
 @inject IOrganizationAccessRequestHttpClient AccessRequestClient
+@inject IOrganizationRoleHttpClient RoleClient
 @inject ISnackbar Snackbar
 
 <MudDialog>
@@ -24,11 +26,25 @@
                     <MudText Typo="Typo.body2" Color="Color.Secondary">
                         Select an organization to request access. An administrator will review your request.
                     </MudText>
-                    <OrganizationSelect @bind-Value="_selectedOrganization"
+                    <OrganizationSelect Value="_selectedOrganization"
+                                        ValueChanged="OnOrganizationChanged"
                                         Label="Organization"
                                         Required="true"
                                         RequiredError="Please select an organization" />
                 }
+                <MudSelect T="string"
+                           @bind-Value="_selectedRoleName"
+                           Label="Role"
+                           Variant="Variant.Outlined"
+                           Required="true"
+                           RequiredError="Please select a role"
+                           Disabled="@(_roles is null || _roles.Count == 0)"
+                           HelperText="@RoleHelperText">
+                    @foreach (var role in _roles ?? [])
+                    {
+                        <MudSelectItem T="string" Value="@role.Name">@role.Name</MudSelectItem>
+                    }
+                </MudSelect>
                 <MudTextField @bind-Value="_requestMessage"
                               Label="Message (Optional)"
                               Placeholder="Why would you like to join this organization?"
@@ -43,7 +59,7 @@
         <MudButton Color="Color.Primary"
                    Variant="Variant.Filled"
                    OnClick="@(() => SubmitState.Execute())"
-                   Disabled="@(!_isValid || SubmitState.IsLoading)">
+                   Disabled="@(!CanSubmit || SubmitState.IsLoading)">
             @if (SubmitState.IsLoading)
             {
                 <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
@@ -63,18 +79,57 @@
     private MudForm _form = null!;
     private bool _isValid;
     private OrganizationDtoForList? _selectedOrganization;
+    private IReadOnlyList<OrganizationRoleDto>? _roles;
+    private string? _selectedRoleName;
     private string? _requestMessage;
 
     private bool IsOrganizationPreselected => PreselectedOrganization is not null;
 
-    protected override void OnInitialized()
+    private bool CanSubmit =>
+        _selectedOrganization is not null && _selectedRoleName is not null && (IsOrganizationPreselected || _isValid);
+
+    private string RoleHelperText =>
+        _selectedOrganization is null ? "Select an organization first"
+        : _roles is null ? "Loading roles…"
+        : _roles.Count == 0 ? "This organization has no roles to request"
+        : "The role you are asking for. Administrators can change it when reviewing.";
+
+    protected override async Task OnInitializedAsync()
     {
-        base.OnInitialized();
         if (PreselectedOrganization is not null)
         {
-            _selectedOrganization = PreselectedOrganization;
-            _isValid = true; // No required fields when org is preselected
+            await OnOrganizationChanged(PreselectedOrganization);
         }
+    }
+
+    private async Task OnOrganizationChanged(OrganizationDtoForList? organization)
+    {
+        _selectedOrganization = organization;
+        _roles = null;
+        _selectedRoleName = null;
+
+        if (organization is null)
+        {
+            return;
+        }
+
+        var result = await RoleClient.GetAllAsync(organization.Id);
+
+        result.Switch(
+            roles =>
+            {
+                _roles = roles;
+                // Viewer was the role every approval used to grant, so it stays the default.
+                _selectedRoleName =
+                    roles.FirstOrDefault(r => r.Name == DefaultOrganizationRoles.Viewer)?.Name
+                    ?? roles.FirstOrDefault()?.Name;
+            },
+            error =>
+            {
+                _roles = [];
+                Snackbar.Add(error.Message ?? "Failed to load roles", Severity.Error);
+            }
+        );
     }
 
     private void Cancel() => MudDialog.Cancel();
@@ -82,17 +137,24 @@
     [Command]
     private async Task Submit()
     {
-        await _form.ValidateAsync();
-        if (!_isValid || _selectedOrganization == null)
+        await _form.Validate();
+        if (!CanSubmit || _selectedOrganization is null || _selectedRoleName is null)
             return;
 
-        var request = new CreateOrganizationAccessRequestRequest(_selectedOrganization.Id, _requestMessage);
+        var request = new CreateOrganizationAccessRequestRequest(
+            _selectedOrganization.Id,
+            _selectedRoleName,
+            _requestMessage
+        );
         var result = await AccessRequestClient.CreateAsync(_selectedOrganization.Id, request);
 
         result.Switch(
             _ =>
             {
-                Snackbar.Add($"Access request submitted for {_selectedOrganization.Name}", Severity.Success);
+                Snackbar.Add(
+                    $"Access request submitted for {_selectedOrganization.Name} as {_selectedRoleName}",
+                    Severity.Success
+                );
                 MudDialog.Close(DialogResult.Ok(true));
             },
             error => Snackbar.Add(error.Message ?? "Failed to submit request", Severity.Error)

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/MyAccessRequestsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/MyAccessRequestsPage.razor
@@ -62,7 +62,7 @@
                             <MudStack Spacing="0">
                                 <MudText Typo="Typo.subtitle1">@request.OrganizationName</MudText>
                                 <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                    Requested @FormatDate(request.CreatedAt)
+                                    Requested @FormatDate(request.CreatedAt)@(request.RoleName is null ? "" : $" as {request.RoleName}")
                                 </MudText>
                                 @if (!string.IsNullOrWhiteSpace(request.RequestMessage))
                                 {

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/OrganizationAccessRequestsPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationAccessRequests/Pages/OrganizationAccessRequestsPage.razor
@@ -90,7 +90,7 @@
                                         @request.UserEmail
                                     </MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        Requested @FormatDate(request.CreatedAt)
+                                        Requested @FormatDate(request.CreatedAt) as <strong>@(request.RoleName ?? DefaultOrganizationRoles.Viewer)</strong>
                                     </MudText>
                                     @if (!string.IsNullOrWhiteSpace(request.RequestMessage))
                                     {
@@ -188,7 +188,7 @@
     {
         var parameters = new DialogParameters<ConfirmDialog>
         {
-            { x => x.ContentText, $"Approve access request from {request.UserDisplayName}? They will be added as a {DefaultOrganizationRoles.Viewer}." },
+            { x => x.ContentText, $"Approve access request from {request.UserDisplayName}? They will be added as {request.RoleName ?? DefaultOrganizationRoles.Viewer}." },
             { x => x.ButtonText, "Approve" },
             { x => x.Color, Color.Success }
         };

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Dialogs/ChangeRoleDialog.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Dialogs/ChangeRoleDialog.razor
@@ -1,5 +1,8 @@
 @using EcoData.Organization.Contracts
 @using EcoData.Organization.Contracts.Dtos
+@using EcoData.Organization.Application.Client
+@inject IOrganizationRoleHttpClient RoleClient
+@inject ISnackbar Snackbar
 
 <MudDialog>
     <TitleContent>
@@ -16,10 +19,13 @@
             <MudSelect T="string"
                        @bind-Value="_role"
                        Label="Role"
-                       Variant="Variant.Outlined">
-                <MudSelectItem Value="@DefaultOrganizationRoles.Viewer">Viewer</MudSelectItem>
-                <MudSelectItem Value="@DefaultOrganizationRoles.Contributor">Contributor</MudSelectItem>
-                <MudSelectItem Value="@DefaultOrganizationRoles.Admin">Admin</MudSelectItem>
+                       Variant="Variant.Outlined"
+                       Disabled="@(_roles is null)"
+                       HelperText="@(_roles is null ? "Loading roles…" : null)">
+                @foreach (var role in _roles ?? [])
+                {
+                    <MudSelectItem T="string" Value="@role.Name">@role.Name</MudSelectItem>
+                }
             </MudSelect>
         </MudStack>
     </DialogContent>
@@ -28,7 +34,7 @@
         <MudButton Color="Color.Primary"
                    Variant="Variant.Filled"
                    OnClick="Submit"
-                   Disabled="@(_role == CurrentRole)">
+                   Disabled="@(_roles is null || _role == CurrentRole)">
             Update Role
         </MudButton>
     </DialogActions>
@@ -39,16 +45,31 @@
     private IMudDialogInstance MudDialog { get; set; } = null!;
 
     [Parameter]
+    public Guid OrganizationId { get; set; }
+
+    [Parameter]
     public string MemberName { get; set; } = string.Empty;
 
     [Parameter]
     public string CurrentRole { get; set; } = DefaultOrganizationRoles.Viewer;
 
+    private IReadOnlyList<OrganizationRoleDto>? _roles;
     private string _role = DefaultOrganizationRoles.Viewer;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         _role = CurrentRole;
+
+        var result = await RoleClient.GetAllAsync(OrganizationId);
+
+        result.Switch(
+            roles => _roles = roles,
+            error =>
+            {
+                _roles = [];
+                Snackbar.Add(error.Message ?? "Failed to load roles", Severity.Error);
+            }
+        );
     }
 
     private void Submit()

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Dialogs/RoleEditorDialog.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Dialogs/RoleEditorDialog.razor
@@ -1,0 +1,109 @@
+@using EcoData.Organization.Contracts.Dtos
+@using EcoData.Organization.Contracts.Requests
+
+<MudDialog>
+    <TitleContent>
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+            <MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings" />
+            <MudText Typo="Typo.h6">@(Role is null ? "New Role" : "Edit Role")</MudText>
+        </MudStack>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="_form" @bind-IsValid="_isValid">
+            <MudStack Spacing="4" Class="pt-2">
+                <MudTextField @bind-Value="_name"
+                              Label="Name"
+                              Variant="Variant.Outlined"
+                              Required="true"
+                              RequiredError="Please name the role"
+                              MaxLength="100"
+                              Immediate="true" />
+
+                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    Members with this role can:
+                </MudText>
+
+                @foreach (var group in PermissionCatalog.Groups)
+                {
+                    <MudStack Spacing="1">
+                        <MudText Typo="Typo.subtitle2">@group.Title</MudText>
+                        @foreach (var option in group.Options)
+                        {
+                            <MudStack Spacing="0">
+                                <MudCheckBox T="bool"
+                                             Value="@_selected.Contains(option.Key)"
+                                             ValueChanged="@(on => Toggle(option.Key, on))"
+                                             Label="@option.Label"
+                                             Dense="true" />
+                                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="ml-10">
+                                    @option.Description
+                                </MudText>
+                            </MudStack>
+                        }
+                    </MudStack>
+                }
+            </MudStack>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary"
+                   Variant="Variant.Filled"
+                   OnClick="Submit"
+                   Disabled="@(!_isValid || string.IsNullOrWhiteSpace(_name))">
+            @(Role is null ? "Create Role" : "Save Changes")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    // Null creates a role; a value edits it.
+    [Parameter]
+    public OrganizationRoleDto? Role { get; set; }
+
+    private MudForm _form = null!;
+    private bool _isValid;
+    private string _name = string.Empty;
+    private readonly HashSet<string> _selected = new(StringComparer.Ordinal);
+
+    protected override void OnInitialized()
+    {
+        if (Role is null)
+        {
+            return;
+        }
+
+        _name = Role.Name;
+        _selected.UnionWith(Role.Permissions);
+        _isValid = true;
+    }
+
+    private void Toggle(string key, bool on)
+    {
+        if (on)
+        {
+            _selected.Add(key);
+        }
+        else
+        {
+            _selected.Remove(key);
+        }
+    }
+
+    private async Task Submit()
+    {
+        await _form.Validate();
+        if (!_isValid)
+        {
+            return;
+        }
+
+        var request = new OrganizationRoleRequest(_name.Trim(), _selected.Order().ToList());
+        MudDialog.Close(DialogResult.Ok(request));
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Pages/OrganizationRolesPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Pages/OrganizationRolesPage.razor
@@ -1,0 +1,187 @@
+@page "/organizations/{OrganizationId:guid}/roles"
+@using EcoData.Organization.Contracts
+@using EcoData.Common.Problems.Contracts
+@using EcoPortal.Client.Authorization
+@attribute [OrganizationPermission(Permissions.Organization.ManageMembers)]
+@using EcoData.Organization.Contracts.Dtos
+@using EcoData.Organization.Contracts.Requests
+@using EcoData.Organization.Application.Client
+@using EcoPortal.Client.Components
+@using EcoPortal.Client.Features.OrganizationMembers.Dialogs
+@inherits StatefulComponent
+@inject IOrganizationRoleHttpClient RoleClient
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<PageTitle>Roles - EcoData</PageTitle>
+
+<NuiPageLayout Title="Roles" ParentPath="@($"/organizations/{OrganizationId}/team")"
+               Actions="@([new("New role", OnNewRole)])">
+    @if (LoadRolesState.IsLoading || !LoadRolesState.HasResult)
+    {
+        <MudPaper Elevation="0" Class="rounded-lg">
+            @for (var i = 0; i < 4; i++)
+            {
+                <MudPaper Elevation="0" Class="pa-4 border-b">
+                    <MudStack Spacing="2">
+                        <MudSkeleton Width="140px" Height="20px" />
+                        <MudSkeleton Width="60%" Height="14px" />
+                    </MudStack>
+                </MudPaper>
+            }
+        </MudPaper>
+    }
+    else if (_loadError is not null)
+    {
+        <MudPaper Elevation="0" Class="pa-8 rounded-lg">
+            <MudStack AlignItems="AlignItems.Center">
+                <MudIcon Icon="@Icons.Material.Filled.Error" Size="Size.Large" Color="Color.Error" />
+                <MudText Typo="Typo.h6" Color="Color.Error" Class="mt-2">@_loadError</MudText>
+                <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="@(() => LoadRolesState.Execute())" Class="mt-3">
+                    Try again
+                </MudButton>
+            </MudStack>
+        </MudPaper>
+    }
+    else if (LoadRolesState.Result.Count == 0)
+    {
+        <MudPaper Elevation="0" Class="pa-8 rounded-lg">
+            <MudStack AlignItems="AlignItems.Center">
+                <MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings" Size="Size.Large" Color="Color.Secondary" />
+                <MudText Typo="Typo.h6" Color="Color.Secondary" Class="mt-2">No roles yet</MudText>
+                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    Roles decide what members of this organization can do.
+                </MudText>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
+                           OnClick="OnNewRole" Class="mt-3">
+                    New role
+                </MudButton>
+            </MudStack>
+        </MudPaper>
+    }
+    else
+    {
+        <MudPaper Elevation="0" Class="rounded-lg">
+            @foreach (var role in LoadRolesState.Result)
+            {
+                <MudPaper Elevation="0" Class="pa-4 border-b">
+                    <MudStack Row AlignItems="AlignItems.Start" Justify="Justify.SpaceBetween" Class="flex-wrap gap-3">
+                        <MudStack Spacing="1">
+                            <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+                                <MudText Typo="Typo.subtitle1">@role.Name</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    @(role.MemberCount == 1 ? "1 member" : $"{role.MemberCount} members")
+                                </MudText>
+                            </MudStack>
+                            @if (role.Permissions.Count == 0)
+                            {
+                                <MudText Typo="Typo.body2" Color="Color.Secondary">No permissions</MudText>
+                            }
+                            else
+                            {
+                                <MudChipSet T="string" ReadOnly="true" Class="flex-wrap">
+                                    @foreach (var permission in role.Permissions)
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
+                                            @PermissionCatalog.Label(permission)
+                                        </MudChip>
+                                    }
+                                </MudChipSet>
+                            }
+                        </MudStack>
+                        <MudStack Row Spacing="1">
+                            <MudTooltip Text="Edit role">
+                                <MudIconButton Icon="@Icons.Material.Outlined.Edit" Size="Size.Small"
+                                               OnClick="@(() => OpenEditor(role))" />
+                            </MudTooltip>
+                            <MudTooltip Text="@(role.MemberCount > 0 ? "Move its members to another role first" : "Delete role")">
+                                <MudIconButton Icon="@Icons.Material.Outlined.Delete" Size="Size.Small" Color="Color.Error"
+                                               Disabled="@(role.MemberCount > 0)"
+                                               OnClick="@(() => ConfirmDelete(role))" />
+                            </MudTooltip>
+                        </MudStack>
+                    </MudStack>
+                </MudPaper>
+            }
+        </MudPaper>
+    }
+</NuiPageLayout>
+
+@code {
+    [Parameter]
+    public Guid OrganizationId { get; set; }
+
+    private string? _loadError;
+
+    [Command, RunOnLoad]
+    private async Task<IReadOnlyList<OrganizationRoleDto>> LoadRoles(CancellationToken ct)
+    {
+        _loadError = null;
+
+        var result = await RoleClient.GetAllAsync(OrganizationId, ct);
+        if (!result.TryPickT0(out var roles, out var failure))
+        {
+            _loadError = failure.Message ?? "Couldn't load roles.";
+            return [];
+        }
+
+        return roles;
+    }
+
+    private void OnNewRole() => _ = OpenEditor(null);
+
+    private async Task OpenEditor(OrganizationRoleDto? role)
+    {
+        var parameters = new DialogParameters<RoleEditorDialog> { { x => x.Role, role } };
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<RoleEditorDialog>(role is null ? "New Role" : "Edit Role", parameters, options);
+        var result = await dialog.Result;
+
+        if (result is not { Canceled: false, Data: OrganizationRoleRequest request })
+        {
+            return;
+        }
+
+        var saved = role is null
+            ? await RoleClient.CreateAsync(OrganizationId, request)
+            : await RoleClient.UpdateAsync(OrganizationId, role.Id, request);
+
+        if (!saved.TryPickT0(out var savedRole, out var failure))
+        {
+            Snackbar.Add(failure.Message ?? "Failed to save role", Severity.Error);
+            return;
+        }
+
+        Snackbar.Add(role is null ? $"Role {savedRole.Name} created" : $"Role {savedRole.Name} updated", Severity.Success);
+        await LoadRolesState.Execute();
+    }
+
+    private async Task ConfirmDelete(OrganizationRoleDto role)
+    {
+        var parameters = new DialogParameters<ConfirmDialog>
+        {
+            { x => x.ContentText, $"Delete the role \"{role.Name}\"? Pending access requests asking for it will be refused." },
+            { x => x.ButtonText, "Delete" },
+            { x => x.Color, Color.Error }
+        };
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.ExtraSmall };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>("Delete Role", parameters, options);
+        var result = await dialog.Result;
+
+        if (result is not { Canceled: false })
+        {
+            return;
+        }
+
+        var deleted = await RoleClient.DeleteAsync(OrganizationId, role.Id);
+
+        if (!deleted.TryPickT0(out _, out var failure))
+        {
+            Snackbar.Add(failure.Message ?? "Failed to delete role", Severity.Error);
+            return;
+        }
+
+        Snackbar.Add($"Role {role.Name} deleted", Severity.Success);
+        await LoadRolesState.Execute();
+    }
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Pages/OrganizationTeamPage.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/Pages/OrganizationTeamPage.razor
@@ -21,7 +21,7 @@
 <PageTitle>Team - EcoData</PageTitle>
 
 <NuiPageLayout Title="Teams" ParentPath="@($"/organizations/{OrganizationId}")"
-                 Actions="@([new("Requests", NavigateToRequests)])">
+                 Actions="@([new("Requests", NavigateToRequests), new("Roles", NavigateToRoles)])">
         <SearchHeader @bind-Value="SearchTextState.Value" Placeholder="Search members..." EnableSticky="true" />
 
         @if (LoadOrganizationState.IsLoading)
@@ -170,6 +170,8 @@ cancellationToken)
         SearchTextState.Value = null;
     }
 
+    private void NavigateToRoles() => Navigation.NavigateTo($"/organizations/{OrganizationId}/roles");
+
     private void NavigateToRequests()
     {
         Navigation.NavigateTo($"/organizations/{OrganizationId}/requests");
@@ -180,6 +182,7 @@ cancellationToken)
         var parameters = new DialogParameters<ChangeRoleDialog>
         {
             { x => x.MemberName, member.DisplayName },
+            { x => x.OrganizationId, OrganizationId },
             { x => x.CurrentRole, member.RoleName }
         };
         var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };

--- a/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/PermissionCatalog.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Features/OrganizationMembers/PermissionCatalog.cs
@@ -1,0 +1,78 @@
+using OrganizationPermissions = EcoData.Organization.Contracts.Permissions;
+using SensorPermissions = EcoData.Sensors.Contracts.Permissions;
+using WildlifePermissions = EcoData.Wildlife.Contracts.Permissions;
+
+namespace EcoPortal.Client.Features.OrganizationMembers;
+
+public sealed record PermissionOption(string Key, string Label, string Description);
+
+public sealed record PermissionGroup(string Title, IReadOnlyList<PermissionOption> Options);
+
+// The app is the one place that sees every module, so it is where the keys each module
+// declares are gathered into something a person can pick from.
+public static class PermissionCatalog
+{
+    public static readonly IReadOnlyList<PermissionGroup> Groups =
+    [
+        new(
+            "Organization",
+            [
+                new(
+                    OrganizationPermissions.Organization.Update,
+                    "Edit organization",
+                    "Change the profile, branding and contact details."
+                ),
+                new(
+                    OrganizationPermissions.Organization.ManageMembers,
+                    "Manage members and roles",
+                    "Review access requests, change member roles, edit roles."
+                ),
+                new(
+                    OrganizationPermissions.Organization.Delete,
+                    "Delete organization",
+                    "Remove the organization and everything it owns."
+                ),
+            ]
+        ),
+        new(
+            "Sensors",
+            [
+                new(SensorPermissions.Sensor.Read, "View sensors", "See sensors and their readings."),
+                new(SensorPermissions.Sensor.Create, "Register sensors", "Add new sensors."),
+                new(
+                    SensorPermissions.Sensor.Update,
+                    "Configure sensors",
+                    "Edit sensor details and health settings."
+                ),
+                new(SensorPermissions.Sensor.Delete, "Delete sensors", "Remove sensors."),
+            ]
+        ),
+        new(
+            "Wildlife",
+            [
+                new(
+                    WildlifePermissions.Species.Read,
+                    "View species",
+                    "Browse the species catalogue."
+                ),
+                new(
+                    WildlifePermissions.Occurrence.Submit,
+                    "Submit sightings",
+                    "Record species occurrences."
+                ),
+                new(
+                    WildlifePermissions.Occurrence.Verify,
+                    "Verify sightings",
+                    "Confirm or reject submitted occurrences."
+                ),
+            ]
+        ),
+    ];
+
+    private static readonly Dictionary<string, PermissionOption> ByKey = Groups
+        .SelectMany(g => g.Options)
+        .ToDictionary(o => o.Key, StringComparer.Ordinal);
+
+    // Keys the catalogue does not know (older data, another module) still show as themselves.
+    public static string Label(string key) => ByKey.TryGetValue(key, out var option) ? option.Label : key;
+}

--- a/src/Apps/EcoPortal/EcoPortal.Client/Routes.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Routes.razor
@@ -1,3 +1,4 @@
+@using EcoPortal.Client.Components
 @using EcoPortal.Client.Layout
 @using Microsoft.AspNetCore.Components.Authorization
 @inject NavigationManager Navigation
@@ -6,7 +7,14 @@
     <Found Context="routeData">
         <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)">
             <NotAuthorized>
-                @{
+                @* Only a missing sign-in is fixed by logging in. A signed-in user who lacks a
+                   permission is told so in place, on the URL they asked for. *@
+                @if (context.User.Identity?.IsAuthenticated == true)
+                {
+                    <AccessDenied />
+                }
+                else
+                {
                     var returnUrl = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
                     Navigation.NavigateTo($"/login?returnUrl={returnUrl}", forceLoad: false);
                 }

--- a/src/Apps/EcoPortal/EcoPortal.Client/Routes.razor
+++ b/src/Apps/EcoPortal/EcoPortal.Client/Routes.razor
@@ -11,7 +11,7 @@
                    permission is told so in place, on the URL they asked for. *@
                 @if (context.User.Identity?.IsAuthenticated == true)
                 {
-                    <AccessDenied />
+                    <AccessDenied OrganizationId="OrganizationIdOf(routeData)" />
                 }
                 else
                 {
@@ -26,3 +26,14 @@
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
 </Router>
+
+@code {
+    // Organization pages declare {OrganizationId:guid}; the router has already parsed it.
+    private static Guid? OrganizationIdOf(RouteData routeData) =>
+        routeData.RouteValues.TryGetValue("OrganizationId", out var value) switch
+        {
+            true when value is Guid id => id,
+            true when value is string text && Guid.TryParse(text, out var parsed) => parsed,
+            _ => null,
+        };
+}

--- a/src/Apps/EcoPortal/EcoPortal.Server/Authorization/ClientRoutedPageAuthorizationHandler.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Server/Authorization/ClientRoutedPageAuthorizationHandler.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Components.Endpoints;
+
+namespace EcoPortal.Server.Authorization;
+
+// Pages run in the browser (InteractiveWebAssembly, no prerender), yet [Authorize] and
+// [OrganizationPermission] on a page become endpoint metadata that the server would enforce
+// on the initial document request — answering a typed-in URL with a bare 401/403 before the
+// app ever loads. The document is only the app shell; every API call still enforces its own
+// authorization. Serve it and let the client router send the person to login or show that
+// their role lacks the permission.
+public sealed class ClientRoutedPageAuthorizationHandler : IAuthorizationMiddlewareResultHandler
+{
+    private readonly AuthorizationMiddlewareResultHandler _default = new();
+
+    public Task HandleAsync(
+        RequestDelegate next,
+        HttpContext context,
+        AuthorizationPolicy policy,
+        PolicyAuthorizationResult authorizeResult
+    )
+    {
+        if (
+            !authorizeResult.Succeeded
+            && context.GetEndpoint()?.Metadata.GetMetadata<ComponentTypeMetadata>() is not null
+        )
+        {
+            return next(context);
+        }
+
+        return _default.HandleAsync(next, context, policy, authorizeResult);
+    }
+}

--- a/src/Apps/EcoPortal/EcoPortal.Server/Program.cs
+++ b/src/Apps/EcoPortal/EcoPortal.Server/Program.cs
@@ -21,6 +21,8 @@ using EcoData.Sensors.Database.Extensions;
 using EcoData.Wildlife.Api;
 using EcoData.Wildlife.DataAccess;
 using EcoData.Wildlife.Database.Extensions;
+using EcoPortal.Server.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using EcoPortal.Server.Components;
 using EcoPortal.Server.Services;
 using EcoPortal.Server.Workers;
@@ -38,6 +40,7 @@ builder.AddWildlifeDatabase();
 
 builder.Services.AddRazorComponents().AddInteractiveWebAssemblyComponents().AddAuthenticationStateSerialization();
 builder.Services.AddCascadingAuthenticationState();
+builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, ClientRoutedPageAuthorizationHandler>();
 
 builder.Services.AddMudServices();
 builder.Services.AddTempest();

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationAccessRequestEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationAccessRequestEndpoints.cs
@@ -37,6 +37,7 @@ public static class OrganizationAccessRequestEndpoints
                     IOrganizationAccessRequestRepository repository,
                     IOrganizationMemberRepository memberRepository,
                     IOrganizationBlockedUserRepository blockedUserRepository,
+                    IOrganizationRoleRepository roleRepository,
                     CancellationToken ct
                 ) =>
                 {
@@ -85,9 +86,20 @@ public static class OrganizationAccessRequestEndpoints
                         );
                     }
 
+                    var role = await roleRepository.GetByNameAsync(organizationId, request.RoleName, ct);
+
+                    if (role is null)
+                    {
+                        return TypedResults.Problem(
+                            detail: $"Role '{request.RoleName}' does not exist in this organization.",
+                            statusCode: StatusCodes.Status400BadRequest
+                        );
+                    }
+
                     var accessRequest = await repository.CreateAsync(
                         token.UserId.Value,
                         organizationId,
+                        role.Id,
                         request.RequestMessage,
                         ct
                     );
@@ -249,7 +261,8 @@ public static class OrganizationAccessRequestEndpoints
                         await memberRepository.CreateAsync(
                             organizationId,
                             existingRequest.UserId,
-                            DefaultRoles.Viewer,
+                            // Requests made before role selection existed carry no role; they join as Viewer.
+                            existingRequest.RoleName ?? DefaultRoles.Viewer,
                             ct
                         );
                     }

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationApiExtensions.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationApiExtensions.cs
@@ -8,6 +8,7 @@ public static class OrganizationApiExtensions
     {
         app.MapOrganizationEndpoints();
         app.MapOrganizationAccessRequestEndpoints();
+        app.MapOrganizationRoleEndpoints();
         app.MapOrganizationBlockedUserEndpoints();
         app.MapMemberEndpoints();
         app.MapPermissionEndpoints();

--- a/src/Features/Organization/EcoData.Organization.Api/OrganizationRoleEndpoints.cs
+++ b/src/Features/Organization/EcoData.Organization.Api/OrganizationRoleEndpoints.cs
@@ -1,0 +1,232 @@
+using System.Security.Claims;
+using EcoData.Identity.Contracts.Claims;
+using EcoData.Organization.Application.Server.Services;
+using EcoData.Organization.Contracts.Dtos;
+using EcoData.Organization.Contracts.Requests;
+using EcoData.Organization.DataAccess.Interfaces;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+using Permissions = EcoData.Organization.Contracts.Permissions;
+
+namespace EcoData.Organization.Api;
+
+public static class OrganizationRoleEndpoints
+{
+    private const int MaxLength = 100;
+
+    public static IEndpointRouteBuilder MapOrganizationRoleEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/organization/organizations/{organizationId:guid}/roles")
+            .WithTags("Organization Roles")
+            .RequireAuthorization();
+
+        // Any signed-in user may read roles: a prospective member picks one when requesting
+        // access, before holding any membership in the organization.
+        group
+            .MapGet(
+                "/",
+                async Task<Ok<IReadOnlyList<OrganizationRoleDto>>> (
+                    Guid organizationId,
+                    IOrganizationRoleRepository repository,
+                    CancellationToken ct
+                ) => TypedResults.Ok(await repository.GetByOrganizationAsync(organizationId, ct))
+            )
+            .WithName("GetOrganizationRoles");
+
+        group
+            .MapPost(
+                "/",
+                async Task<Results<Created<OrganizationRoleDto>, ProblemHttpResult, ForbidHttpResult>> (
+                    Guid organizationId,
+                    OrganizationRoleRequest request,
+                    ClaimsPrincipal user,
+                    IOrganizationRoleRepository repository,
+                    IOrganizationPermissionService permissionService,
+                    CancellationToken ct
+                ) =>
+                {
+                    if (!await CanManageAsync(user, organizationId, permissionService, ct))
+                    {
+                        return TypedResults.Forbid();
+                    }
+
+                    var invalid = Normalize(request, out var name, out var permissions);
+                    if (invalid is not null)
+                    {
+                        return invalid;
+                    }
+
+                    if (await repository.NameExistsAsync(organizationId, name, null, ct))
+                    {
+                        return TypedResults.Problem(
+                            detail: $"A role named '{name}' already exists in this organization.",
+                            statusCode: StatusCodes.Status409Conflict
+                        );
+                    }
+
+                    var role = await repository.CreateAsync(organizationId, name, permissions, ct);
+
+                    return TypedResults.Created(
+                        $"/organization/organizations/{organizationId}/roles/{role.Id}",
+                        role
+                    );
+                }
+            )
+            .WithName("CreateOrganizationRole");
+
+        group
+            .MapPut(
+                "/{roleId:guid}",
+                async Task<Results<Ok<OrganizationRoleDto>, ProblemHttpResult, ForbidHttpResult>> (
+                    Guid organizationId,
+                    Guid roleId,
+                    OrganizationRoleRequest request,
+                    ClaimsPrincipal user,
+                    IOrganizationRoleRepository repository,
+                    IOrganizationPermissionService permissionService,
+                    CancellationToken ct
+                ) =>
+                {
+                    if (!await CanManageAsync(user, organizationId, permissionService, ct))
+                    {
+                        return TypedResults.Forbid();
+                    }
+
+                    var invalid = Normalize(request, out var name, out var permissions);
+                    if (invalid is not null)
+                    {
+                        return invalid;
+                    }
+
+                    if (await repository.NameExistsAsync(organizationId, name, roleId, ct))
+                    {
+                        return TypedResults.Problem(
+                            detail: $"A role named '{name}' already exists in this organization.",
+                            statusCode: StatusCodes.Status409Conflict
+                        );
+                    }
+
+                    var role = await repository.UpdateAsync(
+                        organizationId,
+                        roleId,
+                        name,
+                        permissions,
+                        ct
+                    );
+
+                    if (role is null)
+                    {
+                        return TypedResults.Problem(
+                            detail: "Role not found.",
+                            statusCode: StatusCodes.Status404NotFound
+                        );
+                    }
+
+                    return TypedResults.Ok(role);
+                }
+            )
+            .WithName("UpdateOrganizationRole");
+
+        group
+            .MapDelete(
+                "/{roleId:guid}",
+                async Task<Results<NoContent, ProblemHttpResult, ForbidHttpResult>> (
+                    Guid organizationId,
+                    Guid roleId,
+                    ClaimsPrincipal user,
+                    IOrganizationRoleRepository repository,
+                    IOrganizationPermissionService permissionService,
+                    CancellationToken ct
+                ) =>
+                {
+                    if (!await CanManageAsync(user, organizationId, permissionService, ct))
+                    {
+                        return TypedResults.Forbid();
+                    }
+
+                    var role = await repository.GetByIdAsync(organizationId, roleId, ct);
+                    if (role is null)
+                    {
+                        return TypedResults.Problem(
+                            detail: "Role not found.",
+                            statusCode: StatusCodes.Status404NotFound
+                        );
+                    }
+
+                    if (await repository.IsInUseAsync(roleId, ct))
+                    {
+                        return TypedResults.Problem(
+                            detail: $"'{role.Name}' is still assigned to members or pending access requests. Move them to another role first.",
+                            statusCode: StatusCodes.Status409Conflict
+                        );
+                    }
+
+                    await repository.DeleteAsync(organizationId, roleId, ct);
+
+                    return TypedResults.NoContent();
+                }
+            )
+            .WithName("DeleteOrganizationRole");
+
+        return app;
+    }
+
+    // Roles decide what members may do, so changing them is part of managing members.
+    private static async Task<bool> CanManageAsync(
+        ClaimsPrincipal user,
+        Guid organizationId,
+        IOrganizationPermissionService permissionService,
+        CancellationToken ct
+    )
+    {
+        var token = new RequestClaimToken(user);
+
+        if (!token.IsAuthenticated)
+        {
+            return false;
+        }
+
+        return await permissionService.HasPermissionAsync(
+            token.UserId.Value,
+            organizationId,
+            Permissions.Organization.ManageMembers,
+            ct
+        );
+    }
+
+    // Permission keys are opaque strings here: the modules that own them (Sensors, Wildlife,
+    // Organization itself) declare them, and the client offers the catalogue.
+    private static ProblemHttpResult? Normalize(
+        OrganizationRoleRequest request,
+        out string name,
+        out IReadOnlyList<string> permissions
+    )
+    {
+        name = request.Name?.Trim() ?? "";
+        permissions = (request.Permissions ?? [])
+            .Select(p => p.Trim())
+            .Where(p => p.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (name.Length == 0 || name.Length > MaxLength)
+        {
+            return TypedResults.Problem(
+                detail: $"Role name must be between 1 and {MaxLength} characters.",
+                statusCode: StatusCodes.Status400BadRequest
+            );
+        }
+
+        if (permissions.Any(p => p.Length > MaxLength))
+        {
+            return TypedResults.Problem(
+                detail: $"Permission keys must be at most {MaxLength} characters.",
+                statusCode: StatusCodes.Status400BadRequest
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/Features/Organization/EcoData.Organization.Application.Client/DependencyInjection.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/DependencyInjection.cs
@@ -32,6 +32,11 @@ public static class DependencyInjection
             configureClient?.Invoke(client);
         });
 
+        services.AddHttpClient<IOrganizationRoleHttpClient, OrganizationRoleHttpClient>(client =>
+        {
+            configureClient?.Invoke(client);
+        });
+
         services.AddHttpClient<IPermissionHttpClient, PermissionHttpClient>(client =>
         {
             configureClient?.Invoke(client);

--- a/src/Features/Organization/EcoData.Organization.Application.Client/IOrganizationRoleHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/IOrganizationRoleHttpClient.cs
@@ -1,0 +1,34 @@
+using EcoData.Common.Problems.Contracts;
+using EcoData.Organization.Contracts.Dtos;
+using EcoData.Organization.Contracts.Requests;
+using OneOf;
+using OneOf.Types;
+
+namespace EcoData.Organization.Application.Client;
+
+public interface IOrganizationRoleHttpClient
+{
+    Task<OneOf<IReadOnlyList<OrganizationRoleDto>, RequestFailed>> GetAllAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<OneOf<OrganizationRoleDto, RequestFailed>> CreateAsync(
+        Guid organizationId,
+        OrganizationRoleRequest request,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<OneOf<OrganizationRoleDto, RequestFailed>> UpdateAsync(
+        Guid organizationId,
+        Guid roleId,
+        OrganizationRoleRequest request,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<OneOf<Success, RequestFailed>> DeleteAsync(
+        Guid organizationId,
+        Guid roleId,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationRoleHttpClient.cs
+++ b/src/Features/Organization/EcoData.Organization.Application.Client/OrganizationRoleHttpClient.cs
@@ -1,0 +1,136 @@
+using System.Net.Http.Json;
+using EcoData.Common.Problems.Contracts;
+using EcoData.Organization.Contracts.Dtos;
+using EcoData.Organization.Contracts.Requests;
+using OneOf;
+using OneOf.Types;
+
+namespace EcoData.Organization.Application.Client;
+
+public sealed class OrganizationRoleHttpClient(HttpClient httpClient) : IOrganizationRoleHttpClient
+{
+    public async Task<OneOf<IReadOnlyList<OrganizationRoleDto>, RequestFailed>> GetAllAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        try
+        {
+            var response = await httpClient.GetAsync(
+                $"organization/organizations/{organizationId}/roles",
+                cancellationToken
+            );
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var problem = await ProblemDetailsParser.ParseAsync(response, cancellationToken);
+                return new RequestFailed((int)response.StatusCode, problem?.Detail ?? problem?.Title);
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<List<OrganizationRoleDto>>(
+                cancellationToken
+            );
+
+            return result ?? [];
+        }
+        catch (HttpRequestException e)
+        {
+            return new RequestFailed(0, e.Message);
+        }
+    }
+
+    public async Task<OneOf<OrganizationRoleDto, RequestFailed>> CreateAsync(
+        Guid organizationId,
+        OrganizationRoleRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        try
+        {
+            var response = await httpClient.PostAsJsonAsync(
+                $"organization/organizations/{organizationId}/roles",
+                request,
+                cancellationToken
+            );
+
+            return await ReadRoleAsync(response, cancellationToken);
+        }
+        catch (HttpRequestException e)
+        {
+            return new RequestFailed(0, e.Message);
+        }
+    }
+
+    public async Task<OneOf<OrganizationRoleDto, RequestFailed>> UpdateAsync(
+        Guid organizationId,
+        Guid roleId,
+        OrganizationRoleRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        try
+        {
+            var response = await httpClient.PutAsJsonAsync(
+                $"organization/organizations/{organizationId}/roles/{roleId}",
+                request,
+                cancellationToken
+            );
+
+            return await ReadRoleAsync(response, cancellationToken);
+        }
+        catch (HttpRequestException e)
+        {
+            return new RequestFailed(0, e.Message);
+        }
+    }
+
+    public async Task<OneOf<Success, RequestFailed>> DeleteAsync(
+        Guid organizationId,
+        Guid roleId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        try
+        {
+            var response = await httpClient.DeleteAsync(
+                $"organization/organizations/{organizationId}/roles/{roleId}",
+                cancellationToken
+            );
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var problem = await ProblemDetailsParser.ParseAsync(response, cancellationToken);
+                return new RequestFailed((int)response.StatusCode, problem?.Detail ?? problem?.Title);
+            }
+
+            return new Success();
+        }
+        catch (HttpRequestException e)
+        {
+            return new RequestFailed(0, e.Message);
+        }
+    }
+
+    private static async Task<OneOf<OrganizationRoleDto, RequestFailed>> ReadRoleAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            var problem = await ProblemDetailsParser.ParseAsync(response, cancellationToken);
+            return new RequestFailed((int)response.StatusCode, problem?.Detail ?? problem?.Title);
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<OrganizationRoleDto>(cancellationToken);
+        if (result is null)
+        {
+            return new RequestFailed(
+                (int)response.StatusCode,
+                "The server returned an empty response."
+            );
+        }
+
+        return result;
+    }
+}

--- a/src/Features/Organization/EcoData.Organization.Contracts/Dtos/OrganizationAccessRequestDto.cs
+++ b/src/Features/Organization/EcoData.Organization.Contracts/Dtos/OrganizationAccessRequestDto.cs
@@ -9,6 +9,7 @@ public sealed record OrganizationAccessRequestDto(
     string OrganizationName,
     string Status,
     string? RequestMessage,
+    string? RoleName,
     string? ReviewNotes,
     Guid? ReviewedByUserId,
     string? ReviewedByDisplayName,

--- a/src/Features/Organization/EcoData.Organization.Contracts/Dtos/OrganizationRoleDto.cs
+++ b/src/Features/Organization/EcoData.Organization.Contracts/Dtos/OrganizationRoleDto.cs
@@ -1,0 +1,8 @@
+namespace EcoData.Organization.Contracts.Dtos;
+
+public sealed record OrganizationRoleDto(
+    Guid Id,
+    string Name,
+    IReadOnlyList<string> Permissions,
+    int MemberCount
+);

--- a/src/Features/Organization/EcoData.Organization.Contracts/Requests/CreateOrganizationAccessRequestRequest.cs
+++ b/src/Features/Organization/EcoData.Organization.Contracts/Requests/CreateOrganizationAccessRequestRequest.cs
@@ -1,3 +1,7 @@
 namespace EcoData.Organization.Contracts.Requests;
 
-public sealed record CreateOrganizationAccessRequestRequest(Guid OrganizationId, string? RequestMessage = null);
+public sealed record CreateOrganizationAccessRequestRequest(
+    Guid OrganizationId,
+    string RoleName,
+    string? RequestMessage = null
+);

--- a/src/Features/Organization/EcoData.Organization.Contracts/Requests/OrganizationRoleRequest.cs
+++ b/src/Features/Organization/EcoData.Organization.Contracts/Requests/OrganizationRoleRequest.cs
@@ -1,0 +1,4 @@
+namespace EcoData.Organization.Contracts.Requests;
+
+// Shared by create and update: a role is its name plus the permission keys it grants.
+public sealed record OrganizationRoleRequest(string Name, IReadOnlyList<string> Permissions);

--- a/src/Features/Organization/EcoData.Organization.DataAccess/DependencyInjection.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/DependencyInjection.cs
@@ -14,6 +14,7 @@ public static class DependencyInjection
         services.AddScoped<IOrganizationMemberRepository, OrganizationMemberRepository>();
         services.AddScoped<IOrganizationMembershipRepository, OrganizationMembershipRepository>();
         services.AddScoped<IOrganizationAccessRequestRepository, OrganizationAccessRequestRepository>();
+        services.AddScoped<IOrganizationRoleRepository, OrganizationRoleRepository>();
         services.AddScoped<IOrganizationBlockedUserRepository, OrganizationBlockedUserRepository>();
         services.AddScoped<IDataSourceRepository, DataSourceRepository>();
         services.AddScoped<IOrganizationPermissionService, OrganizationPermissionService>();

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Interfaces/IOrganizationAccessRequestRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Interfaces/IOrganizationAccessRequestRepository.cs
@@ -26,6 +26,7 @@ public interface IOrganizationAccessRequestRepository
     Task<OrganizationAccessRequestDto> CreateAsync(
         Guid userId,
         Guid organizationId,
+        Guid roleId,
         string? requestMessage,
         CancellationToken cancellationToken = default
     );

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Interfaces/IOrganizationRoleRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Interfaces/IOrganizationRoleRepository.cs
@@ -1,0 +1,54 @@
+using EcoData.Organization.Contracts.Dtos;
+
+namespace EcoData.Organization.DataAccess.Interfaces;
+
+public interface IOrganizationRoleRepository
+{
+    Task<IReadOnlyList<OrganizationRoleDto>> GetByOrganizationAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<OrganizationRoleDto?> GetByIdAsync(
+        Guid organizationId,
+        Guid roleId,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<OrganizationRoleDto?> GetByNameAsync(
+        Guid organizationId,
+        string name,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<bool> NameExistsAsync(
+        Guid organizationId,
+        string name,
+        Guid? excludeRoleId = null,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<OrganizationRoleDto> CreateAsync(
+        Guid organizationId,
+        string name,
+        IReadOnlyList<string> permissions,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<OrganizationRoleDto?> UpdateAsync(
+        Guid organizationId,
+        Guid roleId,
+        string name,
+        IReadOnlyList<string> permissions,
+        CancellationToken cancellationToken = default
+    );
+
+    // True while any member holds the role or any pending access request asks for it.
+    Task<bool> IsInUseAsync(Guid roleId, CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteAsync(
+        Guid organizationId,
+        Guid roleId,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationAccessRequestRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationAccessRequestRepository.cs
@@ -54,6 +54,7 @@ public sealed class OrganizationAccessRequestRepository(
                 OrganizationName = r.Organization!.Name,
                 r.Status,
                 r.RequestMessage,
+                RoleName = r.Role != null ? r.Role.Name : null,
                 r.ReviewNotes,
                 r.ReviewedByUserId,
                 r.ReviewedAt,
@@ -91,6 +92,7 @@ public sealed class OrganizationAccessRequestRepository(
                 request.OrganizationName,
                 request.Status.ToString(),
                 request.RequestMessage,
+                request.RoleName,
                 request.ReviewNotes,
                 request.ReviewedByUserId,
                 reviewer?.DisplayName,
@@ -144,6 +146,7 @@ public sealed class OrganizationAccessRequestRepository(
                 OrganizationName = r.Organization!.Name,
                 r.Status,
                 r.RequestMessage,
+                RoleName = r.Role != null ? r.Role.Name : null,
                 r.ReviewNotes,
                 r.ReviewedByUserId,
                 r.ReviewedAt,
@@ -180,6 +183,7 @@ public sealed class OrganizationAccessRequestRepository(
                 request.OrganizationName,
                 request.Status.ToString(),
                 request.RequestMessage,
+                request.RoleName,
                 request.ReviewNotes,
                 request.ReviewedByUserId,
                 reviewer?.DisplayName,
@@ -206,6 +210,7 @@ public sealed class OrganizationAccessRequestRepository(
                 OrganizationName = r.Organization!.Name,
                 r.Status,
                 r.RequestMessage,
+                RoleName = r.Role != null ? r.Role.Name : null,
                 r.ReviewNotes,
                 r.ReviewedByUserId,
                 r.ReviewedAt,
@@ -235,6 +240,7 @@ public sealed class OrganizationAccessRequestRepository(
             request.OrganizationName,
             request.Status.ToString(),
             request.RequestMessage,
+            request.RoleName,
             request.ReviewNotes,
             request.ReviewedByUserId,
             reviewer?.DisplayName,
@@ -246,6 +252,7 @@ public sealed class OrganizationAccessRequestRepository(
     public async Task<OrganizationAccessRequestDto> CreateAsync(
         Guid userId,
         Guid organizationId,
+        Guid roleId,
         string? requestMessage,
         CancellationToken cancellationToken = default
     )
@@ -257,12 +264,15 @@ public sealed class OrganizationAccessRequestRepository(
             .Select(o => new { o.Id, o.Name })
             .FirstAsync(cancellationToken);
 
+        var roleName = await RoleNameAsync(context, roleId, cancellationToken);
+
         var now = DateTimeOffset.UtcNow;
         var entity = new OrganizationAccessRequest
         {
             Id = Guid.CreateVersion7(),
             UserId = userId,
             OrganizationId = organizationId,
+            RoleId = roleId,
             Status = OrganizationAccessRequestStatus.Pending,
             RequestMessage = requestMessage,
             ReviewNotes = null,
@@ -285,6 +295,7 @@ public sealed class OrganizationAccessRequestRepository(
             organization.Name,
             entity.Status.ToString(),
             entity.RequestMessage,
+            roleName,
             null,
             null,
             null,
@@ -324,6 +335,8 @@ public sealed class OrganizationAccessRequestRepository(
             .Select(o => o.Name)
             .FirstOrDefaultAsync(cancellationToken) ?? "";
 
+        var roleName = await RoleNameAsync(context, entity.RoleId, cancellationToken);
+
         var user = await userLookupService.GetByIdAsync(entity.UserId, cancellationToken);
         var reviewer = await userLookupService.GetByIdAsync(reviewedByUserId, cancellationToken);
 
@@ -336,6 +349,7 @@ public sealed class OrganizationAccessRequestRepository(
             organizationName,
             entity.Status.ToString(),
             entity.RequestMessage,
+            roleName,
             entity.ReviewNotes,
             entity.ReviewedByUserId,
             reviewer?.DisplayName,
@@ -388,6 +402,8 @@ public sealed class OrganizationAccessRequestRepository(
             .Select(o => o.Name)
             .FirstOrDefaultAsync(cancellationToken) ?? "";
 
+        var roleName = await RoleNameAsync(context, entity.RoleId, cancellationToken);
+
         var user = await userLookupService.GetByIdAsync(entity.UserId, cancellationToken);
 
         return new OrganizationAccessRequestDto(
@@ -399,6 +415,7 @@ public sealed class OrganizationAccessRequestRepository(
             organizationName,
             entity.Status.ToString(),
             entity.RequestMessage,
+            roleName,
             entity.ReviewNotes,
             entity.ReviewedByUserId,
             null,
@@ -422,5 +439,22 @@ public sealed class OrganizationAccessRequestRepository(
                 && r.Status == OrganizationAccessRequestStatus.Pending,
             cancellationToken
         );
+    }
+
+    private static async Task<string?> RoleNameAsync(
+        OrganizationDbContext context,
+        Guid? roleId,
+        CancellationToken cancellationToken
+    )
+    {
+        if (roleId is null)
+        {
+            return null;
+        }
+
+        return await context
+            .OrganizationRoles.Where(r => r.Id == roleId)
+            .Select(r => r.Name)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 }

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRoleRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRoleRepository.cs
@@ -17,11 +17,9 @@ public sealed class OrganizationRoleRepository(
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 
-        // Creation order keeps the defaults in Owner, Admin, Contributor, Viewer order.
         var roles = await context
             .OrganizationRoles.Where(r => r.OrganizationId == organizationId)
-            .OrderBy(r => r.CreatedAt)
-            .ThenBy(r => r.Name)
+            .OrderBy(r => r.Name)
             .Select(r => new
             {
                 r.Id,

--- a/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRoleRepository.cs
+++ b/src/Features/Organization/EcoData.Organization.DataAccess/Repositories/OrganizationRoleRepository.cs
@@ -1,0 +1,252 @@
+using EcoData.Organization.Contracts.Dtos;
+using EcoData.Organization.DataAccess.Interfaces;
+using EcoData.Organization.Database;
+using EcoData.Organization.Database.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace EcoData.Organization.DataAccess.Repositories;
+
+public sealed class OrganizationRoleRepository(
+    IDbContextFactory<OrganizationDbContext> contextFactory
+) : IOrganizationRoleRepository
+{
+    public async Task<IReadOnlyList<OrganizationRoleDto>> GetByOrganizationAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        // Creation order keeps the defaults in Owner, Admin, Contributor, Viewer order.
+        var roles = await context
+            .OrganizationRoles.Where(r => r.OrganizationId == organizationId)
+            .OrderBy(r => r.CreatedAt)
+            .ThenBy(r => r.Name)
+            .Select(r => new
+            {
+                r.Id,
+                r.Name,
+                Permissions = r.Permissions.Select(p => p.Permission).OrderBy(p => p).ToList(),
+                MemberCount = r.Members.Count,
+            })
+            .ToListAsync(cancellationToken);
+
+        return roles
+            .Select(r => new OrganizationRoleDto(r.Id, r.Name, r.Permissions, r.MemberCount))
+            .ToList();
+    }
+
+    public async Task<OrganizationRoleDto?> GetByIdAsync(
+        Guid organizationId,
+        Guid roleId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var role = await context
+            .OrganizationRoles.Where(r => r.OrganizationId == organizationId && r.Id == roleId)
+            .Select(r => new
+            {
+                r.Id,
+                r.Name,
+                Permissions = r.Permissions.Select(p => p.Permission).OrderBy(p => p).ToList(),
+                MemberCount = r.Members.Count,
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (role is null)
+        {
+            return null;
+        }
+
+        return new OrganizationRoleDto(role.Id, role.Name, role.Permissions, role.MemberCount);
+    }
+
+    public async Task<OrganizationRoleDto?> GetByNameAsync(
+        Guid organizationId,
+        string name,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var role = await context
+            .OrganizationRoles.Where(r => r.OrganizationId == organizationId && r.Name == name)
+            .Select(r => new
+            {
+                r.Id,
+                r.Name,
+                Permissions = r.Permissions.Select(p => p.Permission).OrderBy(p => p).ToList(),
+                MemberCount = r.Members.Count,
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (role is null)
+        {
+            return null;
+        }
+
+        return new OrganizationRoleDto(role.Id, role.Name, role.Permissions, role.MemberCount);
+    }
+
+    public async Task<bool> NameExistsAsync(
+        Guid organizationId,
+        string name,
+        Guid? excludeRoleId = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context.OrganizationRoles.AnyAsync(
+            r =>
+                r.OrganizationId == organizationId
+                && r.Name == name
+                && (excludeRoleId == null || r.Id != excludeRoleId),
+            cancellationToken
+        );
+    }
+
+    public async Task<OrganizationRoleDto> CreateAsync(
+        Guid organizationId,
+        string name,
+        IReadOnlyList<string> permissions,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = new OrganizationRole
+        {
+            Id = Guid.CreateVersion7(),
+            OrganizationId = organizationId,
+            Name = name,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        foreach (var permission in permissions)
+        {
+            entity.Permissions.Add(
+                new OrganizationRolePermission { RoleId = entity.Id, Permission = permission }
+            );
+        }
+
+        context.OrganizationRoles.Add(entity);
+        await context.SaveChangesAsync(cancellationToken);
+
+        return new OrganizationRoleDto(
+            entity.Id,
+            entity.Name,
+            permissions.Order().ToList(),
+            MemberCount: 0
+        );
+    }
+
+    public async Task<OrganizationRoleDto?> UpdateAsync(
+        Guid organizationId,
+        Guid roleId,
+        string name,
+        IReadOnlyList<string> permissions,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context
+            .OrganizationRoles.AsTracking()
+            .Include(r => r.Permissions)
+            .FirstOrDefaultAsync(
+                r => r.OrganizationId == organizationId && r.Id == roleId,
+                cancellationToken
+            );
+
+        if (entity is null)
+        {
+            return null;
+        }
+
+        entity.Name = name;
+
+        var wanted = permissions.ToHashSet(StringComparer.Ordinal);
+
+        foreach (var existing in entity.Permissions.ToList())
+        {
+            if (!wanted.Remove(existing.Permission))
+            {
+                context.OrganizationRolePermissions.Remove(existing);
+            }
+        }
+
+        foreach (var added in wanted)
+        {
+            entity.Permissions.Add(
+                new OrganizationRolePermission { RoleId = entity.Id, Permission = added }
+            );
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var memberCount = await context.OrganizationMembers.CountAsync(
+            m => m.RoleId == roleId,
+            cancellationToken
+        );
+
+        return new OrganizationRoleDto(
+            entity.Id,
+            entity.Name,
+            permissions.Order().ToList(),
+            memberCount
+        );
+    }
+
+    public async Task<bool> IsInUseAsync(Guid roleId, CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        if (await context.OrganizationMembers.AnyAsync(m => m.RoleId == roleId, cancellationToken))
+        {
+            return true;
+        }
+
+        return await context.OrganizationAccessRequests.AnyAsync(
+            r => r.RoleId == roleId && r.Status == OrganizationAccessRequestStatus.Pending,
+            cancellationToken
+        );
+    }
+
+    public async Task<bool> DeleteAsync(
+        Guid organizationId,
+        Guid roleId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context
+            .OrganizationRoles.AsTracking()
+            .FirstOrDefaultAsync(
+                r => r.OrganizationId == organizationId && r.Id == roleId,
+                cancellationToken
+            );
+
+        if (entity is null)
+        {
+            return false;
+        }
+
+        // Resolved access requests keep their FK; the role row is what they pointed at, so
+        // those references are cleared rather than blocking the delete.
+        await context
+            .OrganizationAccessRequests.Where(r => r.RoleId == roleId)
+            .ExecuteUpdateAsync(
+                setters => setters.SetProperty(r => r.RoleId, (Guid?)null),
+                cancellationToken
+            );
+
+        context.OrganizationRoles.Remove(entity);
+        await context.SaveChangesAsync(cancellationToken);
+
+        return true;
+    }
+}

--- a/src/Features/Organization/EcoData.Organization.Database/Migrations/20260822021439_AddAccessRequestRole.Designer.cs
+++ b/src/Features/Organization/EcoData.Organization.Database/Migrations/20260822021439_AddAccessRequestRole.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EcoData.Organization.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EcoData.Organization.Database.Migrations
 {
     [DbContext(typeof(OrganizationDbContext))]
-    partial class OrganizationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260822021439_AddAccessRequestRole")]
+    partial class AddAccessRequestRole
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Features/Organization/EcoData.Organization.Database/Migrations/20260822021439_AddAccessRequestRole.cs
+++ b/src/Features/Organization/EcoData.Organization.Database/Migrations/20260822021439_AddAccessRequestRole.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoData.Organization.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAccessRequestRole : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "role_id",
+                table: "organization_access_requests",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_organization_access_requests_role_id",
+                table: "organization_access_requests",
+                column: "role_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_organization_access_requests_organization_roles_role_id",
+                table: "organization_access_requests",
+                column: "role_id",
+                principalTable: "organization_roles",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_organization_access_requests_organization_roles_role_id",
+                table: "organization_access_requests");
+
+            migrationBuilder.DropIndex(
+                name: "ix_organization_access_requests_role_id",
+                table: "organization_access_requests");
+
+            migrationBuilder.DropColumn(
+                name: "role_id",
+                table: "organization_access_requests");
+        }
+    }
+}

--- a/src/Features/Organization/EcoData.Organization.Database/Models/OrganizationAccessRequest.cs
+++ b/src/Features/Organization/EcoData.Organization.Database/Models/OrganizationAccessRequest.cs
@@ -8,6 +8,8 @@ public sealed class OrganizationAccessRequest
     public required Guid Id { get; set; }
     public required Guid UserId { get; set; }
     public required Guid OrganizationId { get; set; }
+    // Nullable only for requests that predate role selection; new requests always carry one.
+    public required Guid? RoleId { get; set; }
     public required OrganizationAccessRequestStatus Status { get; set; }
     public required string? RequestMessage { get; set; }
     public required string? ReviewNotes { get; set; }
@@ -16,6 +18,7 @@ public sealed class OrganizationAccessRequest
     public required DateTimeOffset CreatedAt { get; set; }
 
     public Organization? Organization { get; set; }
+    public OrganizationRole? Role { get; set; }
 
     public sealed class EntityConfiguration : IEntityTypeConfiguration<OrganizationAccessRequest>
     {
@@ -49,6 +52,12 @@ public sealed class OrganizationAccessRequest
                 .WithMany()
                 .HasForeignKey(static e => e.OrganizationId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            builder
+                .HasOne(static e => e.Role)
+                .WithMany()
+                .HasForeignKey(static e => e.RoleId)
+                .OnDelete(DeleteBehavior.Restrict);
         }
     }
 }

--- a/src/Features/Wildlife/EcoData.Wildlife.Application/EcoData.Wildlife.Application.csproj
+++ b/src/Features/Wildlife/EcoData.Wildlife.Application/EcoData.Wildlife.Application.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Common\EcoData.Common.Authorization\EcoData.Common.Authorization.csproj" />
+    <ProjectReference Include="..\EcoData.Wildlife.Contracts\EcoData.Wildlife.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Features/Wildlife/EcoData.Wildlife.Application/WildlifePermissions.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Application/WildlifePermissions.cs
@@ -1,12 +1,13 @@
 using EcoData.Common.Authorization;
+using EcoData.Wildlife.Contracts;
 
 namespace EcoData.Wildlife.Application;
 
 public static class WildlifePermissions
 {
-    public static readonly OrgPermission ReadSpecies = new("wildlife:species:read");
+    public static readonly OrgPermission ReadSpecies = new(Permissions.Species.Read);
 
-    public static readonly OrgPermission SubmitOccurrence = new("wildlife:occurrence:submit");
+    public static readonly OrgPermission SubmitOccurrence = new(Permissions.Occurrence.Submit);
 
-    public static readonly OrgPermission VerifyOccurrence = new("wildlife:occurrence:verify");
+    public static readonly OrgPermission VerifyOccurrence = new(Permissions.Occurrence.Verify);
 }

--- a/src/Features/Wildlife/EcoData.Wildlife.Contracts/Permissions.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.Contracts/Permissions.cs
@@ -1,0 +1,15 @@
+namespace EcoData.Wildlife.Contracts;
+
+public static class Permissions
+{
+    public static class Species
+    {
+        public const string Read = "wildlife:species:read";
+    }
+
+    public static class Occurrence
+    {
+        public const string Submit = "wildlife:occurrence:submit";
+        public const string Verify = "wildlife:occurrence:verify";
+    }
+}

--- a/tests/EcoData.IntegrationTests/Authenticated/OrganizationAccessRequestTests.cs
+++ b/tests/EcoData.IntegrationTests/Authenticated/OrganizationAccessRequestTests.cs
@@ -32,7 +32,7 @@ public sealed class OrganizationAccessRequestTests(EcoDataTestFixture fixture)
         roles
             .AsT0.Select(r => r.Name)
             .Should()
-            .Equal(
+            .BeEquivalentTo(
                 DefaultOrganizationRoles.Owner,
                 DefaultOrganizationRoles.Admin,
                 DefaultOrganizationRoles.Contributor,

--- a/tests/EcoData.IntegrationTests/Authenticated/OrganizationAccessRequestTests.cs
+++ b/tests/EcoData.IntegrationTests/Authenticated/OrganizationAccessRequestTests.cs
@@ -1,0 +1,97 @@
+using EcoData.IntegrationTests.Bases;
+using EcoData.Organization.Application.Client;
+using EcoData.Organization.Contracts;
+using EcoData.Organization.Contracts.Dtos;
+using EcoData.Organization.Contracts.Requests;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EcoData.IntegrationTests.Authenticated;
+
+public sealed class OrganizationAccessRequestTests(EcoDataTestFixture fixture)
+    : AuthenticatedTestBase(fixture)
+{
+    IOrganizationHttpClient OrganizationHttpClient =>
+        Services.GetRequiredService<IOrganizationHttpClient>();
+    IOrganizationAccessRequestHttpClient AccessRequestHttpClient =>
+        Services.GetRequiredService<IOrganizationAccessRequestHttpClient>();
+    IOrganizationRoleHttpClient RoleHttpClient =>
+        Services.GetRequiredService<IOrganizationRoleHttpClient>();
+    IOrganizationMemberHttpClient MemberHttpClient =>
+        Services.GetRequiredService<IOrganizationMemberHttpClient>();
+
+    [Fact]
+    public async Task GetRoles_NewOrganization_ListsTheDefaultRoles()
+    {
+        var orgId = await CreateOrganizationAsync();
+
+        var roles = await RoleHttpClient.GetAllAsync(orgId);
+
+        roles.IsT0.Should().BeTrue("Listing roles should succeed");
+        roles
+            .AsT0.Select(r => r.Name)
+            .Should()
+            .Equal(
+                DefaultOrganizationRoles.Owner,
+                DefaultOrganizationRoles.Admin,
+                DefaultOrganizationRoles.Contributor,
+                DefaultOrganizationRoles.Viewer
+            );
+    }
+
+    [Fact]
+    public async Task RequestAccess_WithRole_ApprovalGrantsThatRole()
+    {
+        var orgId = await CreateOrganizationAsync();
+
+        var created = await AccessRequestHttpClient.CreateAsync(
+            orgId,
+            new CreateOrganizationAccessRequestRequest(
+                orgId,
+                DefaultOrganizationRoles.Contributor,
+                "I would like to contribute sightings"
+            )
+        );
+        created.IsT0.Should().BeTrue("Access request creation should succeed");
+        created.AsT0.RoleName.Should().Be(DefaultOrganizationRoles.Contributor);
+
+        var approved = await AccessRequestHttpClient.UpdateStatusAsync(
+            orgId,
+            created.AsT0.Id,
+            new UpdateOrganizationAccessRequestStatusRequest(Approved: true)
+        );
+        approved.IsT0.Should().BeTrue("Approval should succeed");
+        approved.AsT0.Status.Should().Be("Approved");
+        approved.AsT0.RoleName.Should().Be(DefaultOrganizationRoles.Contributor);
+
+        var member = await MemberHttpClient.GetAsync(orgId, created.AsT0.UserId);
+        member.IsT0.Should().BeTrue("The approved requester should now be a member");
+        member.AsT0.RoleName.Should().Be(DefaultOrganizationRoles.Contributor);
+    }
+
+    [Fact]
+    public async Task RequestAccess_WithUnknownRole_ReturnsBadRequest()
+    {
+        var orgId = await CreateOrganizationAsync();
+
+        var result = await AccessRequestHttpClient.CreateAsync(
+            orgId,
+            new CreateOrganizationAccessRequestRequest(orgId, "Wizard")
+        );
+
+        result.IsT1.Should().BeTrue("A role the organization does not have should be rejected");
+        result.AsT1.StatusCode.Should().Be(400);
+    }
+
+    private async Task<Guid> CreateOrganizationAsync()
+    {
+        var orgName = $"Test Org Access {Guid.CreateVersion7():N}";
+        var createResult = await OrganizationHttpClient.CreateAsync(
+            new OrganizationDtoForCreate(orgName, null, null, null, null)
+        );
+        createResult.IsT0.Should().BeTrue("Organization creation should succeed");
+
+        return createResult.AsT0.Id;
+    }
+}

--- a/tests/EcoData.IntegrationTests/Authenticated/OrganizationRoleTests.cs
+++ b/tests/EcoData.IntegrationTests/Authenticated/OrganizationRoleTests.cs
@@ -1,0 +1,149 @@
+using EcoData.IntegrationTests.Bases;
+using EcoData.Organization.Application.Client;
+using EcoData.Organization.Contracts;
+using EcoData.Organization.Contracts.Dtos;
+using EcoData.Organization.Contracts.Requests;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using SensorPermissions = EcoData.Sensors.Contracts.Permissions;
+
+namespace EcoData.IntegrationTests.Authenticated;
+
+public sealed class OrganizationRoleTests(EcoDataTestFixture fixture) : AuthenticatedTestBase(fixture)
+{
+    IOrganizationHttpClient OrganizationHttpClient =>
+        Services.GetRequiredService<IOrganizationHttpClient>();
+    IOrganizationRoleHttpClient RoleHttpClient =>
+        Services.GetRequiredService<IOrganizationRoleHttpClient>();
+    IOrganizationAccessRequestHttpClient AccessRequestHttpClient =>
+        Services.GetRequiredService<IOrganizationAccessRequestHttpClient>();
+
+    [Fact]
+    public async Task CreateRole_WithPermissions_AppearsInList()
+    {
+        var orgId = await CreateOrganizationAsync();
+
+        var created = await RoleHttpClient.CreateAsync(
+            orgId,
+            new OrganizationRoleRequest(
+                "Field Technician",
+                [SensorPermissions.Sensor.Update, SensorPermissions.Sensor.Read]
+            )
+        );
+
+        created.IsT0.Should().BeTrue("Role creation should succeed");
+        created.AsT0.Name.Should().Be("Field Technician");
+        created
+            .AsT0.Permissions.Should()
+            .Equal(SensorPermissions.Sensor.Read, SensorPermissions.Sensor.Update);
+        created.AsT0.MemberCount.Should().Be(0);
+
+        var roles = await RoleHttpClient.GetAllAsync(orgId);
+        roles.IsT0.Should().BeTrue();
+        roles.AsT0.Should().ContainSingle(r => r.Name == "Field Technician");
+    }
+
+    [Fact]
+    public async Task UpdateRole_ReplacesNameAndPermissions()
+    {
+        var orgId = await CreateOrganizationAsync();
+        var viewer = await RoleByNameAsync(orgId, DefaultOrganizationRoles.Viewer);
+
+        var updated = await RoleHttpClient.UpdateAsync(
+            orgId,
+            viewer.Id,
+            new OrganizationRoleRequest(
+                "Observer",
+                [SensorPermissions.Sensor.Read, Permissions.Organization.Update]
+            )
+        );
+        updated.IsT0.Should().BeTrue("Role update should succeed");
+        updated.AsT0.Name.Should().Be("Observer");
+        updated
+            .AsT0.Permissions.Should()
+            .Equal(Permissions.Organization.Update, SensorPermissions.Sensor.Read);
+
+        var narrowed = await RoleHttpClient.UpdateAsync(
+            orgId,
+            viewer.Id,
+            new OrganizationRoleRequest("Observer", [SensorPermissions.Sensor.Read])
+        );
+        narrowed.IsT0.Should().BeTrue();
+        narrowed.AsT0.Permissions.Should().Equal(SensorPermissions.Sensor.Read);
+    }
+
+    [Fact]
+    public async Task CreateRole_DuplicateName_ReturnsConflict()
+    {
+        var orgId = await CreateOrganizationAsync();
+
+        var result = await RoleHttpClient.CreateAsync(
+            orgId,
+            new OrganizationRoleRequest(DefaultOrganizationRoles.Viewer, [])
+        );
+
+        result.IsT1.Should().BeTrue("A second role with the same name should be rejected");
+        result.AsT1.StatusCode.Should().Be(409);
+    }
+
+    [Fact]
+    public async Task DeleteRole_Unused_Succeeds()
+    {
+        var orgId = await CreateOrganizationAsync();
+        var viewer = await RoleByNameAsync(orgId, DefaultOrganizationRoles.Viewer);
+
+        var deleted = await RoleHttpClient.DeleteAsync(orgId, viewer.Id);
+
+        deleted.IsT0.Should().BeTrue("Deleting an unused role should succeed");
+
+        var roles = await RoleHttpClient.GetAllAsync(orgId);
+        roles.AsT0.Should().NotContain(r => r.Id == viewer.Id);
+    }
+
+    [Fact]
+    public async Task DeleteRole_HeldByMember_ReturnsConflict()
+    {
+        var orgId = await CreateOrganizationAsync();
+        var contributor = await RoleByNameAsync(orgId, DefaultOrganizationRoles.Contributor);
+
+        var request = await AccessRequestHttpClient.CreateAsync(
+            orgId,
+            new CreateOrganizationAccessRequestRequest(orgId, DefaultOrganizationRoles.Contributor)
+        );
+        request.IsT0.Should().BeTrue();
+        var approved = await AccessRequestHttpClient.UpdateStatusAsync(
+            orgId,
+            request.AsT0.Id,
+            new UpdateOrganizationAccessRequestStatusRequest(Approved: true)
+        );
+        approved.IsT0.Should().BeTrue();
+
+        var deleted = await RoleHttpClient.DeleteAsync(orgId, contributor.Id);
+
+        deleted.IsT1.Should().BeTrue("A role with members should not be deletable");
+        deleted.AsT1.StatusCode.Should().Be(409);
+
+        var roles = await RoleHttpClient.GetAllAsync(orgId);
+        roles.AsT0.Should().ContainSingle(r => r.Id == contributor.Id && r.MemberCount == 1);
+    }
+
+    private async Task<OrganizationRoleDto> RoleByNameAsync(Guid orgId, string name)
+    {
+        var roles = await RoleHttpClient.GetAllAsync(orgId);
+        roles.IsT0.Should().BeTrue("Listing roles should succeed");
+
+        return roles.AsT0.Single(r => r.Name == name);
+    }
+
+    private async Task<Guid> CreateOrganizationAsync()
+    {
+        var orgName = $"Test Org Roles {Guid.CreateVersion7():N}";
+        var createResult = await OrganizationHttpClient.CreateAsync(
+            new OrganizationDtoForCreate(orgName, null, null, null, null)
+        );
+        createResult.IsT0.Should().BeTrue("Organization creation should succeed");
+
+        return createResult.AsT0.Id;
+    }
+}

--- a/tests/EcoData.IntegrationTests/ServiceCollectionExtensions.cs
+++ b/tests/EcoData.IntegrationTests/ServiceCollectionExtensions.cs
@@ -27,6 +27,9 @@ public static class ServiceCollectionExtensions
         // HTTP clients (must share HttpClient for cookie auth)
         services.AddSingleton<IAuthHttpClient, AuthHttpClient>();
         services.AddSingleton<IOrganizationHttpClient, OrganizationHttpClient>();
+        services.AddSingleton<IOrganizationAccessRequestHttpClient, OrganizationAccessRequestHttpClient>();
+        services.AddSingleton<IOrganizationMemberHttpClient, OrganizationMemberHttpClient>();
+        services.AddSingleton<IOrganizationRoleHttpClient, OrganizationRoleHttpClient>();
         services.AddSingleton<ISensorHttpClient, SensorHttpClient>();
         services.AddSingleton<ISensorReadingHttpClient, SensorReadingHttpClient>();
         services.AddSingleton<ISensorHealthHttpClient, SensorHealthHttpClient>();


### PR DESCRIPTION
## Summary

Organization roles become something an organization manages, and joining an organization is role-aware.

- **Roles carry permissions.** `GET/POST/PUT/DELETE /organization/organizations/{id}/roles` — list with permissions and member count, create, rename/re-permission, delete. Writes require `org:members:manage`; reads are open to any signed-in user because a prospective member picks a role before holding any membership. Deleting a role still held by members or pending requests is refused (409); resolved requests drop their reference instead of blocking.
- **Access requests name a role.** New `role_id` FK on `organization_access_requests` (migration `AddAccessRequestRole`, nullable for pre-existing rows). Creation validates the role against the organization; approval grants that role instead of always `Viewer`. Unknown role → 400.
- **EcoPortal:** the team page gains a **Roles** action → `/organizations/{id}/roles` with a role editor (name + permission checkboxes grouped by module, with descriptions). *Change Role* lists the organization's real roles instead of three hard-coded names. The request-access dialog asks which role the person wants; both request lists show it.
- **Permission catalogue:** the app assembles the pickable keys from `Organization`, `Sensors` and `Wildlife` contracts; the wildlife keys move into `Wildlife.Contracts` so they can be referenced.

### Two authorization fixes found along the way
- A direct navigation to a page carrying `[Authorize]`/`[OrganizationPermission]` never reached the app: Blazor turns those attributes into endpoint metadata and the server answered the document request with a bare 401/403 before WebAssembly loaded. An `IAuthorizationMiddlewareResultHandler` now serves component-page endpoints and lets the client router decide (APIs unchanged).
- The client router redirected every authorization failure to `/login`. A signed-in user whose role lacks the permission now stays on the URL and sees an in-place "you don't have access" view with a way back to the organization.

## Notes for review
- Default roles (`Owner`, `Admin`, `Contributor`, `Viewer`) are still created **without** permissions; the new Roles page is how they get any. Seeding sensible defaults on organization creation is an easy follow-up if wanted.
- `GET …/roles` exposes role names and permission lists to any authenticated user — deliberate, see above.

## Test plan
- [x] Integration suite: 55/55 (`dotnet test tests/EcoData.IntegrationTests`), including 8 new tests: list defaults, create with permissions, update, duplicate name → 409, delete unused, delete held by member → 409, request → approve into requested role, unknown role → 400.
- [ ] Headless-browser check as a non-admin *Student* member (`sensor:read`) — pending a server restart; expected: `/sensors` renders, `/team` shows the no-access view instead of login, anonymous still lands on login. (Before the server fix the same probe showed the raw 401 on the document request.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
