### PR TITLE
perf(wildlife): cache the catalogue stats in memory

### DIFF
--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/DependencyInjection.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/DependencyInjection.cs
@@ -17,7 +17,11 @@ public static class DependencyInjection
             .AddOptions<WildlifeOptions>()
             .Bind(configuration.GetSection(WildlifeOptions.SectionName));
 
-        services.AddScoped<ISpeciesRepository, SpeciesRepository>();
+        // The stats decorator needs a cache; AddMemoryCache is a TryAdd, so a host
+        // that already registered one keeps its own.
+        services.AddMemoryCache();
+        services.AddScoped<SpeciesRepository>();
+        services.AddScoped<ISpeciesRepository, CachedSpeciesRepository>();
         services.AddScoped<ISpeciesCategoryRepository, SpeciesCategoryRepository>();
         services.AddScoped<INrcsPracticeRepository, NrcsPracticeRepository>();
         services.AddScoped<IFwsActionRepository, FwsActionRepository>();

--- a/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/CachedSpeciesRepository.cs
+++ b/src/Features/Wildlife/EcoData.Wildlife.DataAccess/Repositories/CachedSpeciesRepository.cs
@@ -1,0 +1,73 @@
+using EcoData.Wildlife.Contracts.Dtos;
+using EcoData.Wildlife.Contracts.Parameters;
+using EcoData.Wildlife.DataAccess.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace EcoData.Wildlife.DataAccess.Repositories;
+
+// The catalogue stats are six aggregate queries over the whole species table,
+// asked for by every landing of the Species and Municipios pages and by the MCP
+// tool. Nothing in this process writes species — the seeder and backfills run
+// out of process — so a short time-based cache is safe and needs no invalidation.
+// Everything else passes straight through.
+public sealed class CachedSpeciesRepository(SpeciesRepository inner, IMemoryCache cache) : ISpeciesRepository
+{
+    private const string StatsKey = "wildlife:species:stats";
+    private static readonly TimeSpan StatsLifetime = TimeSpan.FromMinutes(15);
+
+    public async Task<SpeciesStatsDto> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        var stats = await cache.GetOrCreateAsync(
+            StatsKey,
+            entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = StatsLifetime;
+                return inner.GetStatsAsync(cancellationToken);
+            }
+        );
+
+        // GetOrCreateAsync only yields null when the factory does, which it never does here.
+        return stats!;
+    }
+
+    public Task<SpeciesDtoForDetail?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
+        inner.GetByIdAsync(id, cancellationToken);
+
+    public IAsyncEnumerable<SpeciesDtoForList> GetSpeciesAsync(
+        SpeciesParameters parameters,
+        CancellationToken cancellationToken = default
+    ) => inner.GetSpeciesAsync(parameters, cancellationToken);
+
+    public Task<int> GetCountAsync(SpeciesParameters parameters, CancellationToken cancellationToken = default) =>
+        inner.GetCountAsync(parameters, cancellationToken);
+
+    public Task<byte[]?> GetProfileImageAsync(Guid id, CancellationToken cancellationToken = default) =>
+        inner.GetProfileImageAsync(id, cancellationToken);
+
+    public Task<SpeciesFacetsDto> GetFacetsAsync(
+        SpeciesParameters parameters,
+        CancellationToken cancellationToken = default
+    ) => inner.GetFacetsAsync(parameters, cancellationToken);
+
+    public Task<IReadOnlyList<SpeciesDtoForList>> GetFeaturedAsync(CancellationToken cancellationToken = default) =>
+        inner.GetFeaturedAsync(cancellationToken);
+
+    public Task<IReadOnlyList<MunicipalitySpeciesCountDto>> GetCountsByMunicipalityAsync(
+        CancellationToken cancellationToken = default
+    ) => inner.GetCountsByMunicipalityAsync(cancellationToken);
+
+    public Task<IReadOnlyList<SpeciesNearbyDto>> GetNearbyAsync(
+        double latitude,
+        double longitude,
+        double radiusMeters,
+        CancellationToken cancellationToken = default
+    ) => inner.GetNearbyAsync(latitude, longitude, radiusMeters, cancellationToken);
+
+    public Task<IReadOnlyList<SpeciesNearbyDto>> GetInPolygonAsync(
+        IReadOnlyList<PolygonCoordinate> coordinates,
+        CancellationToken cancellationToken = default
+    ) => inner.GetInPolygonAsync(coordinates, cancellationToken);
+
+    public Task<IReadOnlyList<HeatmapPointDto>> GetHeatmapAsync(CancellationToken cancellationToken = default) =>
+        inner.GetHeatmapAsync(cancellationToken);
+}


### PR DESCRIPTION
## Summary

The FaunaFinder catalogue stats (total species, endemic, threatened, municipios covered, added this quarter, endemic hotspots) are six aggregate queries over the whole species table, run on every landing of the Species and Municipios pages and by the MCP `get_catalogue_stats` tool.

- `CachedSpeciesRepository` decorates `ISpeciesRepository`: `GetStatsAsync` is served from `IMemoryCache` with a 15-minute absolute lifetime; every other member passes straight through. Both consumers keep calling the interface, so neither can bypass the cache.
- `AddWildlifeDataAccess` registers `SpeciesRepository` concretely, the decorator as `ISpeciesRepository`, and calls `AddMemoryCache()` (a TryAdd — EcoPortal's existing registration is untouched; FaunaFinder gets one).
- No invalidation hooks: nothing in the web process writes species — the seeder and backfills run out of process — so a stale window of at most 15 minutes after a seed is the only effect.

## Test plan
- [x] `EcoData.Wildlife.DataAccess`, `.Api`, `.Mcp` build.
- [ ] `/wildlife/species/stats` returns the same payload as before; second call within 15 minutes issues no species queries (EF logs / Aspire traces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
